### PR TITLE
DemoRecord Update - Cursor visibility toggle, F12 keypress, camera boundary check

### DIFF
--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -538,8 +538,14 @@ void CDemoRecord::IR_OnKeyboardPress(int dik)
 void CDemoRecord::IR_OnKeyboardRelease(int dik)
 {
 	if (isInputBlocked) return;
-	if (m_b_redirect_input_to_level)
+	if (m_b_redirect_input_to_level){
 		g_pGameLevel->IR_OnKeyboardRelease(dik);
+	}else{
+		if (dik == DIK_F12 && return_ctrl_inputs) {
+			// if demo_record_return_ctrl_inputs is enabled we return the event F12 key release also to the launcher entity
+			g_pGameLevel->IR_OnKeyboardRelease(dik);
+		}		
+	}
 }
 
 static void update_whith_timescale(Fvector& v, const Fvector& v_delta)

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -10,7 +10,7 @@
 #include "render.h"
 #include "CustomHUD.h"
 #include "CameraManager.h"
-
+#include "../xrGame/UICursor.h"
 extern BOOL g_bDisableRedText;
 static Flags32 s_hud_flag = {0};
 static Flags32 s_dev_flags = {0};
@@ -135,6 +135,8 @@ CDemoRecord::CDemoRecord(const char* name, xr_unordered_set<CDemoRecord*>* pDemo
 	if (!file) {
 		StopDemo();
 	}
+	// when demo_record is launched, mouse controls are redirected to camera movements, so we hide the cursor
+	GetUICursor().Hide();
 }
 
 void CDemoRecord::StopDemo() {
@@ -472,9 +474,18 @@ void CDemoRecord::IR_OnKeyboardPress(int dik)
 
 		if (m_b_redirect_input_to_level)
 		{
+			// control inputs are redirected to the invoker
+			if (return_ctrl_inputs){
+				// if the invoker is a script that launched demo_record with return_ctrl_inputs enabled we show the cursor
+				GetUICursor().Show();
+			}
 			g_pGameLevel->IR_OnKeyboardPress(dik);
 			return;
 		}else{
+			if (GetUICursor().IsVisible()){
+				// mouse controls are back to the camera movements, so we hide the cursor
+				GetUICursor().Hide();
+			}
 			// we end up here if controls have not been redirected to the invoker
 			// if we launched demo_record_return_ctrl_inputs we return the event DIK_TAB key press also to the invoker 
 			if (dik == DIK_TAB && return_ctrl_inputs) {
@@ -495,6 +506,8 @@ void CDemoRecord::IR_OnKeyboardPress(int dik)
 			StopDemo();
 			// if we launched demo_record_return_ctrl_inputs we return the event ESCAPE key press also to the launcher entity
 			if (return_ctrl_inputs){
+				// we also show the cursor
+				GetUICursor().Show();
 				// sends upstream the DIK_ESCAPE keyboard press event. This key quit demo_record and returns controls to its launcher (game console or script)
 				// This can help scripts that execute command demo_record_photomode to know when the demo_record has exited
 				g_pGameLevel->IR_OnKeyboardPress(dik);

--- a/src/xrEngine/FDemoRecord.h
+++ b/src/xrEngine/FDemoRecord.h
@@ -28,6 +28,8 @@ private:
 	IWriter* file;
 	Fvector m_HPB;
 	Fvector m_Position;
+	Fvector m_Actor_Position;	
+	Fvector m_Starting_Position;
 	Fmatrix m_Camera;
 	u32 m_Stage;
 
@@ -41,6 +43,7 @@ private:
 	int m_iLMScreenshotFragment;
 	BOOL m_bMakeLevelMap;
 	BOOL return_ctrl_inputs;
+	BOOL m_CameraBoundaryEnabled;
 
 	float m_fSpeed0;
 	float m_fSpeed1;
@@ -50,6 +53,8 @@ private:
 	float m_fAngSpeed1;
 	float m_fAngSpeed2;
 	float m_fAngSpeed3;
+	float m_fCameraBoundary;
+	float m_fGroundPosition;
 
 	BOOL isInputBlocked;
 	xr_unordered_set<CDemoRecord*>* pDemoRecords;
@@ -75,6 +80,7 @@ public:
 	virtual void IR_OnMouseRelease(int btn);
 	void StopDemo();
 	void EnableReturnCtrlInputs();
+	void SetCameraBoundary(float boundary);
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
 	static void SetGlobalPosition(const Fvector& p) { g_position.p.set(p), g_position.set_position = true; }
 	static void GetGlobalPosition(Fvector& p) { p.set(g_position.p); }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -535,6 +535,7 @@ public:
 
 		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
 		pDemoRecord->EnableReturnCtrlInputs();
+		pDemoRecord->SetCameraBoundary(15.f);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
 };


### PR DESCRIPTION
This set of changes only affect the **DemoRecord** application

- fixed cursor staying visible when launching _demo_record_ 
- adds propagation of F12 keypress screenshot event (only available with cmd  _demo_record_return_ctrl_inputs_ )
- toggle cursor visibility when _demo_record_ controls are switched to invoker script and back (only available with cmd  _demo_record_return_ctrl_inputs_ )
- added new api to enable camera bonduary check (limits the camera distance from the actor)
- added camera bonduary check and that the camera does not go below the actor ground (not really a ground collision check) 
- update console cmd _demo_record_return_ctrl_inputs_ to enable camera bonduary check