### PR TITLE
Editable variables that allow weapon position adjustements that don't require aim tweaks

### DIFF
--- a/gamedata/gamedata/configs/mod_system_base_hud.ltx
+++ b/gamedata/gamedata/configs/mod_system_base_hud.ltx
@@ -1,0 +1,5 @@
+![hud_base]
+base_hud_offset_pos			= 0,0,0
+base_hud_offset_pos_16x9	= 0,0,0
+base_hud_offset_rot			= 0,0,0
+base_hud_offset_rot_16x9	= 0,0,0

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -2179,8 +2179,8 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		{
 			if (idx == 0)
 			{
-				curr_offs = { 0.f, 0.f, 0.f };
-				curr_rot = { 0.f, 0.f, 0.f };
+				curr_offs = g_player_hud->m_adjust_offset[0][5]; //pos,aim
+				curr_rot = g_player_hud->m_adjust_offset[1][5]; //rot,aim
 			}
 			else
 			{
@@ -2190,8 +2190,15 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		}
 		else
 		{
-			curr_offs = hi->m_measures.m_hands_offset[0][idx]; //pos,aim
-			curr_rot = hi->m_measures.m_hands_offset[1][idx]; //rot,aim
+			if (idx == 0)
+			{
+				curr_offs = hi->m_measures.m_hands_offset[0][5]; //pos,aim
+				curr_rot = hi->m_measures.m_hands_offset[1][5]; //pos,aim
+			}
+			else {
+				curr_offs = hi->m_measures.m_hands_offset[0][idx]; //pos,aim
+				curr_rot = hi->m_measures.m_hands_offset[1][idx]; //rot,aim
+			}
 		}
 
 		float factor;

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -282,13 +282,13 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 	else
 		m_shell_point_offset.set(0, 0, 0);
 
-	//m_hands_offset[0][0].set(0, 0, 0);
-	//m_hands_offset[1][0].set(0, 0, 0);
+	m_hands_offset[0][0].set(0, 0, 0);
+	m_hands_offset[1][0].set(0, 0, 0);
 
 	strconcat(sizeof(val_name), val_name, "base_hud_offset_pos", _prefix);
-	m_hands_offset[0][0] = pSettings->r_fvector3(sect_name, val_name);
+	m_hands_offset[0][5] = pSettings->r_fvector3(sect_name, val_name);
 	strconcat(sizeof(val_name), val_name, "base_hud_offset_rot", _prefix);
-	m_hands_offset[1][0] = pSettings->r_fvector3(sect_name, val_name);
+	m_hands_offset[1][5] = pSettings->r_fvector3(sect_name, val_name);
 
 	strconcat(sizeof(val_name), val_name, "aim_hud_offset_pos", _prefix);
 	m_hands_offset[0][1] = pSettings->r_fvector3(sect_name, val_name);

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -282,8 +282,13 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 	else
 		m_shell_point_offset.set(0, 0, 0);
 
-	m_hands_offset[0][0].set(0, 0, 0);
-	m_hands_offset[1][0].set(0, 0, 0);
+	//m_hands_offset[0][0].set(0, 0, 0);
+	//m_hands_offset[1][0].set(0, 0, 0);
+
+	strconcat(sizeof(val_name), val_name, "base_hud_offset_pos", _prefix);
+	m_hands_offset[0][0] = pSettings->r_fvector3(sect_name, val_name);
+	strconcat(sizeof(val_name), val_name, "base_hud_offset_rot", _prefix);
+	m_hands_offset[1][0] = pSettings->r_fvector3(sect_name, val_name);
 
 	strconcat(sizeof(val_name), val_name, "aim_hud_offset_pos", _prefix);
 	m_hands_offset[0][1] = pSettings->r_fvector3(sect_name, val_name);

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -200,7 +200,7 @@ struct hud_item_measures
 	Flags8 m_prop_flags;
 
 	Fvector m_item_attach[2]; // pos,rot
-	Fvector m_hands_offset[2][5]; // pos,rot/ normal,aim,GL,aim_alt,safemode --#SM+#--
+	Fvector m_hands_offset[2][6]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2 --#SM+#--
 	Fvector m_strafe_offset[4][2]; // pos,rot,data1,data2/ normal,aim-GL	 --#SM+#--
 
 	u16 m_fire_bone;
@@ -380,7 +380,7 @@ private:
 public:
 	IKinematicsAnimated* m_model;
 	IKinematicsAnimated* m_model_2;
-	Fvector m_adjust_offset[2][5]; // pos,rot/ normal,aim,GL,aim_alt,safemode
+	Fvector m_adjust_offset[2][6]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2
 	Fvector m_adjust_obj[2]; // pos,rot; used for the item/weapon itself
 	Fvector m_adjust_ui_offset[2]; // pos,rot; used for custom device ui
 	Fvector m_adjust_firepoint_shell[2][2];


### PR DESCRIPTION
To do: Debug mode weapon position modifier. At current moment just adding the new value results in the game treating base_hud_offsets as default value which isn't ideal.