### PR TITLE
Fix warnings about potentially uninitialized variable usage

### DIFF
--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -1189,7 +1189,7 @@ static inline bool match_shader_id(LPCSTR const debug_shader_id, LPCSTR const fu
 
 void CRender::RenderToTarget(RRT target)
 {
-	ref_rt* RT;
+	ref_rt* RT = nullptr;
 
 	switch (target)
 	{

--- a/src/Layers/xrRenderPC_R2/r2_R_render.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_R_render.cpp
@@ -514,7 +514,7 @@ void CRender::render_forward()
 
 void CRender::RenderToTarget(RRT target)
 {
-	ref_rt* RT;
+	ref_rt* RT = nullptr;
 
 	switch (target)
 	{

--- a/src/Layers/xrRenderPC_R3/r3_R_render.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_R_render.cpp
@@ -570,7 +570,7 @@ void CRender::render_forward()
 
 void CRender::RenderToTarget(RRT target)
 {
-	ref_rt* RT;
+	ref_rt* RT = nullptr;
 
 	switch (target)
 	{

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -573,7 +573,7 @@ void CRender::render_forward()
 
 void CRender::RenderToTarget(RRT target)
 {
-	ref_rt* RT;
+	ref_rt* RT = nullptr;
 
 	switch (target)
 	{

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1820,7 +1820,7 @@ void remove_object(u16 id)
 DBG_ScriptObject* add_object(u16 id, DebugRenderType type)
 {
 	remove_object(id);
-	DBG_ScriptObject* dbg_obj;
+	DBG_ScriptObject* dbg_obj = nullptr;
 
 	switch (type)
 	{


### PR DESCRIPTION
* All involved variables involve use of a switch without a default case to set it to null. It's unlikely said default case will ever be hit, but the compiler doesn't know this.