### PR TITLE
xrCore: rt_compressor.cpp: Use appropriate integer type

### DIFF
--- a/src/xrCore/rt_compressor.cpp
+++ b/src/xrCore/rt_compressor.cpp
@@ -25,7 +25,7 @@ u32 rtc_csize(u32 in)
 
 u32 rtc_compress(void* dst, u32 dst_len, const void* src, u32 src_len)
 {
-	u32 out_size = dst_len;
+	lzo_uint out_size = dst_len;
 	int r = lzo1x_1_compress(
 		(const lzo_byte*)src, (lzo_uint)src_len,
 		(lzo_byte*)dst, (lzo_uintp)&out_size,
@@ -36,7 +36,7 @@ u32 rtc_compress(void* dst, u32 dst_len, const void* src, u32 src_len)
 
 u32 rtc_decompress(void* dst, u32 dst_len, const void* src, u32 src_len)
 {
-	u32 out_size = dst_len;
+	lzo_uint out_size = dst_len;
 	int r = lzo1x_decompress(
 		(const lzo_byte*)src, (lzo_uint)src_len,
 		(lzo_byte*)dst, (lzo_uintp)&out_size,


### PR DESCRIPTION
* rtc_compress, rtc_decompress: Both of these functions pass a pointer to an out_size variable which lzo1x_1_compress and lzo1x_1_decompress dereference to store the value for the caller to use. The problem is that with a u32 type it's passing a pointer to a 4-byte integer but cast as an 8-byte integer hence the dereference and store is unsafe.
```
    *out_len = 0;
00000001405064F6  mov         rax,qword ptr [out_len]
00000001405064FE  mov         qword ptr [rsp+58h],rax
0000000140506503  mov         rcx,qword ptr [rsp+58h]
0000000140506508  call        __asan_store8 (014355B111h)
000000014050650D  mov         rax,qword ptr [out_len]
0000000140506515  mov         qword ptr [rax],0 <----- *qword*
```
  Found with address sanitizer.