### PR TITLE
Added `GetWindow()` method

### DIFF
--- a/src/xrGame/UIGameCustom.h
+++ b/src/xrGame/UIGameCustom.h
@@ -120,6 +120,8 @@ public:
 	void ShowCrosshair(bool show) { psHUD_Flags.set(HUD_CROSSHAIR_RT, show); }
 	bool CrosshairShown() { return !!psHUD_Flags.test(HUD_CROSSHAIR_RT); }
 
+	CUIWindow* GetWindow() { return Window; }
+
 	virtual void HideShownDialogs()
 	{
 	}

--- a/src/xrGame/UIGameCustom_script.cpp
+++ b/src/xrGame/UIGameCustom_script.cpp
@@ -29,6 +29,7 @@ void CUIGameCustom::script_register(lua_State* L)
 		.def("UpdateActorMenu", &CUIGameCustom::UpdateActorMenu)
 		.def("CurrentItemAtCell", &CUIGameCustom::CurrentItemAtCell)
 		//-Alundaio
+		.def("GetWindow", &CUIGameCustom::GetWindow)	//--DSR--
 		.def("HidePdaMenu", &CUIGameCustom::HidePdaMenu)
 		.def("show_messages", &CUIGameCustom::ShowMessagesWindow)
 		.def("hide_messages", &CUIGameCustom::HideMessagesWindow)


### PR DESCRIPTION
A method to access main HUD's `CUIWindow` instance. 