### PR TITLE
Fix some hud particles alignment (smoke)

### DIFF
--- a/src/xrGame/ShootingObject.cpp
+++ b/src/xrGame/ShootingObject.cpp
@@ -242,7 +242,7 @@ void CShootingObject::StartParticles(CParticlesObject*& pParticles, LPCSTR parti
 	pParticles = CParticlesObject::Create(particles_name, (BOOL)auto_remove_flag);
 
 	UpdateParticles(pParticles, pos, vel);
-	pParticles->Play(false);
+	pParticles->Play(IsHudModeNow());
 }
 
 void CShootingObject::StopParticles(CParticlesObject*& pParticles)


### PR DESCRIPTION
This should fix the problem where weapon muzzle flash and smoke particles were wrongly aligned wrt each other.