### PR TITLE
Demo_Record update

### DIFF
--- a/gamedata/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/gamedata/scripts/lua_help_ex.script
@@ -15,11 +15,10 @@
         sds_zoom_enable [0; 1] // Enable correction of max. zoom with scope_factor, if this option is enabled then max. zoom will be such as prescribed in settings regardless of scope_factor value, if this option is disabled then max. zoom will be sum of value prescribed in settings and the increase that gives scope_factor.
         new_zoom_enable [0; 1] // Enable alternative zoom control. Minimal zoom is equal to either mechanical zoom or the one prescribed in section min_scope_zoom_factor. The step of zoom adjustment is more precise. 
         zoom_step_count [1.0, 10.0] // Adjust the step of zoom if new_zoom_enable is on
-
+        demo_record_return_ctrl_inputs // Launch (from console or scripts) `demo_record` but propagate ESC and TAB keypresses back to launcher entity (game or scripts) 
         demo_record_blocked_input 1 // Start demo_record without move or stop. The console and Esc key are available
         demo_record_stop // Stop all launched `demo_record` commands 
         demo_set_cam_direction [head, pitch, roll] // Set the direction the camera is facing and its roll. The parameters are in RADIANS, beware
-
         first_person_death // Enable First Person Death Camera
         first_person_death_direction_offset // FPD Camera Direction Offset (in DEGREES)
         first_person_death_position_offset // FPD Camera Position Offset (x, y, z)

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -466,22 +466,23 @@ void CDemoRecord::IR_OnKeyboardPress(int dik)
 		if (dik == DIK_ESCAPE)
 			Console->Execute("main_menu on");
 	} else {
-		// Added dik == DIK_TAB as extra keybind to support keyboards with no numpad
-		// if launching demo_record from game console it's important that TAB key is not bound to any menu or gui (e.g. inventory, pda, etc)
-		if (dik == DIK_MULTIPLY || dik == DIK_TAB) m_b_redirect_input_to_level = !m_b_redirect_input_to_level;
+		// Added dik == DIK_RCONTROL as extra keybind to support keyboards with no numpad
+		// Added dik == DIK_TAB as extra keybind that can also be used if return_ctrl_inputs is enabled. This key press event can be captured by the Demo Record invoker 
+		if (dik == DIK_MULTIPLY || dik == DIK_RCONTROL || (dik == DIK_TAB && return_ctrl_inputs)) m_b_redirect_input_to_level = !m_b_redirect_input_to_level;
 
 		if (m_b_redirect_input_to_level)
 		{
 			g_pGameLevel->IR_OnKeyboardPress(dik);
 			return;
 		}else{
-			// we end up here if controls have not been redirected to the caller entity
-			// if we launched demo_record_return_ctrl_inputs we return the event TAB key press also to the launcher entity
+			// we end up here if controls have not been redirected to the invoker
+			// if we launched demo_record_return_ctrl_inputs we return the event DIK_TAB key press also to the invoker 
 			if (dik == DIK_TAB && return_ctrl_inputs) {
 				// Sends upstream the DIK_TAB keyboard press event. This key toggles controls between demo_record and its launcher (game console or script)
-				// upon relinquishing the controls (to gameconsole/scripts), if the TAB key is pressed (captured by DemoRecord regardless) we end up here 
-				// but we like to let know the lancher that the TAB key was pressed and controls are back into DemoRecord hands
+				// upon relinquishing the controls (to gameconsole/scripts), if the DIK_TAB key is pressed (captured by DemoRecord regardless) we end up here 
+				// but we like to let know the invoker that the DIK_TAB key was pressed and controls are back into DemoRecord hands
 				g_pGameLevel->IR_OnKeyboardPress(dik);
+				return;
 			}
 		}
 		if (dik == DIK_GRAVE)

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -461,7 +461,7 @@ void CDemoRecord::IR_OnKeyboardPress(int dik)
 		if (dik == DIK_ESCAPE)
 			Console->Execute("main_menu on");
 	} else {
-		if (dik == DIK_MULTIPLY) m_b_redirect_input_to_level = !m_b_redirect_input_to_level;
+		if (dik == DIK_MULTIPLY || dik == DIK_TAB) m_b_redirect_input_to_level = !m_b_redirect_input_to_level;
 
 		if (m_b_redirect_input_to_level)
 		{
@@ -557,12 +557,14 @@ void CDemoRecord::IR_OnKeyboardHold(int dik)
 	case DIK_NUMPAD4:
 		vR_delta.y -= 1.0f;
 		break; // Turn Right
+	case DIK_C:
 	case DIK_NUMPAD9:
 		vR_delta.z -= 2.0f;
-		break; // Turn Right
+		break; // tilt Right
+	case DIK_Z:
 	case DIK_NUMPAD7:
 		vR_delta.z += 2.0f;
-		break; // Turn Right
+		break; // tilt left
 	}
 
 	update_whith_timescale(m_vT, vT_delta);

--- a/src/xrEngine/FDemoRecord.h
+++ b/src/xrEngine/FDemoRecord.h
@@ -40,6 +40,7 @@ private:
 	BOOL m_bMakeScreenshot;
 	int m_iLMScreenshotFragment;
 	BOOL m_bMakeLevelMap;
+	BOOL return_ctrl_inputs;
 
 	float m_fSpeed0;
 	float m_fSpeed1;
@@ -73,7 +74,7 @@ public:
 	virtual void IR_OnMousePress(int btn);
 	virtual void IR_OnMouseRelease(int btn);
 	void StopDemo();
-
+	void EnableReturnCtrlInputs();
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
 	static void SetGlobalPosition(const Fvector& p) { g_position.p.set(p), g_position.set_position = true; }
 	static void GetGlobalPosition(Fvector& p) { p.set(g_position.p); }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -509,6 +509,36 @@ public:
 	}
 };
 
+class CCC_DemoRecordReturnCtrlInputs : public IConsole_Command
+{
+public:
+
+	CCC_DemoRecordReturnCtrlInputs(LPCSTR N) : IConsole_Command(N)
+	{
+	};
+
+	virtual void Execute(LPCSTR args)
+	{
+#ifndef	DEBUG
+		//if (GameID() != eGameIDSingle)
+		//{
+		//	Msg("For this game type Demo Record is disabled.");
+		//	return;
+		//};
+#endif
+		Console->Hide();
+
+		LPSTR fn_;
+		STRCONCAT(fn_, args, ".xrdemo");
+		string_path fn;
+		FS.update_path(fn, "$game_saves$", fn_);
+
+		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
+		pDemoRecord->EnableReturnCtrlInputs();
+		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
+	}
+};
+
 class CCC_DemoRecordBlockedInput : public IConsole_Command
 {
 public:
@@ -2224,6 +2254,7 @@ void CCC_RegisterCommands()
 	CMD1(CCC_DemoRecord, "demo_record");
 	CMD1(CCC_DemoRecordBlockedInput, "demo_record_blocked_input");
 	CMD1(CCC_DemoRecordStop, "demo_record_stop");
+	CMD1(CCC_DemoRecordReturnCtrlInputs, "demo_record_return_ctrl_inputs");
 	CMD1(CCC_DemoRecordSetPos, "demo_set_cam_position");
 	CMD1(CCC_DemoRecordSetDir, "demo_set_cam_direction");
 	//#endif // #ifndef MASTER_GOLD


### PR DESCRIPTION
- added to DemoRecord extra keybindings to support pc/laptops with no numpad
- added new console command (demo_record_return_ctrl_inputs) to launch DemoRecord with the ability for client scripts to receive certain keystrokes and react to it while DemoRecord is still running