### PR TITLE
HeatVision flares fix + hot sun 

### DIFF
--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -82,13 +82,13 @@ void CRenderTarget::phase_combine()
 	{
 		HW.pContext->ClearRenderTargetView(rt_Generic_0->pRT, ColorRGBA);
 		HW.pContext->ClearRenderTargetView(rt_Generic_1->pRT, ColorRGBA);
-		u_setrt(rt_Generic_0, rt_Generic_1, rt_Heat, HW.pBaseZB);
+		u_setrt(rt_Generic_0, rt_Generic_1, rt_Heat, HW.pBaseZB);	//--DSR-- HeatVision
 	}
 	else
 	{
 		HW.pContext->ClearRenderTargetView(rt_Generic_0_r->pRT, ColorRGBA);
 		HW.pContext->ClearRenderTargetView(rt_Generic_1_r->pRT, ColorRGBA);
-		u_setrt(rt_Generic_0_r, rt_Generic_1_r, rt_Heat, RImplementation.Target->rt_MSAADepth->pZRT);
+		u_setrt(rt_Generic_0_r, rt_Generic_1_r, rt_Heat, RImplementation.Target->rt_MSAADepth->pZRT);	//--DSR-- HeatVision
 	}
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
@@ -417,6 +417,11 @@ void CRenderTarget::phase_combine()
 	if(ps_r2_nightvision > 0)
 		phase_nightvision();
 
+	//--DSR-- HeatVision_start
+	if (ps_r2_heatvision > 0)
+		phase_heatvision();
+	//--DSR-- HeatVision_end
+
 	if (scope_fake_enabled)
 	{
 		phase_fakescope(); //crookr
@@ -563,13 +568,8 @@ void CRenderTarget::phase_combine()
 
 	//	if FP16-BLEND !not! supported - draw flares here, overwise they are already in the bloom target
 	/* if (!RImplementation.o.fp16_blend)*/
-	if (ps_r2_anomaly_flags.test(R2_AN_FLAG_FLARES))
+	if (ps_r2_anomaly_flags.test(R2_AN_FLAG_FLARES) && ps_r2_heatvision == 0) //--DSR-- HeatVision
 		g_pGamePersistent->Environment().RenderFlares(); // lens-flares
-
-	//--DSR-- HeatVision_start
-	if (ps_r2_heatvision > 0)
-		phase_heatvision();
-	//--DSR-- HeatVision_end
 
 	//	PP-if required
 	if (PP_Complex)

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -82,13 +82,13 @@ void CRenderTarget::phase_combine()
 	{
 		HW.pContext->ClearRenderTargetView(rt_Generic_0->pRT, ColorRGBA);
 		HW.pContext->ClearRenderTargetView(rt_Generic_1->pRT, ColorRGBA);
-		u_setrt(rt_Generic_0, rt_Generic_1, 0, HW.pBaseZB);
+		u_setrt(rt_Generic_0, rt_Generic_1, rt_Heat, HW.pBaseZB);
 	}
 	else
 	{
 		HW.pContext->ClearRenderTargetView(rt_Generic_0_r->pRT, ColorRGBA);
 		HW.pContext->ClearRenderTargetView(rt_Generic_1_r->pRT, ColorRGBA);
-		u_setrt(rt_Generic_0_r, rt_Generic_1_r, 0, RImplementation.Target->rt_MSAADepth->pZRT);
+		u_setrt(rt_Generic_0_r, rt_Generic_1_r, rt_Heat, RImplementation.Target->rt_MSAADepth->pZRT);
 	}
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
@@ -416,11 +416,6 @@ void CRenderTarget::phase_combine()
 	
 	if(ps_r2_nightvision > 0)
 		phase_nightvision();
-	
-	//--DSR-- HeatVision_start
-	if (ps_r2_heatvision > 0)
-		phase_heatvision();
-	//--DSR-- HeatVision_end
 
 	if (scope_fake_enabled)
 	{
@@ -570,6 +565,11 @@ void CRenderTarget::phase_combine()
 	/* if (!RImplementation.o.fp16_blend)*/
 	if (ps_r2_anomaly_flags.test(R2_AN_FLAG_FLARES))
 		g_pGamePersistent->Environment().RenderFlares(); // lens-flares
+
+	//--DSR-- HeatVision_start
+	if (ps_r2_heatvision > 0)
+		phase_heatvision();
+	//--DSR-- HeatVision_end
 
 	//	PP-if required
 	if (PP_Complex)


### PR DESCRIPTION
1) Fix issue when lens flares - from sun, etc - were rendered on top of infrared image.
2) Rendering sun/moon into heat RT - makes it possible for those to be displayed hot in infrared.