### PR TITLE
HeatVision tweaks

### DIFF
--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -259,8 +259,10 @@ Fvector ps_r2_drops_control = {.0f, 1.15f, .0f}; // r2-only
 int ps_r2_nightvision = 0;
 
 //--DSR-- HeatVision_start
-int ps_r2_heatvision = 0;
-float heat_vision_mode = 0.0f;
+int ps_r2_heatvision = 0;			// heatvision shader ON/OFF
+float heat_vision_mode = 0.0f;		// heatvision mode - rgb/greyscale
+int heat_vision_cooldown = 1;		// heatvision corpse cooling down ON/OFF
+float heat_vision_cooldown_time = 20000.f;	// heatvision corpse cooling down time (in ms)
 Fvector4 heat_vision_steps = { 0.45f, 0.65f, 0.76f, .0f };
 Fvector4 heat_vision_blurring = { 15.f, 4.f, 60.f, .0f };
 Fvector4 heat_vision_args_1 = { .0f, .0f, .0f, .0f };
@@ -1226,6 +1228,8 @@ void xrRender_initconsole()
 	CMD4(CCC_Float, "ssfx_wpn_dof_2", &ps_ssfx_wpn_dof_2, 0, 1);
 
 	//--DSR-- HeatVision_start
+	CMD4(CCC_Integer, "heat_vision_cooldown",	&heat_vision_cooldown, 0, 1);
+	CMD4(CCC_Float, "heat_vision_cooldown_time", &heat_vision_cooldown_time, 0, 300000.f);
 	CMD2(CCC_Float,   "heat_vision_mode",		&heat_vision_mode);
 	CMD4(CCC_Vector4, "heat_vision_steps",		&heat_vision_steps, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "heat_vision_blurring",	&heat_vision_blurring, tw2_min, tw2_max);

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -160,7 +160,9 @@ extern ECORE_API Fvector4 ps_r2_mask_control; // r2-only
 extern ECORE_API Fvector ps_r2_drops_control; // r2-only
 extern ECORE_API int ps_r2_nightvision;
 extern ECORE_API int scope_fake_enabled; //crookr
-extern ECORE_API int ps_r2_heatvision; //--DSR-- HeatVision
+extern ECORE_API int ps_r2_heatvision;			//--DSR-- HeatVision
+extern ECORE_API int heat_vision_cooldown;		//--DSR-- HeatVision
+extern ECORE_API float heat_vision_cooldown_time;	//--DSR-- HeatVision
 extern ECORE_API float ps_r2_ss_sunshafts_length;
 extern ECORE_API float ps_r2_ss_sunshafts_radius;
 extern u32 ps_sunshafts_mode;

--- a/src/Layers/xrRenderPC_R3/r3_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_rendertarget_phase_combine.cpp
@@ -83,13 +83,13 @@ void CRenderTarget::phase_combine()
 
 	// low/hi RTs
 	if (!RImplementation.o.dx10_msaa)
-		u_setrt(rt_Generic_0, rt_Generic_1, 0, HW.pBaseZB);
+		u_setrt(rt_Generic_0, rt_Generic_1, rt_Heat, HW.pBaseZB); //--DSR-- HeatVision
 	else
 	{
 		FLOAT ColorRGBA[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 		HW.pDevice->ClearRenderTargetView(rt_Generic_0_r->pRT, ColorRGBA);
 		HW.pDevice->ClearRenderTargetView(rt_Generic_1_r->pRT, ColorRGBA);
-		u_setrt(rt_Generic_0_r, rt_Generic_1_r, 0, RImplementation.Target->rt_MSAADepth->pZRT);
+		u_setrt(rt_Generic_0_r, rt_Generic_1_r, rt_Heat, RImplementation.Target->rt_MSAADepth->pZRT); //--DSR-- HeatVision
 	}
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
@@ -552,7 +552,7 @@ void CRenderTarget::phase_combine()
 
 	//	if FP16-BLEND !not! supported - draw flares here, overwise they are already in the bloom target
 	/* if (!RImplementation.o.fp16_blend)*/
-	if (ps_r2_anomaly_flags.test(R2_AN_FLAG_FLARES))	
+	if (ps_r2_anomaly_flags.test(R2_AN_FLAG_FLARES) && ps_r2_heatvision == 0) //--DSR-- HeatVision
 		g_pGamePersistent->Environment().RenderFlares(); // lens-flares
 
 	//	PP-if required

--- a/src/xrGame/Entity.cpp
+++ b/src/xrGame/Entity.cpp
@@ -17,6 +17,7 @@
 #include "ai_space.h"
 #include "alife_simulator.h"
 #include "alife_time_manager.h"
+#include "../Layers/xrRender/xrRender_console.h"
 
 #define BODY_REMOVE_TIME		600000
 
@@ -410,8 +411,8 @@ u32 clampU(u32 x, u32 a, u32 b) {
 }
 
 float CEntity::GetHotness() {
-	if (AlreadyDie() || !g_Alive())
-		return 1.0f - (float)clampU(Device.dwTimeGlobal - m_level_death_time, 0, 20000) / 20000.0f;
+	if (heat_vision_cooldown && (AlreadyDie() || !g_Alive())) 
+		return 1.0f - (float)clampU(Device.dwTimeGlobal - m_level_death_time, 0, heat_vision_cooldown_time) / heat_vision_cooldown_time;
 	return 1.0f;
 }
 


### PR DESCRIPTION
1) Fix lens flares and sun/moon for heatvision for DX10 (forgot in the last request);
2) Make corpses heat decay configurable through new console parameters;