### PR TITLE
(Modding) Add new telekinesis type for grav anomalies

### DIFF
--- a/src/xrGame/Mincer.cpp
+++ b/src/xrGame/Mincer.cpp
@@ -41,17 +41,11 @@ void CMincer::OnStateSwitch(EZoneState new_state)
 void CMincer::Load(LPCSTR section)
 {
 	inherited::Load(section);
-
-	if (pSettings->line_exist(section, "tele_height_fixed"))
+	m_oTelekinesis.Load(section);
+	if (pSettings->line_exist(section, "torn_particles"))
 	{
-		m_oTelekinesis.SetHeightFixed(pSettings->r_bool(section, "tele_height_fixed"));
+		m_sParticlesSkeleton = pSettings->r_string(section, "torn_particles");
 	}
-
-	m_oTelekinesis.SetTearingSound(pSettings->r_string(section, "body_tearing_sound"));
-	m_oTelekinesis.SetTearingParticles(shared_str(pSettings->r_string(section, "tearing_particles")));
-	m_oTelekinesis.SetThrowPower(pSettings->r_float(section, "throw_out_impulse"));
-
-	m_sParticlesSkeleton = pSettings->r_string(section, "torn_particles");
 	m_fActorBlowoutRadiusPercent = pSettings->r_float(section, "actor_blowout_radius_percent");
 }
 

--- a/src/xrGame/TeleWhirlwind.cpp
+++ b/src/xrGame/TeleWhirlwind.cpp
@@ -12,11 +12,14 @@
 
 CTeleWhirlwind::CTeleWhirlwind()
 {
+	m_fTeleTime = 2900.f;
+	m_iTelekinesisType = 0;
 	m_bHeightFixed = true;
 	m_iOwnerID = 0;
 	m_vCenter.set(0.f, 0.f, 0.f);
 	m_fKeepRadius = 1.f;
 	m_fThrowPower = 100.f;
+	m_bSpawnSkeleton = true;
 }
 
 CTelekineticObject* CTeleWhirlwind::activate(CPhysicsShellHolder* obj, float strength, float height, u32 max_time_keep,
@@ -24,13 +27,52 @@ CTelekineticObject* CTeleWhirlwind::activate(CPhysicsShellHolder* obj, float str
 {
 	if (inherited::activate(obj, strength, height, max_time_keep, rot))
 	{
-		CTeleWhirlwindObject* o = smart_cast<CTeleWhirlwindObject*>(objects.back());
-		VERIFY(o);
-		o->set_throw_power(m_fThrowPower);
+		CTelekineticObject* o = objects.back();
+		if (smart_cast<CTeleWhirlwindObject*>(o)) 
+		{
+			smart_cast<CTeleWhirlwindObject*>(o)->set_throw_power(m_fThrowPower);
+		}
+		else if (smart_cast<CTeleTrampolinObject*>(o))
+		{
+			smart_cast<CTeleTrampolinObject*>(o)->set_throw_power(m_fThrowPower);
+		}
 		return o;
 	}
 	else
 		return 0;
+}
+
+void CTeleWhirlwind::Load(LPCSTR section)
+{
+	if (pSettings->line_exist(section, "tele_type"))
+	{
+		m_iTelekinesisType = pSettings->r_u16(section, "tele_type");
+	}
+
+	if (pSettings->line_exist(section, "tele_height_fixed"))
+	{
+		m_bHeightFixed = pSettings->r_bool(section, "tele_height_fixed");
+	}
+
+	if (pSettings->line_exist(section, "tele_time"))
+	{
+		m_fTeleTime = pSettings->r_u32(section, "tele_time");
+	}
+
+	if (pSettings->line_exist(section, "tele_rotate_speed"))
+	{
+		m_fTeleRotateSpeed = pSettings->r_u32(section, "tele_rotate_speed");
+	}
+
+	if (pSettings->line_exist(section, "spawn_skeleton"))
+	{
+		m_bSpawnSkeleton = pSettings->r_bool(section, "spawn_skeleton");
+	}
+
+	m_pTearingSound.create(pSettings->r_string(section, "body_tearing_sound"), st_Effect, sg_SourceType);
+	m_sTearingParticles = shared_str(pSettings->r_string(section, "tearing_particles"));
+	m_fThrowPower = pSettings->r_float(section, "throw_out_impulse");
+
 }
 
 void CTeleWhirlwind::ClearImpacts()
@@ -157,15 +199,18 @@ bool CTeleWhirlwindObject::destroy_object(const Fvector dir, float val)
 	if (D && D->CanDestroy())
 	{
 		D->PhysicallyRemoveSelf();
-		D->Destroy(m_pTelekinesis->GetOwnerID());
 
-		if (IsGameTypeSingle())
+		if (m_pTelekinesis->GetSpawnSkeleton())
 		{
-			for (auto& object : D->m_destroyed_obj_visual_names) 
+			D->Destroy(m_pTelekinesis->GetOwnerID());
+			if (IsGameTypeSingle())
 			{
-				m_pTelekinesis->AddImpact(dir, val * 10.f);
-			}				
-		};
+				for (auto& object : D->m_destroyed_obj_visual_names)
+				{
+					m_pTelekinesis->AddImpact(dir, val * 10.f);
+				}
+			};
+		}
 
 		CEntityAlive* pEntity = smart_cast<CEntityAlive*>(object);
 		if (pEntity)
@@ -202,8 +247,8 @@ void CTeleWhirlwindObject::raise(float step)
 		return;
 	else
 	{
-		p->SetAirResistance(0.f, 0.f);
-		p->set_ApplyByGravity(TRUE);
+	p->SetAirResistance(0.f, 0.f);
+	p->set_ApplyByGravity(TRUE);
 	}
 	u16 element_number = p->get_ElementsNumber();
 	Fvector center = m_pTelekinesis->GetCenter();
@@ -343,10 +388,13 @@ void CTeleWhirlwindObject::keep()
 	dist.sub(center, maxE->mass_Center());
 	if (dist.magnitude() > m_pTelekinesis->GetKeepRadius() * 1.5f)
 	{
-		p->setTorque(Fvector().set(0, 0, 0));
-		p->setForce(Fvector().set(0, 0, 0));
-		p->set_LinearVel(Fvector().set(0, 0, 0));
-		p->set_AngularVel(Fvector().set(0, 0, 0));
+		if (m_pTelekinesis->GetHeightFixed())
+		{
+			p->setTorque(Fvector().set(0, 0, 0));
+			p->setForce(Fvector().set(0, 0, 0));
+			p->set_LinearVel(Fvector().set(0, 0, 0));
+			p->set_AngularVel(Fvector().set(0, 0, 0));
+		}
 		p->set_ApplyByGravity(TRUE);
 		switch_state(TS_Raise);
 	}
@@ -375,4 +423,181 @@ void CTeleWhirlwindObject::switch_state(ETelekineticState new_state)
 bool CTeleWhirlwindObject::can_activate(CPhysicsShellHolder* obj)
 {
 	return (obj != NULL);
+}
+
+
+// ================================================================================================
+
+static float clampF(float x, float a, float b)
+{
+	return x < a ? a : (x > b ? b : x);
+}
+
+CTeleTrampolinObject::CTeleTrampolinObject()
+{
+	m_bDestroyable = false;
+	m_pTelekinesis = NULL;
+	m_fThrowPower = 0.f;
+}
+
+bool CTeleTrampolinObject::init(CTelekinesis* tele, CPhysicsShellHolder* obj, float s, float h, u32 ttk, bool rot)
+{
+	bool result = inherited::init(tele, obj, s, h, ttk, rot);
+	m_pTelekinesis = static_cast<CTeleWhirlwind*>(tele);
+	m_fThrowPower = strength;
+	if (m_pTelekinesis->is_active_object(obj))
+	{
+		return false;
+	}
+	if (obj->PPhysicsShell())
+	{
+		obj->PPhysicsShell()->SetAirResistance(0.f, 0.f);
+		obj->m_pPhysicsShell->set_ApplyByGravity(TRUE);
+	}
+
+	if (object->ph_destroyable() && object->ph_destroyable()->CanDestroy())
+		m_bDestroyable = true;
+	else
+		m_bDestroyable = false;
+
+	return result;
+}
+
+void CTeleTrampolinObject::set_throw_power(float throw_pow)
+{
+	m_fThrowPower = throw_pow;
+}
+
+bool CTeleTrampolinObject::can_activate(CPhysicsShellHolder* obj)
+{
+	return (obj != NULL);
+}
+
+void CTeleTrampolinObject::raise(float step)
+{
+	CPhysicsShell* p = object->PPhysicsShell();
+
+	if (!p || !p->isActive())
+		return;
+
+	p->SetAirResistance(0.f, 0.f);
+	p->set_ApplyByGravity(TRUE);
+
+	CPhysicsElement* maxE = p->get_ElementByStoreOrder(0);
+
+	for (u16 element = 0; element < p->get_ElementsNumber(); ++element)
+	{
+		CPhysicsElement* E = p->get_ElementByStoreOrder(element);
+		if (!E->isActive()) continue;
+		if (maxE->getMass() < E->getMass()) maxE = E;
+	}
+
+	Fvector pos = maxE->mass_Center();
+	Fvector center = m_pTelekinesis->GetCenter();
+
+	float currentHeight = pos.y;
+	float peakHeight = target_height;
+
+	float diff = peakHeight - currentHeight;
+
+	u32 rotateSpeed = m_pTelekinesis->GetTeleRotateSpeed();
+	float timeRaisePassed = Device.dwTimeGlobal - time_raise_started;
+	float angularVelocity = clampF(timeRaisePassed * rotateSpeed, 0.f, rotateSpeed);
+
+	maxE->set_AngularVel(Fvector().set(0, angularVelocity, 0));
+
+	if (timeRaisePassed <= m_pTelekinesis->GetTeleTime())
+	{
+
+		if (diff <= 0)
+		{
+			maxE->set_LinearVel(Fvector().set(0.f, 0.f, 0.f));
+		}
+		else
+		{
+			maxE->set_LinearVel(Fvector().set(0.f, diff, 0.f));
+		}
+	}
+	else
+	{
+	
+		//IRenderVisual* v = object->Visual();
+		//IKinematics* k = v->dcast_PKinematics();
+
+		Fvector randomDir;
+		randomDir.random_dir();
+		randomDir.y = 1.0f;
+
+		maxE->applyForce(randomDir, 10000000.f);
+	}
+}
+
+void CTeleTrampolinObject::raise_update()
+{
+}
+
+void CTeleTrampolinObject::keep()
+{
+}
+
+void CTeleTrampolinObject::release()
+{
+	if (!object || object->getDestroy() || !object->m_pPhysicsShell || !object->m_pPhysicsShell->isActive()) return;
+	switch_state(TS_None);
+}
+
+void CTeleTrampolinObject::fire(const Fvector& target)
+{
+}
+
+void CTeleTrampolinObject::fire(const Fvector& target, float power)
+{
+}
+
+void CTeleTrampolinObject::switch_state(ETelekineticState new_state)
+{
+	inherited::switch_state(new_state);
+}
+
+bool CTeleTrampolinObject::destroy_object(const Fvector dir, float val)
+{
+	CPHDestroyable* D = object->ph_destroyable();
+	if (D && D->CanDestroy())
+	{
+		D->PhysicallyRemoveSelf();
+		D->Destroy(m_pTelekinesis->GetOwnerID());
+
+		if (IsGameTypeSingle())
+		{
+			for (auto& object : D->m_destroyed_obj_visual_names)
+			{
+				m_pTelekinesis->AddImpact(dir, val * 10.f);
+			}
+		};
+
+		CEntityAlive* pEntity = smart_cast<CEntityAlive*>(object);
+		if (pEntity)
+		{
+			CParticlesObject* pParticles = CParticlesObject::Create(
+				m_pTelekinesis->GetTearingParticles(), true, true);
+
+			Fmatrix xform, m;
+			Fvector angles;
+
+			xform.identity();
+			xform.k.normalize(Fvector().set(0, 1, 0));
+			Fvector::generate_orthonormal_basis(xform.k, xform.j, xform.i);
+			xform.getHPB(angles);
+
+			m.setHPB(angles.x, angles.y, angles.z);
+			m.c = pEntity->Position();
+
+			pParticles->UpdateParent(m, zero_vel);
+			pParticles->Play(false);
+
+			m_pTelekinesis->PlayTearingSound(object);
+		}
+		return true;
+	}
+	return false;
 }

--- a/src/xrGame/TeleWhirlwind.h
+++ b/src/xrGame/TeleWhirlwind.h
@@ -34,6 +34,33 @@ public:
 	virtual bool destroy_object(const Fvector dir, float val);
 };
 
+class CTeleTrampolinObject : public CTelekineticObject
+{
+private:
+	typedef CTelekineticObject inherited;
+
+	CTeleWhirlwind* m_pTelekinesis;
+	bool			m_bDestroyable;
+	float			m_fThrowPower;
+
+public:
+	virtual ~CTeleTrampolinObject()
+	{
+	};
+	CTeleTrampolinObject();
+	virtual bool init(CTelekinesis* tele, CPhysicsShellHolder* obj, float s, float h, u32 ttk, bool rot = true);
+	void set_throw_power(float throw_pow);
+	virtual bool can_activate(CPhysicsShellHolder* obj);
+	virtual void raise(float step);
+	virtual void raise_update();
+	virtual void keep();
+	virtual void release();
+	virtual void fire(const Fvector& target);
+	virtual void fire(const Fvector& target, float power);
+	virtual void switch_state(ETelekineticState new_state);
+	virtual bool destroy_object(const Fvector dir, float val);
+};
+
 class CTeleWhirlwind : public CTelekinesis
 {
 private:
@@ -42,10 +69,16 @@ private:
 	// ID of the owner object
 	u16 m_iOwnerID;
 
+	// Type of telekinesis: 0 - default (whirlwind), 1 - trampolin
+	u16 m_iTelekinesisType;
+
 	Fvector	m_vCenter;
 	float	m_fKeepRadius;
 	float	m_fThrowPower;
 	boolean	m_bHeightFixed;		// whether object will be hard-fixed at tele_heigh or can go above (true - default)
+	boolean m_bSpawnSkeleton;
+	float   m_fTeleTime;
+	u16		m_fTeleRotateSpeed;
 
 	// Arrays of impacts
 	PH_IMPACT_STORAGE m_vSavedImpacts;
@@ -67,7 +100,14 @@ public:
 	virtual CTelekineticObject* activate(CPhysicsShellHolder* obj, float strength, float height, u32 max_time_keep, bool rot = true);
 	virtual CTelekineticObject* alloc_tele_object()
 	{
-		return static_cast<CTelekineticObject*>(xr_new<CTeleWhirlwindObject>());
+		if (m_iTelekinesisType == 1) 
+		{
+			return static_cast<CTelekineticObject*>(xr_new<CTeleTrampolinObject>());
+		}
+		else 
+		{
+			return static_cast<CTelekineticObject*>(xr_new<CTeleWhirlwindObject>());
+		}
 	}
 
 	void PlayTearingSound(CObject* object) 
@@ -75,10 +115,16 @@ public:
 		m_pTearingSound.play_at_pos(object, m_vCenter); 
 	}
 
+	void Load(LPCSTR section);
+
 public: // Getters
 
 	u16				GetOwnerID() const { return m_iOwnerID; }
+	u16				GetTelekinesisType() const { return m_iTelekinesisType; }
 	float			GetKeepRadius() const { return m_fKeepRadius; }
+	float			GetTeleTime() const { return m_fTeleTime; }
+	u16				GetTeleRotateSpeed() const { return m_fTeleRotateSpeed; }
+	boolean			GetSpawnSkeleton() const { return m_bSpawnSkeleton; }
 	boolean			GetHeightFixed() const { return m_bHeightFixed; }
 	const Fvector&	GetCenter() const { return m_vCenter; }
 	LPCSTR			GetTearingParticles() const { return *m_sTearingParticles; }
@@ -87,10 +133,6 @@ public: // Setters
 
 	void SetCenter(const Fvector& center) { m_vCenter.set(center); }
 	void SetOwnerID(u16 owner_id) { m_iOwnerID = owner_id; }
-	void SetThrowPower(float throw_pow) { m_fThrowPower = throw_pow;}
-	void SetHeightFixed(boolean value) { m_bHeightFixed = value; }
-	void SetTearingParticles(const shared_str& particles) { m_sTearingParticles = particles; }
-	void SetTearingSound(LPCSTR name) {	m_pTearingSound.create(name, st_Effect, sg_SourceType); }
 
 };
 


### PR DESCRIPTION
Added new optional telekinesis type for gravitational anomalies behavior: `CTeleTrampolin`
Can be used by mods, which set `tele_type 1` inside anomalies config sections.

`CTeleTrampolin` Launches objects caught in an anomaly very high to the sky.
Now one can experiment with immersive lore-friendly "Springboard"/"Trampolin" anomalies :)