### PR TITLE
Poltergeists and Burers throw corpses

### DIFF
--- a/gamedata/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -118,4 +118,8 @@
 	<string id="ui_mm_modded_exes_freelook_cam_limit">
 		<text>Freelook angle limit (freelook_cam_limit)</text>
 	</string>
+
+	<string id="ui_mm_modded_exes_telekinetic_objects_include_corpses">
+		<text>Poltergeists and Burers throw Corpses (telekinetic_objects_include_corpses)</text>
+	</string>
 </string_table>

--- a/gamedata/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -118,4 +118,8 @@
 	<string id="ui_mm_modded_exes_freelook_cam_limit">
 		<text>Угол свободного обзора (freelook_cam_limit)</text>
 	</string>
+
+	<string id="ui_mm_modded_exes_telekinetic_objects_include_corpses">
+		<text>Полтергейсты и бюреры бросают трупы (telekinetic_objects_include_corpses)</text>
+	</string>
 </string_table>

--- a/gamedata/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/gamedata/scripts/lua_help_ex.script
@@ -9,6 +9,8 @@
         crash_save_count [0; 20] // Crash saves max number
 
         pseudogiant_can_damage_objects_on_stomp [0; 1] // Enable the ability for pseudogiants to damage objects on stomp
+
+        telekinetic_objects_include_corpses [0; 1] // Enable the ability for poltergeists and burers to throw corpses
         
         sds_enable [0; 1] // Enable shader based scopes
         sds_speed_enable [0; 1] // Enable mouse sensitivity change on zooming

--- a/gamedata/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/gamedata/scripts/ui_options_modded_exes.script
@@ -319,6 +319,14 @@ function init_opt_base()
 				content = {function() return {{"1", "ON"}, {"0", "OFF"}} end},
 				cmd = "pseudogiant_can_damage_objects_on_stomp",
 			},
+			{
+				id = "telekinetic_objects_include_corpses",
+				type = "list",
+				val = 0,
+				curr = {function() return get_console_cmd(0, "telekinetic_objects_include_corpses") end},
+				content = {function() return {{"1", "ON"}, {"0", "OFF"}} end},
+				cmd = "telekinetic_objects_include_corpses",
+			},
 
 			{ id = "divider", type = "line" },
 

--- a/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
+++ b/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
@@ -5,6 +5,8 @@
 #define GOOD_DISTANCE_FOR_TELE	15.f
 #define MAX_TIME_CHECK_FAILURE	6000
 
+BOOL g_telekinetic_objects_include_corpses = 0;
+
 template <typename Object>
 CStateBurerAttackTele<Object>::CStateBurerAttackTele(Object* obj) : inherited(obj), m_action()
 {
@@ -204,16 +206,11 @@ void CStateBurerAttackTele<Object>::FindFreeObjects(xr_vector<CObject*>& tpObjec
 		CGrenade* grenade = smart_cast<CGrenade *>(tpObjects[i]);
 		CInventoryItem* itm = smart_cast<CInventoryItem*>(tpObjects[i]);
 
-		if (obj && obj->PPhysicsShell() && obj->PPhysicsShell()->isActive() && obj != object) {
-			Msg("%s has mass %f", obj->Name(), obj->m_pPhysicsShell->getMass());
-			// custom_monster->m_pPhysicsShell->setMass();
-		}
-
 		if (grenade || // grenades are handled by HandleGrenades function
 			!obj ||
 			!obj->PPhysicsShell() ||
 			!obj->PPhysicsShell()->isActive() ||
-			custom_monster && custom_monster->g_Alive() ||
+			custom_monster && (!g_telekinetic_objects_include_corpses || custom_monster->g_Alive()) ||
 			(obj->spawn_ini() && obj->spawn_ini()->section_exist("ph_heavy")) ||
 			(obj->m_pPhysicsShell->getMass() < object->m_tele_object_min_mass) ||
 			(obj->m_pPhysicsShell->getMass() > object->m_tele_object_max_mass) ||

--- a/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
+++ b/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
@@ -204,11 +204,16 @@ void CStateBurerAttackTele<Object>::FindFreeObjects(xr_vector<CObject*>& tpObjec
 		CGrenade* grenade = smart_cast<CGrenade *>(tpObjects[i]);
 		CInventoryItem* itm = smart_cast<CInventoryItem*>(tpObjects[i]);
 
+		if (obj && obj->PPhysicsShell() && obj->PPhysicsShell()->isActive() && obj != object) {
+			Msg("%s has mass %f", obj->Name(), obj->m_pPhysicsShell->getMass());
+			// custom_monster->m_pPhysicsShell->setMass();
+		}
+
 		if (grenade || // grenades are handled by HandleGrenades function
 			!obj ||
 			!obj->PPhysicsShell() ||
 			!obj->PPhysicsShell()->isActive() ||
-			custom_monster ||
+			custom_monster && custom_monster->g_Alive() ||
 			(obj->spawn_ini() && obj->spawn_ini()->section_exist("ph_heavy")) ||
 			(obj->m_pPhysicsShell->getMass() < object->m_tele_object_min_mass) ||
 			(obj->m_pPhysicsShell->getMass() > object->m_tele_object_max_mass) ||

--- a/src/xrGame/ai/monsters/poltergeist/poltergeist_telekinesis.cpp
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist_telekinesis.cpp
@@ -189,6 +189,7 @@ bool CPolterTele::trace_object(CObject* obj, const Fvector& target)
 	return false;
 }
 
+extern BOOL g_telekinetic_objects_include_corpses;
 void CPolterTele::tele_find_objects(xr_vector<CObject*>& objects, const Fvector& pos)
 {
 	m_nearest.clear_not_free();
@@ -202,7 +203,7 @@ void CPolterTele::tele_find_objects(xr_vector<CObject*>& objects, const Fvector&
 		if (!obj ||
 			!obj->PPhysicsShell() ||
 			!obj->PPhysicsShell()->isActive() ||
-			custom_monster ||
+			custom_monster && (!g_telekinetic_objects_include_corpses || custom_monster->g_Alive()) ||
 			(obj->spawn_ini() && obj->spawn_ini()->section_exist("ph_heavy")) ||
 			(obj->m_pPhysicsShell->getMass() < m_pmt_object_min_mass) ||
 			(obj->m_pPhysicsShell->getMass() > m_pmt_object_max_mass) ||

--- a/src/xrGame/ai/monsters/telekinetic_object.cpp
+++ b/src/xrGame/ai/monsters/telekinetic_object.cpp
@@ -112,6 +112,7 @@ void CTelekineticObject::switch_state(ETelekineticState new_state)
 	state = new_state;
 }
 
+extern BOOL g_telekinetic_objects_include_corpses;
 void CTelekineticObject::raise(float step)
 {
 	if (!object || !object->m_pPhysicsShell || !object->m_pPhysicsShell->isActive()) return;
@@ -122,6 +123,11 @@ void CTelekineticObject::raise(float step)
 	dir.set(0.f, 1.0f, 0.f);
 
 	float elem_size = float(object->m_pPhysicsShell->Elements().size());
+
+	// Tosox
+	if (g_telekinetic_objects_include_corpses)
+		clamp(elem_size, 1.f, 5.f); // Clamp elem_size so objects with many elements don't hover to high up in the air
+
 	dir.mul(elem_size * elem_size * strength);
 
 	if (OnServer())

--- a/src/xrGame/ai/monsters/telekinetic_object.cpp
+++ b/src/xrGame/ai/monsters/telekinetic_object.cpp
@@ -123,10 +123,13 @@ void CTelekineticObject::raise(float step)
 	dir.set(0.f, 1.0f, 0.f);
 
 	float elem_size = float(object->m_pPhysicsShell->Elements().size());
+	// Msg("Object %s has elem_size %.2f", object->Name(), elem_size);
 
 	// Tosox
+	// Clamp elem_size so objects with many elements don't hover to high up in the air
+	// Common physic objects have elem_size 1-2 while bodies have about 11
 	if (g_telekinetic_objects_include_corpses)
-		clamp(elem_size, 1.f, 5.f); // Clamp elem_size so objects with many elements don't hover to high up in the air
+		clamp(elem_size, 1.f, 3.f);
 
 	dir.mul(elem_size * elem_size * strength);
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -113,6 +113,8 @@ float streff;
 
 extern BOOL g_ai_die_in_anomaly; //Alundaio
 
+extern BOOL g_telekinetic_objects_include_corpses; // Tosox
+
 //demonized: new console vars
 extern BOOL firstPersonDeath;
 extern BOOL pseudogiantCanDamageObjects;
@@ -2603,6 +2605,8 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "ai_die_in_anomaly", &g_ai_die_in_anomaly, 0, 1); //Alundaio
 
 	CMD4(CCC_Integer, "pseudogiant_can_damage_objects_on_stomp", &pseudogiantCanDamageObjects, 0, 1);
+
+	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
 
 	CMD4(CCC_Float, "ai_aim_predict_time", &g_aim_predict_time, 0.f, 10.f);
 


### PR DESCRIPTION
I had to modify `telekinetic_objects.cpp` since it appears that the height at which objects levitate above ground during the attack phase correlates with the object's physics shell elements count (`object->m_pPhysicsShell->Elements().size() ^ 2 * strength`). Therefore, objects with fewer elements like weapons hover at a regular height, while those with more elements like bodies hover very high in the air. To resolve this, I've capped the element count at a maximum of 5.

The proposed code alteration enables both poltergeists and burers to utilize their telekinetic attack to throw corpses of stalkers and mutants. By default, this feature is disabled but can be enabled through either the options menu or via command.

Burers preview: https://youtu.be/DrYh5UuXoRU
Poltergeists preview: https://youtu.be/Outy2Fq6OvQ