### PR TITLE
Increased lua_gcstep default to 400 and allow console editing

### DIFF
--- a/src/xrGame/Level.cpp
+++ b/src/xrGame/Level.cpp
@@ -764,7 +764,7 @@ void CLevel::OnFrame()
 	}
 }
 
-int psLUA_GCSTEP = 100;
+int psLUA_GCSTEP = 400;
 
 void CLevel::script_gc()
 {

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2249,8 +2249,9 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask, "ai_dbg_lua", &psAI_Flags, aiLua);
 #endif // MASTER_GOLD
 
-#ifdef DEBUG
+        // Moved lua_gcstep outside of DEBUG to allow for easier experimentation.
 	CMD4(CCC_Integer, "lua_gcstep", &psLUA_GCSTEP, 1, 1000);
+#ifdef DEBUG
 	CMD3(CCC_Mask, "ai_debug", &psAI_Flags, aiDebug);
 	CMD3(CCC_Mask, "ai_dbg_brain", &psAI_Flags, aiBrain);
 	CMD3(CCC_Mask, "ai_dbg_motion", &psAI_Flags, aiMotion);


### PR DESCRIPTION
Hi @themrdemonized,

This is an experiment with changed lua_gcstep variable. I think by default it is set too low in xray at the moment. The current default 100 is actually half the step size of lua/luajit 's GC, which is 200. I'm playtesting with 400, with better results (fewer stutters) than on the default 100.

It seems also a step size of 1000 is too much - leading to average FPS decrease.