### PR TITLE
Add npc_on_item_before_pickup callback

### DIFF
--- a/gamedata/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/gamedata/scripts/callbacks_gameobject.script
@@ -192,6 +192,14 @@ _G.CUIMessagesWindow__AddIconedPdaMessage = function(UIWindow, UITimeText, UICap
 	SendScriptCallback("on_news_received", UIWindow, UITimeText, UICaptionText, UIMsgText, UIIconStatic, tags)
 end
 
+-- NPC on item before pickup callback
+AddScriptCallback("npc_on_item_before_pickup")
+_G.CAI_Stalker__OnBeforeOwnershipTake = function(npc, item)
+	local flags = { ret_value = true }
+	SendScriptCallback("npc_on_item_before_pickup", npc, item, flags)
+	return flags.ret_value
+end
+
 -- actor_on_task_callback
 AddScriptCallback("actor_on_task_callback")
 task_callback = task_manager.task_callback

--- a/src/xrGame/ai/stalker/ai_stalker_events.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_events.cpp
@@ -16,6 +16,7 @@
 #include "../../ai_monster_space.h"
 #include "../../characterphysicssupport.h"
 #include "CustomZone.h"
+#include "script_game_object.h"
 
 using namespace StalkerSpace;
 using namespace MonsterSpace;
@@ -164,6 +165,15 @@ void CAI_Stalker::feel_touch_new(CObject* O)
 #ifndef SILENCE
 		Msg("Taking item %s (%d)!",I->object().cName().c_str(),I->object().ID());
 #endif
+		// Tosox
+		// Callback for when NPC tries to pickup an item
+		luabind::functor<bool> func;
+		if (ai().script_engine().functor("_G.CAI_Stalker__OnBeforeOwnershipTake", func)) {
+			if (!func(this->lua_game_object(), I->cast_game_object()->lua_game_object())) {
+				return;
+			}
+		}
+
 		generate_take_event(O);
 		return;
 	}


### PR DESCRIPTION
Did some play testing and didn't stumble upon errors.
The callback doesn't fire when the NPC receives an item (when spawning; by trading; delayed mechanic weapon repairs), but when the NPC walks over the item which is then transferred to its inventory. To my knowledge NPCs can only pickup weapons (including melee weapons) that way.