### PR TITLE
feature(wpn-zoom-type-changed-callback): Add Callback On Weapon Zoom Type Changed

### DIFF
--- a/gamedata/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/gamedata/scripts/callbacks_gameobject.script
@@ -107,6 +107,7 @@ end
 -- Weapons callbacks
 AddScriptCallback("actor_on_weapon_zoom_type_changed")
 
+
 _G.CWeapon_OnSwitchZoomType = function(obj, previous, current)
 	SendScriptCallback("actor_on_weapon_zoom_type_changed", obj, previous, current)
 end

--- a/gamedata/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/gamedata/scripts/callbacks_gameobject.script
@@ -104,6 +104,13 @@ _G.CBulletOnRemove = function(bullet)
 	SendScriptCallback("bullet_on_remove", bullet)
 end
 
+-- Weapons callbacks
+AddScriptCallback("actor_on_weapon_zoom_type_changed")
+
+_G.CWeapon_OnSwitchZoomType = function(obj, previous, current)
+	SendScriptCallback("actor_on_weapon_zoom_type_changed", obj, previous, current)
+end
+
 -- WIP DONT TOUCH
 -- AddScriptCallback("rocket_on_update")
 -- Called when rocket is flying

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -35,6 +35,8 @@
 #include "WeaponMagazinedWGrenade.h"
 #include "../xrEngine/GameMtlLib.h"
 #include "../Layers/xrRender/xrRender_console.h"
+#include "pch_script.h"
+#include "script_game_object.h"
 
 #define WEAPON_REMOVE_TIME		60000
 #define ROTATION_TIME			0.25f

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -381,6 +381,8 @@ void CWeapon::UpdateUIScope()
 
 void CWeapon::SwitchZoomType()
 {
+    int previous_zoom_type = m_zoomtype;
+
 	if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode))
 	{
 		m_zoomtype = 1;
@@ -396,6 +398,12 @@ void CWeapon::SwitchZoomType()
 		m_zoomtype = 0;
         m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Primary || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
 	}
+
+    luabind::functor<void> funct;
+    if (ai().script_engine().functor("_G.CWeapon_OnSwitchZoomType", funct))
+    {
+        funct(this->lua_game_object(), previous_zoom_type, m_zoomtype);
+    }
 
 	UpdateUIScope();
 }


### PR DESCRIPTION
Added a callback that triggers when actor changes zoom type. The callback is fired with three arguments.

- `obj` : `game_object` - the weapon object for which the zoom type was changed
- `previous` : `number` - the previous zoom type, before the change (`0` = normal, `1` = alt, `2` = gl)
- `current` : `number` - the current zoom type, after the change (`0` = normal, `1` = alt, `2` = gl)