### PR TITLE
DemoRecord: adds second console parameter, refactored constructor to pass command flag, reposition camera at start

### DIFF
--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -102,11 +102,13 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 
 		// Set the camera position to the actor's position
 		m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
+
 		// Move the camera a bit in front of the actor
 		float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
 		Fvector cameraOffset = m_Camera.k;
 		cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
 		m_Camera.c.add(m_Actor_Position, cameraOffset);
+		
 		// Turn the camera towards the actor
 		m_Camera.k.invert();
 		m_Position.set(m_Camera.c);

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -64,7 +64,7 @@ Fbox get_level_screenshot_bound()
 
 void _InitializeFont(CGameFont*& F, LPCSTR section, u32 flags);
 
-CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDemo, life_time/*,FALSE*/)
+CDemoRecord::CDemoRecord(const char* name, float life_time, BOOL return_ctrl_inputs) : CEffectorCam(cefDemo, life_time/*,FALSE*/)
 {
 	stored_red_text = g_bDisableRedText;
 	g_bDisableRedText = TRUE;
@@ -100,19 +100,24 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 		m_HPB.y = asinf(dir.y);
 		m_HPB.z = 0;
 
-		// Set the camera position to the actor's position
-		m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
+		if (return_ctrl_inputs){
+			// Set the camera position behind the actor's position
+			m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
 
-		// Move the camera a bit in front of the actor
-		float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
-		Fvector cameraOffset = m_Camera.k;
-		cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
-		m_Camera.c.add(m_Actor_Position, cameraOffset);
-		
-		// Turn the camera towards the actor
-		m_Camera.k.invert();
-		m_Position.set(m_Camera.c);
+			// Move the camera a bit in front of the actor
+			float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
+			Fvector cameraOffset = m_Camera.k;
+			cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
+			m_Camera.c.add(m_Actor_Position, cameraOffset);
 
+			// Turn the camera towards the actor
+			// m_Camera.k.invert();
+			m_Position.set(m_Camera.c);
+		}else{
+			// Set the camera position to the actor's position
+			m_Position.set(m_Camera.c);
+			m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);			
+		}
 		m_fGroundPosition = m_Actor_Position.y - 1.0f;
 		m_vVelocity.set(0, 0, 0);
 		m_vAngularVelocity.set(0, 0, 0);
@@ -140,11 +145,12 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 	}
 }
 
-CDemoRecord::CDemoRecord(const char* name, xr_unordered_set<CDemoRecord*>* pDemoRecords, BOOL isInputBlocked, float life_time) : CDemoRecord(name, life_time)
+CDemoRecord::CDemoRecord(const char* name, xr_unordered_set<CDemoRecord*>* pDemoRecords, BOOL isInputBlocked, float life_time, BOOL return_ctrl_inputs) : CDemoRecord(name, life_time, return_ctrl_inputs)
 {
 	pDemoRecords->insert(this);
 	this->pDemoRecords = pDemoRecords;
 	this->isInputBlocked = isInputBlocked;
+	this->return_ctrl_inputs = return_ctrl_inputs;
 	if (!file) {
 		StopDemo();
 	}

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -100,8 +100,17 @@ CDemoRecord::CDemoRecord(const char* name, float life_time) : CEffectorCam(cefDe
 		m_HPB.y = asinf(dir.y);
 		m_HPB.z = 0;
 
-		m_Position.set(m_Camera.c);
+		// Set the camera position to the actor's position
 		m_Actor_Position.set(m_Camera.c.x,m_Camera.c.y,m_Camera.c.z);
+		// Move the camera a bit in front of the actor
+		float distanceInFrontOfActor = 3.0f; // Set this to the desired distance
+		Fvector cameraOffset = m_Camera.k;
+		cameraOffset.mul(-distanceInFrontOfActor); // Note the negative sign
+		m_Camera.c.add(m_Actor_Position, cameraOffset);
+		// Turn the camera towards the actor
+		m_Camera.k.invert();
+		m_Position.set(m_Camera.c);
+
 		m_fGroundPosition = m_Actor_Position.y - 1.0f;
 		m_vVelocity.set(0, 0, 0);
 		m_vAngularVelocity.set(0, 0, 0);
@@ -452,7 +461,7 @@ BOOL CDemoRecord::ProcessCam(SCamEffectorInfo& info)
 			{
 				z = m_Starting_Position.z;
 			}
-			// fake groud collision check
+			// fake ground collision check
 			if (m_Position.y < m_fGroundPosition){
 				y = m_Starting_Position.y;
 			}

--- a/src/xrEngine/FDemoRecord.h
+++ b/src/xrEngine/FDemoRecord.h
@@ -67,8 +67,8 @@ private:
 	void MakeScreenshot();
 	void MakeLevelMapScreenshot(BOOL bHQ);
 public:
-	CDemoRecord(const char* name, float life_time = 60 * 60 * 1000);
-	CDemoRecord(const char* name, xr_unordered_set<CDemoRecord*>* pDemoRecords, BOOL isInputBlocked = 0, float life_time = 60 * 60 * 1000);
+	CDemoRecord(const char* name, float life_time = 60 * 60 * 1000, BOOL return_ctrl_inputs = 0);
+	CDemoRecord(const char* name, xr_unordered_set<CDemoRecord*>* pDemoRecords, BOOL isInputBlocked = 0, float life_time = 60 * 60 * 1000, BOOL return_ctrl_inputs = 0);
 	virtual ~CDemoRecord();
 
 	virtual void IR_OnKeyboardPress(int dik);

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -532,7 +532,7 @@ public:
 		float boundary = 15.f; // default value
 
 		if (!(iss >> arg1)) {
-			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs [filename] [boundary]");
 			return;
 		}
 
@@ -544,7 +544,7 @@ public:
 			if (iss2 >> num) {
 				boundary = num;
 			} else {
-				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs [filename] [boundary]");
 				return;
 			}
 		}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -503,8 +503,8 @@ public:
 		STRCONCAT(fn_, args, ".xrdemo");
 		string_path fn;
 		FS.update_path(fn, "$game_saves$", fn_);
-
-		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
+		float life_time = 60 * 60 * 1000;
+		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords, FALSE, life_time, FALSE);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
 };
@@ -543,18 +543,14 @@ public:
 			float num;
 			if (iss2 >> num) {
 				boundary = num;
-			} else {
-				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs [filename] [boundary]");
-				return;
 			}
 		}
 		LPSTR fn_;
 		STRCONCAT(fn_, arg1.c_str(), ".xrdemo");
 		string_path fn;
 		FS.update_path(fn, "$game_saves$", fn_);
-
-		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
-		pDemoRecord->EnableReturnCtrlInputs();
+		float life_time = 60 * 60 * 1000;
+		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords, FALSE, life_time, TRUE);
 		pDemoRecord->SetCameraBoundary(boundary);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
@@ -583,8 +579,8 @@ public:
 		STRCONCAT(fn_, args, ".xrdemo");
 		string_path fn;
 		FS.update_path(fn, "$game_saves$", fn_);
-
-		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords, TRUE);
+		float life_time = 60 * 60 * 1000;
+		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords, FALSE, life_time, FALSE);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
 };

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -48,7 +48,7 @@
 
 #include "ai_debug_variables.h"
 #include "../xrphysics/console_vars.h"
-
+#include <sstream>
 #include "..\xrCore\LocatorAPI.h"
 #ifdef DEBUG
 #	include "PHDebug.h"
@@ -527,15 +527,35 @@ public:
 		//};
 #endif
 		Console->Hide();
+		std::istringstream iss(args);
+		std::string arg1;
+		float boundary = 15.f; // default value
 
+		if (!(iss >> arg1)) {
+			Msg("not enough parameters. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+			return;
+		}
+
+		// Try to parse an optional second argument
+		std::string arg2;
+		if (iss >> arg2) {
+			std::istringstream iss2(arg2);
+			float num;
+			if (iss2 >> num) {
+				boundary = num;
+			} else {
+				Msg("bonduary needs to be a number. e.g. demo_record_return_ctrl_inputs <filename> <boundary>");
+				return;
+			}
+		}
 		LPSTR fn_;
-		STRCONCAT(fn_, args, ".xrdemo");
+		STRCONCAT(fn_, arg1.c_str(), ".xrdemo");
 		string_path fn;
 		FS.update_path(fn, "$game_saves$", fn_);
 
 		auto pDemoRecord = xr_new<CDemoRecord>(fn, &pDemoRecords);
 		pDemoRecord->EnableReturnCtrlInputs();
-		pDemoRecord->SetCameraBoundary(15.f);
+		pDemoRecord->SetCameraBoundary(boundary);
 		g_pGameLevel->Cameras().AddCamEffector(pDemoRecord);
 	}
 };


### PR DESCRIPTION
Refactored per your suggestion

The change:

- added a second optional parameter when launching demo_record e.g. demo_record_return_ctrl_inputs
- refactored the class constructor the alternate mode flag (return_ctrl_inputs) and handle carema reposition based on that
- changed the camera position at start, to behind the actor instead of being inside, only when return_ctrl_inputs is true