### PR TITLE
Mark Switch

### DIFF
--- a/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
+++ b/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
@@ -356,6 +356,35 @@ class cl_fakescope_params3 : public R_constant_setup
 };
 static cl_fakescope_params3 binder_fakescope_params3;
 
+// Mark Switch
+extern float ps_markswitch_current;
+extern float ps_markswitch_count;
+extern Fvector4 ps_markswitch_color;
+
+static class markswitch_current : public R_constant_setup
+{
+	virtual void setup(R_constant* C)
+	{
+		RCache.set_c(C, ps_markswitch_current, 0, 0, 0);
+	}
+}    markswitch_current;
+
+static class markswitch_count : public R_constant_setup
+{
+	virtual void setup(R_constant* C)
+	{
+		RCache.set_c(C, ps_markswitch_count, 0, 0, 0);
+	}
+}    markswitch_count;
+
+static class markswitch_color : public R_constant_setup
+{
+	virtual void setup(R_constant* C)
+	{
+		RCache.set_c(C, ps_markswitch_color.x, ps_markswitch_color.y, ps_markswitch_color.z, ps_markswitch_color.w);
+	}
+}    markswitch_color;
+
 //--DSR-- HeatVision_start
 extern float heat_vision_mode;
 extern Fvector4 heat_vision_steps;
@@ -1040,6 +1069,11 @@ void CBlender_Compile::SetMapping()
 	r_Constant("shader_param_6", &dev_param_6);
 	r_Constant("shader_param_7", &dev_param_7);
 	r_Constant("shader_param_8", &dev_param_8);
+	
+	// Mark Switch
+	r_Constant("markswitch_current", &markswitch_current);
+	r_Constant("markswitch_count", &markswitch_count);
+	r_Constant("markswitch_color", &markswitch_color);
 
 	// crookr
 	r_Constant("fakescope_params1", &binder_fakescope_params);

--- a/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
+++ b/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
@@ -357,8 +357,8 @@ class cl_fakescope_params3 : public R_constant_setup
 static cl_fakescope_params3 binder_fakescope_params3;
 
 // Mark Switch
-extern float ps_markswitch_current;
-extern float ps_markswitch_count;
+extern int ps_markswitch_current;
+extern int ps_markswitch_count;
 extern Fvector4 ps_markswitch_color;
 
 static class markswitch_current : public R_constant_setup

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -306,6 +306,11 @@ float ps_particle_update_coeff = 1.f;
 
 /////////////////////////////////
 
+// Mark Switch
+int ps_markswitch_current = 0;
+int ps_markswitch_count = 0;
+Fvector4 ps_markswitch_color = { 0, 0, 0, 0 };
+
 // Screen Space Shaders Stuff
 int ps_ssfx_ssr_quality = 0; // Quality
 Fvector4 ps_ssfx_ssr = { 1.0f, 0.3f, 0.6f, 0.0f }; // Res, Blur, Temp, Noise
@@ -1164,6 +1169,11 @@ void xrRender_initconsole()
 	CMD4(CCC_Vector4, "shader_param_6", &ps_dev_param_6, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "shader_param_7", &ps_dev_param_7, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "shader_param_8", &ps_dev_param_8, tw2_min, tw2_max);
+	
+	// Mark Switch
+	CMD4(CCC_Integer, "markswitch_current", &ps_markswitch_current, 0, 32);
+	CMD4(CCC_Integer, "markswitch_count", &ps_markswitch_count, 0, 32);
+	CMD4(CCC_Vector4, "markswitch_color", &ps_markswitch_color, Fvector4().set(0.0, 0.0, 0.0, 0.0), Fvector4().set(1.0, 1.0, 1.0, 1.0));
 	
 	// Screen Space Shaders
 	CMD4(CCC_Integer, "ssfx_ssr_quality", &ps_ssfx_ssr_quality, 0, 5);


### PR DESCRIPTION
Parameters moved from shader_param_6 to engine for Mark Switch addon. Needed for upcoming update of https://www.moddb.com/mods/stalker-anomaly/addons/mark-switch