### PR TITLE
xrCore: Fix compilation issues under vs2022 17.7+

### DIFF
--- a/src/xrCore/_stl_extensions.h
+++ b/src/xrCore/_stl_extensions.h
@@ -3,6 +3,7 @@
 
 using std::swap;
 
+#include <functional>
 #include "_type_traits.h"
 
 #ifdef __BORLANDC__


### PR DESCRIPTION
* std::binary_function is expected to be included via `<functional>`. This previously worked in earlier versions of vs2022 (17.6, etc) but they recently cleaned up some includes which broke things which probably shouldn't have been working in the first place.