### PR TITLE
xrTrims.cpp: Fix _CopyVal to actually be safe

### DIFF
--- a/src/xrCore/xr_trims.cpp
+++ b/src/xrCore/xr_trims.cpp
@@ -40,13 +40,13 @@ LPCSTR _SetPos(LPCSTR src, u32 pos, char separator)
 	return res;
 }
 
-LPCSTR _CopyVal(LPCSTR src, LPSTR dst, char separator)
+LPCSTR _CopyVal(LPCSTR src, LPSTR dst, u32 const dst_size, char separator)
 {
 	LPCSTR p;
 	size_t n;
 	p = strchr(src, separator);
 	n = (p > 0) ? (p - src) : xr_strlen(src);
-	strncpy(dst, src, n);
+	strncpy(dst, src, _min(dst_size, (u32)n));
 	dst[n] = 0;
 	return dst;
 }
@@ -74,7 +74,7 @@ LPSTR _GetItem(LPCSTR src, int index, LPSTR dst, u32 const dst_size, char separa
 {
 	LPCSTR ptr;
 	ptr = _SetPos(src, index, separator);
-	if (ptr) _CopyVal(ptr, dst, separator);
+	if (ptr) _CopyVal(ptr, dst, dst_size, separator);
 	else xr_strcpy(dst, dst_size, def);
 	if (trim) _Trim(dst);
 	return dst;

--- a/src/xrCore/xr_trims.h
+++ b/src/xrCore/xr_trims.h
@@ -30,7 +30,7 @@ inline LPSTR _GetItem(LPCSTR src, int index, char (&dst)[count], char separator 
 
 XRCORE_API LPSTR _GetItems(LPCSTR, int, int, LPSTR, char separator = ',');
 XRCORE_API LPCSTR _SetPos(LPCSTR src, u32 pos, char separator = ',');
-XRCORE_API LPCSTR _CopyVal(LPCSTR src, LPSTR dst, char separator = ',');
+XRCORE_API LPCSTR _CopyVal(LPCSTR src, LPSTR dst, u32 const dst_size, char separator = ',');
 XRCORE_API LPSTR _Trim(LPSTR str);
 XRCORE_API LPSTR _TrimLeft(LPSTR str);
 XRCORE_API LPSTR _TrimRight(LPSTR str);


### PR DESCRIPTION
* _CopyVal: Called by _GetItem (which explicitly takes a dst_size argument), this function will stomp dst if the tokenized string is longer than the size of dst. Fix this by actually using a dst_size argument (which the caller already has) and clamping the strncpy to it.