### PR TITLE
Fixed gravity anomalies not always playing particles/sounds of body tearing

### DIFF
--- a/src/xrGame/Mincer.h
+++ b/src/xrGame/Mincer.h
@@ -1,10 +1,11 @@
 /////////////////////////////////////////////////////
-// Аномальная зона: "мясорубка"
-// При попадании живого объекта в зону происходит 
-// электрический разряд
-// Зона восстанавливает заряд через определенное время
-// (через m_dwPeriod заряжается с 0 до m_fMaxPower)
-//
+// 
+// Common class for gravity anomalies: Vortex and Whirlgig
+// When object gets caught it will be pulled towards the
+// center + additional tele_height, then ripped apart.
+// Zone recharges after blowout
+// (charges from 0 to m_fMaxPower in m_dwPeriod time)
+// 
 /////////////////////////////////////////////////////
 #pragma once
 
@@ -20,18 +21,18 @@ class CMincer :
 {
 private:
 	typedef CBaseGraviZone inherited;
-	CTeleWhirlwind m_telekinetics;
-	shared_str m_torn_particles;
-	ref_sound m_tearing_sound;
-	float m_fActorBlowoutRadiusPercent;
+
+	CTeleWhirlwind	m_oTelekinesis;
+	shared_str		m_sParticlesSkeleton;
+	float			m_fActorBlowoutRadiusPercent;
 
 public:
-	virtual CTelekinesis& Telekinesis() { return m_telekinetics; }
+	virtual CTelekinesis& Telekinesis() { return m_oTelekinesis; }
 
 public:
 	CMincer();
 	virtual ~CMincer();
-	//	virtual void	SwitchZoneState				(EZoneState new_state);
+
 	virtual void OnStateSwitch(EZoneState new_state);
 	virtual bool feel_touch_contact(CObject* O);
 	virtual void feel_touch_new(CObject* O);

--- a/src/xrGame/TeleWhirlwind.h
+++ b/src/xrGame/TeleWhirlwind.h
@@ -9,10 +9,12 @@ class CGameObject;
 
 class CTeleWhirlwindObject : public CTelekineticObject
 {
+private:
 	typedef CTelekineticObject inherited;
-	CTeleWhirlwind* m_telekinesis;
-	bool b_destroyable;
-	float throw_power;
+
+	CTeleWhirlwind* m_pTelekinesis;
+	bool			m_bDestroyable;
+	float			m_fThrowPower;
 
 public:
 	virtual ~CTeleWhirlwindObject()
@@ -34,43 +36,62 @@ public:
 
 class CTeleWhirlwind : public CTelekinesis
 {
+private:
 	typedef CTelekinesis inherited;
-	Fvector m_center;
-	float m_keep_radius;
-	float m_throw_power;
-	CGameObject* m_owner_object;
-	PH_IMPACT_STORAGE m_saved_impacts;
-	shared_str m_destroying_particles;
+
+	// ID of the owner object
+	u16 m_iOwnerID;
+
+	Fvector	m_vCenter;
+	float	m_fKeepRadius;
+	float	m_fThrowPower;
+	boolean	m_bHeightFixed;		// whether object will be hard-fixed at tele_heigh or can go above (true - default)
+
+	// Arrays of impacts
+	PH_IMPACT_STORAGE m_vSavedImpacts;
+
+	// Effects of tearing
+	shared_str m_sTearingParticles;
+	ref_sound  m_pTearingSound;
 
 public:
 	CTeleWhirlwind();
-	CGameObject* OwnerObject() const { return m_owner_object; }
-	const Fvector& Center() const { return m_center; }
-	void SetCenter(const Fvector center) { m_center.set(center); }
-	void SetOwnerObject(CGameObject* owner_object) { m_owner_object = owner_object; }
-	void add_impact(const Fvector& dir, float val);
-	void draw_out_impact(Fvector& dir, float& val);
-	void clear_impacts();
-
-	void set_destroing_particles(const shared_str& destroying_particles)
-	{
-		m_destroying_particles = destroying_particles;
-	}
-
-	const shared_str& destroing_particles() { return m_destroying_particles; }
-	void play_destroy(CTeleWhirlwindObject* obj);
-	virtual CTelekineticObject* activate(CPhysicsShellHolder* obj, float strength, float height, u32 max_time_keep,
-	                                     bool rot = true);
+	
+	void AddImpact(const Fvector& dir, float val);
+	void DrawOutImpact(Fvector& dir, float& val);
+	void ClearImpacts();
+	
 	virtual void clear();
 	virtual void clear_notrelevant();
 
+	virtual CTelekineticObject* activate(CPhysicsShellHolder* obj, float strength, float height, u32 max_time_keep, bool rot = true);
 	virtual CTelekineticObject* alloc_tele_object()
 	{
 		return static_cast<CTelekineticObject*>(xr_new<CTeleWhirlwindObject>());
 	}
 
-	float keep_radius() { return m_keep_radius; }
-	void set_throw_power(float throw_pow);
+	void PlayTearingSound(CObject* object) 
+	{ 
+		m_pTearingSound.play_at_pos(object, m_vCenter); 
+	}
+
+public: // Getters
+
+	u16				GetOwnerID() const { return m_iOwnerID; }
+	float			GetKeepRadius() const { return m_fKeepRadius; }
+	boolean			GetHeightFixed() const { return m_bHeightFixed; }
+	const Fvector&	GetCenter() const { return m_vCenter; }
+	LPCSTR			GetTearingParticles() const { return *m_sTearingParticles; }
+	
+public: // Setters
+
+	void SetCenter(const Fvector& center) { m_vCenter.set(center); }
+	void SetOwnerID(u16 owner_id) { m_iOwnerID = owner_id; }
+	void SetThrowPower(float throw_pow) { m_fThrowPower = throw_pow;}
+	void SetHeightFixed(boolean value) { m_bHeightFixed = value; }
+	void SetTearingParticles(const shared_str& particles) { m_sTearingParticles = particles; }
+	void SetTearingSound(LPCSTR name) {	m_pTearingSound.create(name, st_Effect, sg_SourceType); }
+
 };
 
 


### PR DESCRIPTION
1) Fix the case, when gravity anomalies would not play particles and sounds of body tearing of mutants/NPC who died in anomalies.

**Explanation:**
There are two particles sections in gravity anomalies configs:
`tearing_particles` and `torn_particles`. 

- The `tearing_particles` are played on the (closest to root) **particle bone** of ORIGINAL object - corpse of NPC or mutant.
- The `torn_particles` are played on all bones of DESTROYED object - this is a skeleton (ph_skeleton_object) which is spawned after anomaly rips the original body apart.

**First:** `torn_particles` were never really played because of some weird check against `CEntityAlive`, which `ph_skeleton_object` isn't. I removed that check, so now `torn_particles` are played properly.

**Second:** `tearing_particles` were only played if object in question has properly defined `particle_bones` (bones which can hold and play particles) inside of their configs. This lead to the situation that some mutants and human NPCs could not play particles because there was no defined bone to attach to. (This is also partially related to the fact that some mutants could not be dismembered - they are considered as solid object with one bone)

**Fix:** I totally detached `tearing_particles` effect from original object's bones. Instead I create auto-removing particle effect at the position of the original object, so that object in question does not have to have properly setup `particle_bones` - particles will just play at the object's position at the time of explosion.

These are the main changes in `CMincer::NotificateDestroy(...)` and `CTeleWhirlwindObject::destroy_object(...)`

2) I did some clean up and prettify classes `CMincer` and `CTeleWhirlwind` - no logic changes, just some prettifying for variables, function names, etc.

3) Added optional parameter `tele_height_fixed` (default `true`). If `false` telekinesis of gravity anomalies will not hard-stop objects at the peak point (`tele_height`) - they would fluctuate around it instead.
