### PR TITLE
Add optional "blowout_disable_idle" option for anomalies

### DIFF
--- a/src/xrGame/CustomZone.cpp
+++ b/src/xrGame/CustomZone.cpp
@@ -314,6 +314,12 @@ void CCustomZone::Load(LPCSTR section)
 		m_fBlowoutWindPowerMax = pSettings->r_float(section, "blowout_wind_power");
 	}
 
+	//загрузить флаг отмены idle анимации при blowout
+	if (pSettings->line_exist(section, "blowout_disable_idle"))
+	{
+		m_zone_flags.set(eBlowoutDisableIdle, pSettings->r_bool(section, "blowout_disable_idle"));
+	}
+
 	//загрузить параметры световой вспышки от взрыва
 	m_zone_flags.set(eBlowoutLight, pSettings->r_bool(section, "blowout_light"));
 	if (m_zone_flags.test(eBlowoutLight))
@@ -483,6 +489,10 @@ bool CCustomZone::BlowoutState()
 {
 	if (m_iStateTime >= m_StateTime[eZoneStateBlowout])
 	{
+
+		if (m_zone_flags.test(eBlowoutDisableIdle))
+			PlayIdleParticles();
+
 		SwitchZoneState(eZoneStateAccumulate);
 		if (m_bBlowoutOnce)
 		{
@@ -491,6 +501,10 @@ bool CCustomZone::BlowoutState()
 
 		return true;
 	}
+
+	if (m_zone_flags.test(eBlowoutDisableIdle))
+		StopIdleParticles();
+
 	return false;
 }
 

--- a/src/xrGame/CustomZone.h
+++ b/src/xrGame/CustomZone.h
@@ -123,6 +123,7 @@ protected:
 		eIdleLightR1 =(1 << 15),
 		eBoltEntranceParticles =(1 << 16),
 		eUseSecondaryHit =(1 << 17),
+		eBlowoutDisableIdle =(1 << 18),
 	};
 
 	u32 m_owner_id;


### PR DESCRIPTION
Setting option "blowout_disable_idle" to true (false by default) in a config will make anomaly temporarily turn off idle particles when anomaly's blowout is triggered, particles are returned upon return to idle state. 

Allows more fine-tuning of anomalies' visuals for modders.