### PR TITLE
hotfix(wpn-zoom-type-changed-with-gl): Fix On Weapon Zoom Type Changed With Grenade Launcher

### DIFF
--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -383,11 +383,9 @@ void CWeapon::UpdateUIScope()
 
 void CWeapon::SwitchZoomType()
 {
-    int previous_zoom_type = m_zoomtype;
-
 	if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode))
 	{
-		m_zoomtype = 1;
+        SetZoomType(1);
         m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Alt || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom_alt", false);
 	}
 	else if (IsGrenadeLauncherAttached())
@@ -397,17 +395,23 @@ void CWeapon::SwitchZoomType()
 	}
 	else if (m_zoomtype != 0)
 	{
-		m_zoomtype = 0;
+        SetZoomType(0);
         m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Primary || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
 	}
+
+	UpdateUIScope();
+}
+
+void CWeapon::SetZoomType(u8 new_zoom_type)
+{
+    int previous_zoom_type = m_zoomtype;
+    m_zoomtype = new_zoom_type;
 
     luabind::functor<void> funct;
     if (ai().script_engine().functor("_G.CWeapon_OnSwitchZoomType", funct))
     {
         funct(this->lua_game_object(), previous_zoom_type, m_zoomtype);
     }
-
-	UpdateUIScope();
 }
 
 extern float g_ironsights_factor;

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -35,6 +35,8 @@
 #include "WeaponMagazinedWGrenade.h"
 #include "../xrEngine/GameMtlLib.h"
 #include "../Layers/xrRender/xrRender_console.h"
+#include "pch_script.h"
+#include "script_game_object.h"
 
 #define WEAPON_REMOVE_TIME		60000
 #define ROTATION_TIME			0.25f

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -35,8 +35,6 @@
 #include "WeaponMagazinedWGrenade.h"
 #include "../xrEngine/GameMtlLib.h"
 #include "../Layers/xrRender/xrRender_console.h"
-#include "pch_script.h"
-#include "script_game_object.h"
 
 #define WEAPON_REMOVE_TIME		60000
 #define ROTATION_TIME			0.25f

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -515,6 +515,7 @@ protected:
 	virtual void UpdateFireDependencies_internal();
 	void UpdateUIScope();
 	void SwitchZoomType();
+    void SetZoomType(u8 new_zoom_type);
 	float GetHudFov();
 	virtual void UpdatePosition(const Fmatrix& transform); //.
 	virtual void UpdateXForm();

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -12,7 +12,8 @@
 #include "game_base_space.h"
 #include "../xrphysics/MathUtils.h"
 #include "player_hud.h"
-
+#include "pch_script.h"
+#include "script_game_object.h"
 #include "../build_config_defines.h"
 
 #ifdef DEBUG

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -12,8 +12,6 @@
 #include "game_base_space.h"
 #include "../xrphysics/MathUtils.h"
 #include "player_hud.h"
-#include "pch_script.h"
-#include "script_game_object.h"
 #include "../build_config_defines.h"
 
 #ifdef DEBUG

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -213,7 +213,15 @@ void CWeaponMagazinedWGrenade::PerformSwitchGL()
 {
 	m_bGrenadeMode = !m_bGrenadeMode;
 
+    int previous_zoom_type = m_zoomtype;
+
 	m_zoomtype = m_bGrenadeMode ? 2 : 0;
+
+    luabind::functor<void> funct;
+    if (ai().script_engine().functor("_G.CWeapon_OnSwitchZoomType", funct))
+    {
+        funct(this->lua_game_object(), previous_zoom_type, m_zoomtype);
+    }
 
 	UpdateUIScope();
 

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -214,15 +214,7 @@ void CWeaponMagazinedWGrenade::PerformSwitchGL()
 {
 	m_bGrenadeMode = !m_bGrenadeMode;
 
-    int previous_zoom_type = m_zoomtype;
-
-	m_zoomtype = m_bGrenadeMode ? 2 : 0;
-
-    luabind::functor<void> funct;
-    if (ai().script_engine().functor("_G.CWeapon_OnSwitchZoomType", funct))
-    {
-        funct(this->lua_game_object(), previous_zoom_type, m_zoomtype);
-    }
+    SetZoomType(m_bGrenadeMode ? 2 : 0);
 
 	UpdateUIScope();
 


### PR DESCRIPTION
This MR fixes the `actor_on_weapon_zoom_type_changed` not triggering properly when switching to the grenade launcher.

When switching to grenade launcher, the change isn't immediate, and is done after a transition, in a completely different file.

To make sure this doesn't happen again, a method called `CWeapon::SetZoomType` was created. It makes the switch and triggers the callback.

All current affectations of `m_zoomtype` were replaced with the method call.

This was tested in-game, and seems to work fine through normal aim, alt aim and gl aim. So this should hopefully be the last MR on this topic.

Sorry I didn't catch this the first time around.