### PR TITLE
xrGame: Fix aim_bullet being uninitialized

### DIFF
--- a/src/xrGame/ShootingObject.cpp
+++ b/src/xrGame/ShootingObject.cpp
@@ -474,7 +474,7 @@ void CShootingObject::FireBullet(const Fvector& pos,
 	m_vCurrentShootPos = pos;
 	m_iCurrentParentID = parent_id;
 
-	bool aim_bullet;
+	bool aim_bullet = false;
 	/*if (m_bUseAimBullet)
 	{
 		if (ParentMayHaveAimBullet())


### PR DESCRIPTION
* ShootingObject.cpp: Set aim_bullet to false to avoid uninitialized variable warning. There was previously a block of code used to init this variable that has since been commented out in Anomaly 1.5.2. The only documentation in the changelog for it is:

  – removed leftovers use_aim_bullet = true
  – Removed use_aim_bullet

```
xray-monolith\src\xrGame\ShootingObject.cpp(526): warning C4700: uninitialized local variable 'aim_bullet' used
```