### PR TITLE
OpenAL-Windows: Fix obvious array sizing issue

### DIFF
--- a/src/3rd party/openal/OpenAL-Windows/Router/alc.cpp
+++ b/src/3rd party/openal/OpenAL-Windows/Router/alc.cpp
@@ -335,7 +335,7 @@ ALvoid BuildDeviceSpecifierList()
 		// Directory[2] is the current app directory
 		// Directory[3] is the system directory
 		//
-		TCHAR dir[3][MAX_PATH + 1];
+		TCHAR dir[4][MAX_PATH + 1];
         int numDirs				= 0;
 		DWORD dirSize			= 0;
 		int i;


### PR DESCRIPTION
* This is dir[4] all throughout the rest of the file so not sure what happened here.

  Found with address sanitizer.