### PR TITLE
Add a console command to toggle mouse wheel zoom direction

### DIFF
--- a/src/xrGame/ActorInput.cpp
+++ b/src/xrGame/ActorInput.cpp
@@ -265,6 +265,8 @@ void CActor::IR_OnKeyboardPress(int cmd)
 
 // demonized: switch to disable mouse wheel weapon change
 BOOL mouseWheelChangeWeapon = TRUE;
+// mbehm: switch to allow inverting mouse wheel zoom direction
+BOOL mouseWheelInvertZoom = TRUE;
 void CActor::IR_OnMouseWheel(int direction)
 {
 	if (hud_adj_mode)
@@ -273,7 +275,11 @@ void CActor::IR_OnMouseWheel(int direction)
 		return;
 	}
 
-	if (inventory().Action((direction > 0) ? (u16)kWPN_ZOOM_DEC : (u16)kWPN_ZOOM_INC, CMD_START)) return;
+	if (mouseWheelInvertZoom) {
+		if (inventory().Action((direction > 0) ? (u16)kWPN_ZOOM_DEC : (u16)kWPN_ZOOM_INC, CMD_START)) return;
+	} else {
+		if (inventory().Action((direction > 0) ? (u16)kWPN_ZOOM_INC : (u16)kWPN_ZOOM_DEC, CMD_START)) return;
+	}
 
 	if (mouseWheelChangeWeapon) {
 		if (direction > 0)

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -125,6 +125,7 @@ namespace crash_saving {
 extern BOOL pda_map_zoom_in_to_mouse;
 extern BOOL pda_map_zoom_out_to_mouse;
 extern BOOL mouseWheelChangeWeapon;
+extern BOOL mouseWheelInvertZoom;
 
 ENGINE_API extern float g_console_sensitive;
 
@@ -2675,6 +2676,7 @@ void CCC_RegisterCommands()
 
 	// Mouse Wheel
 	CMD4(CCC_Integer, "mouse_wheel_change_weapon", &mouseWheelChangeWeapon, 0, 1);
+	CMD4(CCC_Integer, "mouse_wheel_invert_zoom", &mouseWheelInvertZoom, 0, 1);
 
 	//Toggle crash saving
 	CMD4(CCC_Integer, "crash_save", &crash_saving::enabled, 0, 1);

--- a/src/xrGame/ui/UIMapWnd.cpp
+++ b/src/xrGame/ui/UIMapWnd.cpp
@@ -420,6 +420,7 @@ bool CUIMapWnd::OnKeyboardAction(int dik, EUIMessages keyboard_action)
 	return inherited::OnKeyboardAction(dik, keyboard_action);
 }
 
+extern BOOL mouseWheelInvertZoom;
 bool CUIMapWnd::OnMouseAction(float x, float y, EUIMessages mouse_action)
 {
 	if (inherited::OnMouseAction(x, y, mouse_action) /*|| m_btn_nav_parent->OnMouseAction(x,y,mouse_action)*/)
@@ -447,11 +448,11 @@ bool CUIMapWnd::OnMouseAction(float x, float y, EUIMessages mouse_action)
 			break;
 
 		case WINDOW_MOUSE_WHEEL_DOWN:
-			UpdateZoom(true, true);
+			UpdateZoom(mouseWheelInvertZoom, true);
 			return true;
 			break;
 		case WINDOW_MOUSE_WHEEL_UP:
-			UpdateZoom(false, true);
+			UpdateZoom(!mouseWheelInvertZoom, true);
 			return true;
 			break;
 		} //switch	


### PR DESCRIPTION
One of my pet peeves with Stalker games has been the mouse wheel zoom being IMO inverted. Thanks to demonized providing an easy to build repo and a perfect example with the mouse wheel weapon switch toggle, here's a simple switch to toggle the zoom direction for both weapons and PDA map.

`mouse_wheel_invert_zoom 1` (default) Mouse wheel up zooms out, mouse wheel down zooms in, set by default to match original behavior (which I think is inverted).

`mouse_wheel_invert_zoom 0` Mouse wheel up zooms in, mouse wheel down zooms out.

