### PR TITLE
adds a new console command freeze_time (2nd tentative)

### DIFF
--- a/gamedata/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/gamedata/scripts/lua_help_ex.script
@@ -39,6 +39,7 @@
 
         string_table_error_msg // Print xml translation errors
         monster_stuck_fix // Enables fix of stuck monsters at the fps cost
+        freeze_time [0,1] // Freezes the alife but leaves the sounds playing at the time of the freeze, e.g. soundtrack, looped_fx. No new sounds will be played by the ailife, since it is frozen. You can however, after this point, play new sounds from scripts. 
     }
 
     lua extensions {

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -1671,7 +1671,28 @@ public:
 		IConsole_Command::fill_tips(tips, mode);
 	}
 };
+class CCC_FreezeTime : public IConsole_Command
+{
+public:
+	CCC_FreezeTime(LPCSTR N) : IConsole_Command(N)
+	{
+	}
 
+	virtual void Execute(LPCSTR args)
+	{
+		float time_factor;
+		if (EQ(args, "on") || EQ(args, "1"))
+			time_factor = 1;
+
+		if (EQ(args, "off") || EQ(args, "0"))
+			time_factor = 0;
+
+		if (!time_factor)
+			return;
+
+		Device.time_factor(time_factor);
+	}
+};
 class CCC_TimeFactor : public IConsole_Command
 {
 public:
@@ -2432,6 +2453,7 @@ void CCC_RegisterCommands()
 	/* AVO: end */
 
 	CMD1(CCC_TimeFactor, "time_factor");
+	CMD1(CCC_FreezeTime, "freeze_time");
 	CMD3(CCC_Mask, "g_use_tracers", &psActorFlags, AF_USE_TRACERS);
 	CMD3(CCC_Mask, "g_autopickup", &psActorFlags, AF_AUTOPICKUP);
 	CMD3(CCC_Mask, "g_dynamic_music", &psActorFlags, AF_DYNAMIC_MUSIC);

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -1681,16 +1681,29 @@ public:
 	virtual void Execute(LPCSTR args)
 	{
 		float time_factor;
-		if (EQ(args, "on") || EQ(args, "1"))
-			time_factor = 1;
+		bool isSet = false;
 
-		if (EQ(args, "off") || EQ(args, "0"))
-			time_factor = 0;
+		if (EQ(args, "off") || EQ(args, "0")) {
+			time_factor = 1.0f;
+			isSet = true;
+		}
 
-		if (!time_factor)
+		if (EQ(args, "on") || EQ(args, "1")) {
+			time_factor = 0.0f;
+			isSet = true;
+		}
+
+		if (!isSet) {
+			Msg("requires parameter [on,off]");
 			return;
+		}
 
 		Device.time_factor(time_factor);
+	}
+
+		virtual void Info(TInfo& I)
+	{
+		xr_strcpy(I, "[on,off] or [1,0]");
 	}
 };
 class CCC_TimeFactor : public IConsole_Command


### PR DESCRIPTION
Adds a new console command that allows to freeze the alife time e.g. time_factor [0,1] but the sounds can still play.

While the time is frozen, any current playing sounds, from alife scripts or soundtracks will keep playing until their end while looped sounds (anomalies fx) will play normally. You can also play new sounds in this frozen state from scripts