### PR TITLE
DemoRecord. adds second console parameter, reposition camera at start

### DIFF
--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -102,11 +102,13 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 
 		// Set the camera position to the actor's position
 		m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
+
 		// Move the camera a bit in front of the actor
 		float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
 		Fvector cameraOffset = m_Camera.k;
 		cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
 		m_Camera.c.add(m_Actor_Position, cameraOffset);
+		
 		// Turn the camera towards the actor
 		m_Camera.k.invert();
 		m_Position.set(m_Camera.c);

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -100,8 +100,17 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 		m_HPB.y = asinf(dir.y);
 		m_HPB.z = 0;
 
-		m_Position.set(m_Camera.c);
+		// Set the camera position to the actor's position
 		m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
+		// Move the camera a bit in front of the actor
+		float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
+		Fvector cameraOffset = m_Camera.k;
+		cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
+		m_Camera.c.add(m_Actor_Position, cameraOffset);
+		// Turn the camera towards the actor
+		m_Camera.k.invert();
+		m_Position.set(m_Camera.c);
+
 		m_fGroundPosition = m_Actor_Position.y - 1.0f;
 		m_vVelocity.set(0, 0, 0);
 		m_vAngularVelocity.set(0, 0, 0);
@@ -452,7 +461,7 @@ BOOL CDemoRecord::ProcessCam(SCamEffectorInfo& info)
 			{
 				z = m_Starting_Position.z;
 			}
-			// fake groud collision check
+			// fake ground collision check
 			if (m_Position.y < m_fGroundPosition){
 				y = m_Starting_Position.y;
 			}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -532,7 +532,7 @@ public:
 		float boundary = 15.f; // default value
 
 		if (!(iss >> arg1)) {
-			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs [filename] [boundary]");
 			return;
 		}
 
@@ -544,7 +544,7 @@ public:
 			if (iss2 >> num) {
 				boundary = num;
 			} else {
-				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs [filename] [boundary]");
 				return;
 			}
 		}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -48,7 +48,7 @@
 
 #include "ai_debug_variables.h"
 #include "../xrphysics/console_vars.h"
-
+#include <sstream>
 #include "..\xrCore\LocatorAPI.h"
 #ifdef DEBUG
 #	include "PHDebug.h"
@@ -527,15 +527,35 @@ public:
 		//};
 #endif
 		Console->Hide();
+		std::istringstream iss(args);
+		std::string arg1;
+		float boundary = 15.f; // default value
 
+		if (!(iss >> arg1)) {
+			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+			return;
+		}
+
+		// Try to parse an optional second argument
+		std::string arg2;
+		if (iss >> arg2) {
+			std::istringstream iss2(arg2);
+			float num;
+			if (iss2 >> num) {
+				boundary = num;
+			} else {
+				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+				return;
+			}
+		}
 		LPSTR fn_;
-		STRCONCAT(fn_, args, ".xrdemo");
+		STRCONCAT(fn_, arg1.c_str(), ".xrdemo");
 		string_path fn;
 		FS.update_path(fn, "$game_saves$", fn_);
 
 		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
 		pDemoRecord->EnableReturnCtrlInputs();
-		pDemoRecord->SetCameraBoundary(15.f);
+		pDemoRecord->SetCameraBoundary(boundary);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
 };


### PR DESCRIPTION
First of all seems my commits changed the whole files but in reality I only changed few lines.

I think it's because my local git added unix line endings. I had the `git config --global core.autocrlf` set to false temporarily because prior to this I was working on something else that needed the unix line endings. My bad I forgot to change back the git config.
An explanation can be found here in the first response https://stackoverflow.com/questions/2825428/why-should-i-use-core-autocrlf-true-in-git

Anyway I could try to revert the head to a previous commit but I worry is going to even make more mess in the timeline, So if it's ok for you to take this PR then fine otherwise I will try to clean up my commits 

The change:

- added a second optional parameter when launching demo_record e.g. demo_record_return_ctrl_inputs <filename> <boundary>
- changed the camera position at start, to behind the actor instead of being inside

So let me know what to do, I personally hate this kind of commit blunder unfortunately I could not see it until it pushed to github.
Regardless of everything, the project builds fine and the exes too.

Waiting for your advice