### PR TITLE
Added silencer heat glowing functionality (optional)

### DIFF
--- a/src/Include/xrRender/Kinematics.h
+++ b/src/Include/xrRender/Kinematics.h
@@ -70,6 +70,11 @@ public:
 	virtual u64 _BCL LL_GetBonesVisible() = 0;
 	virtual void LL_SetBonesVisible(u64 mask) = 0;
 
+	//--DSR-- SilencerOverheat_start
+	virtual IRenderVisual* GetVisualByBone(u16 bone_id) = 0;
+	virtual IRenderVisual* GetVisualByBone(LPCSTR bone_name) = 0;
+	//--DSR-- SilencerOverheat_end
+
 	// Main functionality
 	virtual void CalculateBones(BOOL bForceExact = FALSE) = 0; // Recalculate skeleton
 	virtual void CalculateBones_Invalidate() = 0;

--- a/src/Include/xrRender/RenderVisual.h
+++ b/src/Include/xrRender/RenderVisual.h
@@ -25,9 +25,8 @@ public:
 	virtual shared_str	_BCL	getDebugName() = 0;
 #endif
 
-	//--DSR-- HeatVision_start
-	virtual void MarkAsHot(bool is_hot) {};
-	//--DSR-- HeatVision_end
+	virtual void MarkAsHot(bool is_hot) {};				//--DSR-- HeatVision
+	virtual void MarkAsGlowing(bool is_glowing) {};		//--DSR-- SilencerOverheat
 
 	virtual IKinematics* _BCL dcast_PKinematics() { return 0; }
 	virtual IKinematicsAnimated* dcast_PKinematicsAnimated() { return 0; }

--- a/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
+++ b/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
@@ -385,6 +385,16 @@ static class markswitch_color : public R_constant_setup
 	}
 }    markswitch_color;
 
+//--DSR-- SilencerOverheat_start
+static class cl_silencer_glowing : public R_constant_setup
+{
+	virtual void setup(R_constant* C)
+	{
+		RCache.hemi.set_c_glowing(C);
+	}
+} binder_silencer_glowing;
+//--DSR-- SilencerOverheat_end
+
 //--DSR-- HeatVision_start
 extern float heat_vision_mode;
 extern Fvector4 heat_vision_steps;
@@ -1087,6 +1097,8 @@ void CBlender_Compile::SetMapping()
 		r_Constant(*cs.first, cs.second);
 	}
 
+
+	r_Constant("L_glowing", &binder_silencer_glowing);		//--DSR-- SilencerOverheat
 	//--DSR-- HeatVision_start
 	r_Constant("L_hotness", &binder_heatvision_hotness);
 	r_Constant("heatvision_params1", &binder_heatvision_params1);

--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -78,19 +78,43 @@ void dxRender_Visual::Load(const char* N, IReader* data, u32)
 }
 
 //--DSR-- HeatVision_start
-void dxRender_Visual::MarkAsHot(bool is_hot) {
-	Shader* s = shader._get();
-	if (0 == s) return;
-	ShaderElement* e = s->E[0]._get();
-	if (0 == e || e->passes.empty()) return;
-	SPass* p = e->passes[0]._get();
-	STextureList* l = p->T._get();
-	if (0 == l || l->empty()) return;
-	CTexture* t = l->at(0).second._get();
-	if (t)
-		t->m_is_hot = is_hot;
+CTexture* dxRender_Visual::GetTexture()
+{
+	Shader* pSh = shader._get();
+	if (pSh == 0) 
+		return 0;
+
+	ShaderElement* pShE = pSh->E[0]._get();
+	if (pShE == 0 || pShE->passes.empty()) 
+		return 0;
+
+	SPass* pPass = pShE->passes[0]._get();
+	if (pPass == 0)
+		return 0;
+
+	STextureList* pTexList = pPass->T._get();
+	if (pTexList == 0 || pTexList->empty()) 
+		return 0;
+
+	return pTexList->at(0).second._get();
+}
+
+void dxRender_Visual::MarkAsHot(bool is_hot) 
+{
+	auto texture = GetTexture();
+	if (texture)
+		texture->m_is_hot = is_hot;
 }
 //--DSR-- HeatVision_end
+
+//--DSR-- SilencerOverheat_start
+void dxRender_Visual::MarkAsGlowing(bool is_glowing)
+{
+	auto texture = GetTexture();
+	if (texture)
+		texture->m_is_glowing = is_glowing;
+}
+//--DSR-- SilencerOverheat_end
 
 #define PCOPY(a)	a = pFrom->a
 

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -78,9 +78,9 @@ public:
 	virtual vis_data& _BCL getVisData() { return vis; }
 	virtual u32 getType() { return Type; }
 	
-	//--DSR-- HeatVision_start
-	virtual void MarkAsHot(bool is_hot);
-	//--DSR-- HeatVision_end
+	CTexture* GetTexture();							//--DSR--
+	virtual void MarkAsHot(bool is_hot);			//--DSR-- HeatVision
+	virtual void MarkAsGlowing(bool is_glowing);	//--DSR-- SilencerOverheat
 
 	dxRender_Visual();
 	virtual ~dxRender_Visual();

--- a/src/Layers/xrRender/R_Backend_hemi.cpp
+++ b/src/Layers/xrRender/R_Backend_hemi.cpp
@@ -13,9 +13,8 @@ void R_hemi::unmap()
 	c_pos_faces = 0;
 	c_neg_faces = 0;
 	c_material = 0;
-	//--DSR-- HeatVision_start
-	c_hotness = 0;
-	//--DSR-- HeatVision_end
+	c_hotness = 0; //--DSR-- HeatVision
+	c_glowing = 0; //--DSR-- SilencerOverheat
 }
 
 void R_hemi::set_pos_faces(float posx, float posy, float posz)
@@ -39,3 +38,10 @@ void R_hemi::set_hotness(float x, float y, float z, float w)
 	if (c_hotness) RCache.set_c(c_hotness, x, y, z, w);
 }
 //--DSR-- HeatVision_end
+
+//--DSR-- SilencerOverheat_start
+void R_hemi::set_glowing(float x, float y, float z, float w)
+{
+	if (c_glowing) RCache.set_c(c_glowing, x, y, z, w);
+}
+//--DSR-- SilencerOverheat_end

--- a/src/Layers/xrRender/R_Backend_hemi.h
+++ b/src/Layers/xrRender/R_Backend_hemi.h
@@ -9,9 +9,8 @@ public:
 	R_constant* c_neg_faces;
 	R_constant* c_material;
 
-	//--DSR-- HeatVision_start
-	R_constant* c_hotness;
-	//--DSR-- HeatVision_end
+	R_constant* c_hotness; //--DSR-- HeatVision
+	R_constant* c_glowing; //--DSR-- SilencerOverheat
 
 public:
 	R_hemi();
@@ -21,17 +20,15 @@ public:
 	void set_c_neg_faces(R_constant* C) { c_neg_faces = C; }
 	void set_c_material(R_constant* C) { c_material = C; }
 
-	//--DSR-- HeatVision_start
-	void set_c_hotness(R_constant* C) { c_hotness = C; }
-	//--DSR-- HeatVision_end
-
+	void set_c_hotness(R_constant* C) { c_hotness = C; } //--DSR-- HeatVision
+	void set_c_glowing(R_constant* C) { c_glowing = C; } //--DSR-- SilencerOverheat
 
 	void set_pos_faces(float posx, float posy, float posz);
 	void set_neg_faces(float negx, float negy, float negz);
 	void set_material(float x, float y, float z, float w);
 
-	//--DSR-- HeatVision_start
-	void set_hotness(float x, float y, float z, float w);
-	//--DSR-- HeatVision_end
+
+	void set_hotness(float x, float y, float z, float w); //--DSR-- HeatVision
+	void set_glowing(float x, float y, float z, float w); //--DSR-- SilencerOverheat
 };
 #endif

--- a/src/Layers/xrRender/SH_Texture.h
+++ b/src/Layers/xrRender/SH_Texture.h
@@ -97,9 +97,8 @@ public: //	Public class members (must be encapsulated furthur)
 	float m_material;
 	shared_str m_bumpmap;
 
-	//--DSR-- HeatVision_start
-	bool m_is_hot = false;
-	//--DSR-- HeatVision_end
+	bool m_is_hot = false;		//--DSR-- HeatVision
+	bool m_is_glowing = false;	//--DSR-- SilencerOverheat
 
 	union
 	{

--- a/src/Layers/xrRender/SkeletonCustom.cpp
+++ b/src/Layers/xrRender/SkeletonCustom.cpp
@@ -333,6 +333,32 @@ void CKinematics::Load(const char* N, IReader* data, u32 dwFlags)
 	LL_Validate();
 }
 
+//--DSR-- SilencerOverheat_start
+IRenderVisual* CKinematics::GetVisualByBone(u16 bone_id)
+{
+	for (u32 it = 0; it < children.size(); it++)
+	{
+		IRenderVisual* child = children[it];
+		CSkeletonX* childSkel = smart_cast<CSkeletonX*>(child);
+		if (childSkel->has_bone_id(bone_id))
+		{
+			return child;
+		}
+	}
+	return 0;
+}
+
+IRenderVisual* CKinematics::GetVisualByBone(LPCSTR bone_name)
+{
+	u16 bone_id = LL_BoneID(bone_name);
+	if (bone_id != BI_NONE)
+	{
+		return GetVisualByBone(bone_id);
+	}
+	return 0;
+}
+//--DSR-- SilencerOverheat_end
+
 IC void iBuildGroups(CBoneData* B, U16Vec& tgt, u16 id, u16& last_id)
 {
 	if (B->IK_data.ik_flags.is(SJointIKData::flBreakable)) id = ++last_id;

--- a/src/Layers/xrRender/SkeletonCustom.h
+++ b/src/Layers/xrRender/SkeletonCustom.h
@@ -152,6 +152,11 @@ protected:
 	void Visibility_Invalidate() { Update_Visibility = TRUE; };
 	void Visibility_Update();
 
+	//--DSR-- SilencerOverheat_start
+	virtual IRenderVisual* GetVisualByBone(u16 bone_id);
+	virtual IRenderVisual* GetVisualByBone(LPCSTR bone_name);
+	//--DSR-- SilencerOverheat_end
+
 	void LL_Validate();
 public:
 	UpdateCallback Update_Callback;

--- a/src/Layers/xrRender/SkeletonX.cpp
+++ b/src/Layers/xrRender/SkeletonX.cpp
@@ -350,7 +350,7 @@ void CSkeletonX::_Load(const char* N, IReader* data, u32& dwVertCount)
 #ifdef _EDITOR
 	if (bids.size()>0)	
 #else
-	if (bids.size() > 1)
+	if (bids.size()>0)		//--DSR-- SilencerOverheat (1 -> 0). Why was 1 tho?
 #endif
 	{
 		crc = crc32(&*bids.begin(), bids.size() * sizeof(u16));

--- a/src/Layers/xrRender/SkeletonX.h
+++ b/src/Layers/xrRender/SkeletonX.h
@@ -100,6 +100,18 @@ protected:
 public:
 	BOOL has_visible_bones();
 
+	//--DSR-- SilencerOverheat_start
+	BOOL has_bone_id(u16 bone_id)
+	{
+		for (u32 it = 0; it < BonesUsed.size(); it++)
+			if (BonesUsed[it] == bone_id)
+			{
+				return TRUE;
+			}
+		return FALSE;
+	}
+	//--DSR-- SilencerOverheat_end
+
 	CSkeletonX()
 	{
 		Parent = 0;

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -258,6 +258,17 @@ Fvector ps_r2_drops_control = {.0f, 1.15f, .0f}; // r2-only
 
 int ps_r2_nightvision = 0;
 
+//--DSR-- SilencerOverheat_start
+float sil_glow_max_temp = 0.15f;				// Max possible weapon temperature
+float sil_glow_shot_temp = 0.004f;				// Temperature added on 1 successful shot
+float sil_glow_cool_temp_rate = 0.01f;			// Temperature removed after 1 second
+Fvector sil_glow_color = { 1.f, .0f, .0f };	// Color of max temperature
+//--DSR-- SilencerOverheat_end
+
+Fvector dsr_test = { 0.f, 0.f, 0.f };
+Fvector dsr_test1 = { 0.f, 0.f, 0.f };
+Fvector dsr_test2 = { 0.f, 0.f, 0.f };
+
 //--DSR-- HeatVision_start
 int ps_r2_heatvision = 0;			// heatvision shader ON/OFF
 float heat_vision_mode = 0.0f;		// heatvision mode - rgb/greyscale
@@ -1226,6 +1237,17 @@ void xrRender_initconsole()
 	
 	CMD4(CCC_Vector4, "ssfx_wpn_dof_1", &ps_ssfx_wpn_dof_1, tw2_min, tw2_max);
 	CMD4(CCC_Float, "ssfx_wpn_dof_2", &ps_ssfx_wpn_dof_2, 0, 1);
+
+	//--DSR-- SilencerOverheat_start
+	CMD4(CCC_Float, "sil_glow_max_temp", &sil_glow_max_temp, 0.f, 1.f);
+	CMD4(CCC_Float, "sil_glow_shot_temp", &sil_glow_shot_temp, 0.f, 1.f);
+	CMD4(CCC_Float, "sil_glow_cool_temp_rate", &sil_glow_cool_temp_rate, 0.f, 1.f);
+	CMD4(CCC_Vector3, "sil_glow_color", &sil_glow_color, Fvector3().set(0, 0, 0), Fvector3().set(1.0, 1.0, 1.0));
+	//--DRS-- SilencerOverheat_end
+
+	CMD4(CCC_Vector3, "dsr_test", &dsr_test, Fvector3().set(-100.f, -100.f, -100.f), Fvector3().set(100.f, 100.f, 100.f));
+	CMD4(CCC_Vector3, "dsr_test1", &dsr_test1, Fvector3().set(-100.f, -100.f, -100.f), Fvector3().set(100.f, 100.f, 100.f));
+	CMD4(CCC_Vector3, "dsr_test2", &dsr_test2, Fvector3().set(-100.f, -100.f, -100.f), Fvector3().set(100.f, 100.f, 100.f));
 
 	//--DSR-- HeatVision_start
 	CMD4(CCC_Integer, "heat_vision_cooldown",	&heat_vision_cooldown, 0, 1);

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -167,6 +167,17 @@ extern ECORE_API float ps_r2_ss_sunshafts_length;
 extern ECORE_API float ps_r2_ss_sunshafts_radius;
 extern u32 ps_sunshafts_mode;
 
+//--DSR-- SilencerOverheat_start
+extern ECORE_API float sil_glow_max_temp;
+extern ECORE_API float sil_glow_shot_temp;
+extern ECORE_API float sil_glow_cool_temp_rate;
+extern ECORE_API Fvector sil_glow_color;
+//--DSR-- SilencerOverheat_end
+
+extern ECORE_API Fvector dsr_test;
+extern ECORE_API Fvector dsr_test1;
+extern ECORE_API Fvector dsr_test2;
+
 extern ECORE_API float ps_r2_tnmp_a; // r2-only
 extern ECORE_API float ps_r2_tnmp_b; // r2-only
 extern ECORE_API float ps_r2_tnmp_c; // r2-only

--- a/src/Layers/xrRenderPC_R3/r3.h
+++ b/src/Layers/xrRenderPC_R3/r3.h
@@ -233,9 +233,11 @@ public:
 		//o_hemi						= 0.5f*LT.get_hemi			()	;
 		o_sun = 0.75f * LT.get_sun();
 
-		//--DSR-- Heatvision start
-		RCache.hemi.set_hotness(O->GetHotness(), O->GetTransparency(), 0.f, 0.f);
-		//--DSR-- Heatvision end
+		RCache.hemi.set_hotness(O->GetHotness(), O->GetTransparency(), 0.f, 0.f);		//--DSR-- HeatVision
+		RCache.hemi.set_glowing(														//--DSR-- SilencerOverheat
+			sil_glow_color.x,
+			sil_glow_color.y,
+			sil_glow_color.z, O->GetGlowing());
 
 		CopyMemory(o_hemi_cube, LT.get_hemi_cube(), CROS_impl::NUM_FACES*sizeof(float));
 	}
@@ -252,8 +254,10 @@ public:
 #ifdef	DEBUG
         if (ps_r2_ls_flags.test(R2FLAG_GLOBALMATERIAL))	mtl=ps_r2_gmaterial;
 #endif
-		if (!(T && T->m_is_hot))
+		if (!(T && T->m_is_hot))							//--DSR-- HeatVision
 			RCache.hemi.set_hotness(0.f, 0.f, 0.f, 0.f);
+		if (!(T && T->m_is_glowing))						//--DSR-- SilencerOverheat
+			RCache.hemi.set_glowing(0.f, 0.f, 0.f, 0.f);
 
 		RCache.hemi.set_material(o_hemi, o_sun, 0, (mtl < 5 ? (mtl + .5f) / 4.f : mtl));
 		RCache.hemi.set_pos_faces(o_hemi_cube[CROS_impl::CUBE_FACE_POS_X],

--- a/src/Layers/xrRenderPC_R4/r4.h
+++ b/src/Layers/xrRenderPC_R4/r4.h
@@ -242,11 +242,15 @@ public:
 		//o_hemi						= 0.5f*LT.get_hemi			()	;
 		o_sun = 0.75f * LT.get_sun();
 		//--DSR-- HeatVision_start
-		RCache.hemi.set_hotness(O->GetHotness(), O->GetTransparency(), 0.f, 0.f);
+		RCache.hemi.set_hotness(O->GetHotness(), O->GetTransparency(), 0.f, 0.f);			//--DSR-- HeatVision
+		RCache.hemi.set_glowing(															//--DSR-- SilencerOverheat
+			sil_glow_color.x, 
+			sil_glow_color.y,
+			sil_glow_color.z, O->GetGlowing());
 		//--DSR-- HeatVision_end
 		CopyMemory(o_hemi_cube, LT.get_hemi_cube(), CROS_impl::NUM_FACES*sizeof(float));
 	}
-
+	
 	IC void apply_lmaterial()
 	{
 		R_constant* C = &*RCache.get_c(c_sbase); // get sampler
@@ -259,8 +263,10 @@ public:
 #ifdef	DEBUG
         if (ps_r2_ls_flags.test(R2FLAG_GLOBALMATERIAL))	mtl=ps_r2_gmaterial;
 #endif
-		if (!(T && T->m_is_hot))
+		if (!(T && T->m_is_hot))										//--DSR-- HeatVision
 			RCache.hemi.set_hotness(0.f, 0.f, 0.f, 0.f);
+		if (!(T && T->m_is_glowing))									//--DSR-- SilencerOverheat
+			RCache.hemi.set_glowing(0.f, 0.f, 0.f, 0.f);
 
 		RCache.hemi.set_material(o_hemi, o_sun, 0, (mtl < 5 ? (mtl + .5f) / 4.f : mtl));
 		RCache.hemi.set_pos_faces(o_hemi_cube[CROS_impl::CUBE_FACE_POS_X],

--- a/src/xrEngine/IRenderable.h
+++ b/src/xrEngine/IRenderable.h
@@ -25,10 +25,9 @@ public:
 	virtual BOOL renderable_ShadowGenerate() { return FALSE; };
 	virtual BOOL renderable_ShadowReceive() { return FALSE; };
 
-	//--DSR-- HeatVision_start
-	virtual float GetHotness() { return 0.0; }
-	virtual float GetTransparency() { return 0.0; }
-	//--DSR-- HeatVision_end
+	virtual float GetHotness() { return 0.0; }			//--DSR-- HeatVision
+	virtual float GetTransparency() { return 0.0; }		//--DSR-- HeatVision
+	virtual float GetGlowing() { return 0.0; }			//--DSR-- SilencerOverheat
 };
 
 #endif // IRENDERABLE_H_INCLUDED

--- a/src/xrGame/Entity.cpp
+++ b/src/xrGame/Entity.cpp
@@ -18,6 +18,9 @@
 #include "alife_simulator.h"
 #include "alife_time_manager.h"
 #include "../Layers/xrRender/xrRender_console.h"
+#include "InventoryOwner.h"
+#include "Inventory.h"
+#include "Weapon.h"
 
 #define BODY_REMOVE_TIME		600000
 
@@ -404,10 +407,9 @@ void CEntity::ChangeTeam(int team, int squad, int group)
 }
 
 //--DSR-- HeatVision_start
-u32 clampU(u32 x, u32 a, u32 b) {
-	if (x < a) return a;
-	else if (x > b) return b;
-	return x;
+static u32 clampU(u32 x, u32 a, u32 b) 
+{
+	return x < a ? a : (x > b ? b : x);
 }
 
 float CEntity::GetHotness() {
@@ -423,3 +425,19 @@ void CEntity::OnChangeVisual()
 		renderable.visual->MarkAsHot(true);
 }
 //--DSR-- HeatVision_end
+
+//--DSR-- SilencerOverheat_start
+float CEntity::GetGlowing() 
+{
+	auto invOwner = smart_cast<CInventoryOwner*>(this);
+	if (invOwner) 
+	{
+		auto weapon = smart_cast<CWeapon*>(invOwner->inventory().ActiveItem());
+		if (weapon)
+		{
+			return weapon->GetGlowing();
+		}
+	}
+	return 0.f;
+}
+//--DSR-- SilencerOverheat_end

--- a/src/xrGame/Entity.h
+++ b/src/xrGame/Entity.h
@@ -82,10 +82,9 @@ public:
 	/*	virtual*/
 	IC void SetMaxHealth(float v) { m_entity_condition->max_health() = v; }
 
-	//--DSR-- HeatVision_start
-	virtual float GetHotness();
-	virtual void  OnChangeVisual();
-	//--DSR-- HeatVision_end
+	virtual float GetGlowing();			//--DSR-- SilencerOverheat
+	virtual float GetHotness();			//--DSR-- HeatVision
+	virtual void  OnChangeVisual();		//--DSR-- HeatVision
 
 	/*virtual*/
 	IC BOOL g_Alive() const { return GetfHealth() > 0; }

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -96,6 +96,20 @@ public:
 	int last_hide_bullet;
 	bool bHasBulletsToHide;
 
+	//--DSR-- SilencerOverheat_start
+	float temperature;
+
+	virtual void FireBullet(const Fvector& pos,
+		const Fvector& shot_dir,
+		float fire_disp,
+		const CCartridge& cartridge,
+		u16 parent_id,
+		u16 weapon_id,
+		bool send_hit, int iShotNum);
+
+	virtual float GetGlowing();
+	//--DSR-- SilencerOverheat_end
+
 	virtual void HUD_VisualBulletUpdate(bool force = false, int force_idx = -1);
 
 	void UpdateSecondVP();

--- a/src/xrGame/WeaponFire.cpp
+++ b/src/xrGame/WeaponFire.cpp
@@ -15,6 +15,7 @@
 
 #include "game_cl_mp.h"
 #include "reward_event_generator.h"
+#include "../Layers/xrRender/xrRender_console.h"
 
 #define FLAME_TIME 0.05f
 
@@ -161,6 +162,27 @@ void CWeapon::FireEnd()
 	StopShotEffector();
 }
 
+//--DSR-- SilencerOverheat_start
+void CWeapon::FireBullet(const Fvector& pos,
+	const Fvector& shot_dir,
+	float fire_disp,
+	const CCartridge& cartridge,
+	u16 parent_id,
+	u16 weapon_id,
+	bool send_hit, int iShotNum)
+{
+	CShootingObject::FireBullet(pos, shot_dir, fire_disp, cartridge, parent_id, weapon_id, send_hit, iShotNum);
+	
+	temperature += sil_glow_shot_temp;
+	if (temperature > sil_glow_max_temp)
+		temperature = sil_glow_max_temp;
+}
+
+float CWeapon::GetGlowing()
+{
+	return temperature;
+}
+//--DSR-- SilencerOverheat_end
 
 void CWeapon::StartFlameParticles2()
 {


### PR DESCRIPTION
Adds an optional and configurable texture glowing for silencers after consecutive shots, visually looks like overheating.

This just enables to do so from engine side. Shader part will be provided later as an addon (without it nothing will happen).

Code changes are very similar to those for HeatVision.