### PR TITLE
A fistful of small edits

### DIFF
--- a/src/xrGame/ActorInput.cpp
+++ b/src/xrGame/ActorInput.cpp
@@ -35,6 +35,8 @@
 #include "Flashlight.h"
 #include "../xrPhysics/IElevatorState.h"
 #include "holder_custom.h"
+#include "Weapon.h"
+#include "CustomOutfit.h"
 
 extern u32 hud_adj_mode;
 
@@ -440,7 +442,7 @@ void CActor::IR_OnMouseMove(int dx, int dy)
 	if (cam_freelook == eflEnabling || cam_freelook == eflDisabling)
 		return;
 
-	float LookFactor = GetLookFactor();
+	const float LookFactor = GetLookFactor();
 
 	CCameraBase* C = cameras[cam_active];
     float scale = (C->f_fov / g_fov) * (psMouseSens * sens_multiple) * psMouseSensScale / 50.f / LookFactor;
@@ -585,7 +587,7 @@ void CActor::ActorUse()
 				}
 				else if (!bCaptured)
 				{
-					//только если находимся в режиме single
+					//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ single
 					CUIGameSP* pGameSP = smart_cast<CUIGameSP*>(CurrentGameUI());
 					if (pGameSP)
 					{
@@ -698,18 +700,40 @@ void CActor::OnPrevWeaponSlot()
 
 extern float g_AimLookFactor;
 
+// momopate: Optional restoration of the handling gimmick from the original games
+BOOL g_allow_weapon_control_inertion_factor = 1;
+BOOL g_allow_outfit_control_inertion_factor = 1;
+
 float CActor::GetLookFactor()
 {
 	if (m_input_external_handler)
 		return m_input_external_handler->mouse_scale_factor();
 
+	float factor = 1.f;
+
 	if (m_bZoomAimingMode)
-		return (1.f / g_AimLookFactor);
+		factor /= g_AimLookFactor;
+
+	if (g_allow_weapon_control_inertion_factor)
+	{
+		PIItem pItem = inventory().ActiveItem();
+		if (pItem)
+			factor *= pItem->GetControlInertionFactor();
+	}
+
+	if (g_allow_outfit_control_inertion_factor)
+	{
+		CCustomOutfit* outfit = GetOutfit();
+		if (outfit)
+			factor *= outfit->GetControlInertionFactor();
+	}
+
+    VERIFY(!fis_zero(factor));
 
 	if (cam_freelook != eflDisabled)
 		return 1.5f;
 
-	return 1.f;
+	return factor;
 }
 
 void CActor::set_input_external_handler(CActorInputHandler* handler)

--- a/src/xrGame/CustomOutfit.cpp
+++ b/src/xrGame/CustomOutfit.cpp
@@ -106,7 +106,7 @@ void CCustomOutfit::Load(LPCSTR section)
 	m_fSatietyRestoreSpeed = READ_IF_EXISTS(pSettings, r_float, section, "satiety_restore_speed", 0.0f);
 	m_fPowerRestoreSpeed = READ_IF_EXISTS(pSettings, r_float, section, "power_restore_speed", 0.0f);
 	m_fBleedingRestoreSpeed = READ_IF_EXISTS(pSettings, r_float, section, "bleeding_restore_speed", 0.0f);
-
+	m_fControlInertionFactor = READ_IF_EXISTS(pSettings, r_float, section, "control_inertion_factor", 1.0f);
 
 	m_full_icon_name = pSettings->r_string(section, "full_icon_name");
 	m_artefact_count = READ_IF_EXISTS(pSettings, r_u32, section, "artefact_count", 0);
@@ -169,9 +169,9 @@ float CCustomOutfit::HitThroughArmor(float hit_power, s16 element, float ap, boo
 		float BoneArmor = ba * GetCondition();
 		if (ap <= BoneArmor)
 		{
-			//пуля НЕ пробила бронь
+			//пїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ
 			NewHitPower *= m_boneProtection->m_fHitFracActor;
-			//add_wound = false; 	//раны нет
+			//add_wound = false; 	//пїЅпїЅпїЅпїЅ пїЅпїЅпїЅ
 
 			if (strstr(Core.Params, "-dbgbullet"))
 				Msg("CCustomOutfit::HitThroughArmor AP(%f) <= bone_armor(%f) [HitFracActor=%f] modified hit_power=%f",
@@ -210,7 +210,7 @@ float CCustomOutfit::HitThroughArmor(float hit_power, s16 element, float ap, boo
 			Msg("CCustomOutfit::HitThroughArmor hit_type=%d | After HitTypeProtection(%f) hit_power=%f", (u32)hit_type,
 			    protect * one, NewHitPower);
 	}
-	//увеличить изношенность костюма
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	Hit(hit_power, hit_type);
 
 	if (strstr(Core.Params, "-dbgbullet"))

--- a/src/xrGame/CustomOutfit.h
+++ b/src/xrGame/CustomOutfit.h
@@ -14,12 +14,12 @@ public:
 
 	virtual void Load(LPCSTR section);
 
-	//уменьшенная версия хита, для вызова, когда костюм надет на персонажа
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	virtual void Hit(float P, ALife::EHitType hit_type);
 
-	//коэффициенты на которые домножается хит
-	//при соответствующем типе воздействия
-	//если на персонаже надет костюм
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ
+	//пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
+	//пїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float GetHitTypeProtection(ALife::EHitType hit_type, s16 element);
 	float GetDefHitTypeProtection(ALife::EHitType hit_type);
 	float GetBoneArmor(s16 element);
@@ -29,6 +29,7 @@ public:
 	virtual void OnMoveToSlot(const SInvItemPlace& prev);
 	virtual void OnMoveToRuck(const SInvItemPlace& previous_place);
 	virtual void OnH_A_Chield();
+	virtual float GetControlInertionFactor() const { return m_fControlInertionFactor; };
 
 protected:
 	HitImmunity::HitTypeSVec m_HitTypeProtection;

--- a/src/xrGame/Explosive.cpp
+++ b/src/xrGame/Explosive.cpp
@@ -426,7 +426,7 @@ void CExplosive::Explode()
 		Level().BulletManager().AddBullet(pos, frag_dir, m_fFragmentSpeed,
 		                                  m_fFragHit, m_fFragHitImpulse, Initiator(),
 		                                  cast_game_object()->ID(), m_eHitTypeFrag, m_fFragsRadius,
-		                                  cartridge, 1.f, SendHits, false, i + 1);
+		                                  cartridge, m_fFragAirRes, SendHits, false, i + 1);
 	}
 
 	if (cast_game_object()->Remote()) return;

--- a/src/xrGame/Explosive.cpp
+++ b/src/xrGame/Explosive.cpp
@@ -1,4 +1,4 @@
-// Explosive.cpp: интерфейс для взврывающихся объектов
+// Explosive.cpp: пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -11,7 +11,7 @@
 //#include "PSObject.h"
 #include "ParticlesObject.h"
 
-//для вызова статических функций поражения осколками
+//пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 #include "Weapon.h"
 
 #include "actor.h"
@@ -51,6 +51,9 @@ CExplosive::CExplosive(void)
 	m_fFragsRadius = 30.0f;
 	m_fFragHit = 50.0f;
 	m_fUpThrowFactor = 0.f;
+
+	m_fFragAP = 1.0f;
+	m_fFragAirRes = 1.0f;
 
 
 	m_eSoundExplode = ESoundTypes(SOUND_TYPE_WEAPON_SHOOTING);
@@ -108,6 +111,14 @@ void CExplosive::Load(CInifile const* ini, LPCSTR section)
 
 	m_fUpThrowFactor = ini->r_float(section, "up_throw_factor");
 
+	// momopate: Extended shrapnel customization
+	m_fFragAP = READ_IF_EXISTS(pSettings, r_float, section, "frags_ap", 1.0f);
+	m_fFragAirRes = READ_IF_EXISTS(pSettings, r_float, section, "frags_air_resistance", 1.0f);
+	m_bFragTracer = READ_IF_EXISTS(pSettings, r_bool, section, "frags_tracer", false);
+	m_bFrag4to1Tracer = READ_IF_EXISTS(pSettings, r_bool, section, "frags_4to1_tracer", false);
+	m_bFragMagneticBeamShot = READ_IF_EXISTS(pSettings, r_bool, section, "frags_magnetic_beam_shot", false);	// Probably has literal zero use cases but, you know, what if?
+	m_bFragAllowRicochet = READ_IF_EXISTS(pSettings, r_bool, section, "frags_allow_ricochet", true);
+	u8FragColorID = READ_IF_EXISTS(pSettings, r_u8, section, "frags_tracer_color_ID", 0);
 
 	fWallmarkSize = ini->r_float(section, "wm_size");
 	R_ASSERT(fWallmarkSize>0);
@@ -118,7 +129,7 @@ void CExplosive::Load(CInifile const* ini, LPCSTR section)
 	m_fLightRange = ini->r_float(section, "light_range");
 	m_fLightTime = ini->r_float(section, "light_time");
 
-	//трассы для разлета осколков
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	m_fFragmentSpeed = ini->r_float(section, "fragment_speed");
 
 	m_layered_sounds.LoadSound(ini, section, "snd_explode", "sndExplode", false, m_eSoundExplode);
@@ -184,7 +195,7 @@ struct SExpQParams
 	float shoot_factor;
 };
 
-//проверка на попадание "осколком" по объекту
+//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ "пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ" пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 ICF static BOOL grenade_hit_callback(collide::rq_result& result, LPVOID params)
 {
 	SExpQParams& ep = *(SExpQParams*)params;
@@ -200,7 +211,7 @@ ICF static BOOL grenade_hit_callback(collide::rq_result& result, LPVOID params)
 	}
 	else
 	{
-		//получить треугольник и узнать его материал
+		//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 		CDB::TRI* T = Level().ObjectSpace.GetStaticTris() + result.element;
 		mtl_idx = T->material;
 	}
@@ -354,11 +365,11 @@ void CExplosive::Explode()
 	
 	//	Msg("---------CExplosive Explode [%d] frame[%d]",cast_game_object()->ID(), Device.dwFrame);
 	OnBeforeExplosion();
-	//играем звук взрыва
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 
 	m_layered_sounds.PlaySound("sndExplode", pos, smart_cast<CObject*>(this), false, false, (u8)-1);
 
-	//показываем эффекты
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 
 	m_wallmark_manager.PlaceWallmarks(pos);
 
@@ -377,14 +388,14 @@ void CExplosive::Explode()
 	pStaticPG->UpdateParent(explode_matrix, vel);
 	pStaticPG->Play(false);
 
-	//включаем подсветку от взрыва
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	StartLight();
 
 	//trace frags
 	Fvector frag_dir;
 
 	//////////////////////////////
-	//осколки
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	//////////////////////////////
 	//-------------------------------------
 	bool SendHits = false;
@@ -402,21 +413,26 @@ void CExplosive::Explode()
 		cartridge.param_s.kHit = 1.f;
 		//.		cartridge.param_s.kCritical			= 1.f;
 		cartridge.param_s.kImpulse = 1.f;
-		cartridge.param_s.kAP = 1.f;
+		cartridge.param_s.kAP = m_fFragAP;
+		cartridge.param_s.kAirRes = m_fFragAirRes;
 		cartridge.param_s.fWallmarkSize = fWallmarkSize;
+		cartridge.param_s.u8ColorID = u8FragColorID;
+		cartridge.m_4to1_tracer = m_bFrag4to1Tracer;
 		cartridge.bullet_material_idx = GMLib.GetMaterialIdx(WEAPON_MATERIAL_NAME);
-		cartridge.m_flags.set(CCartridge::cfTracer,FALSE);
+		cartridge.m_flags.set(CCartridge::cfTracer, m_bFragTracer ? TRUE : FALSE);
+		cartridge.m_flags.set(CCartridge::cfRicochet, m_bFragAllowRicochet ? TRUE : FALSE);
+		cartridge.m_flags.set(CCartridge::cfMagneticBeam, m_bFragMagneticBeamShot ? TRUE : FALSE);
 
 		Level().BulletManager().AddBullet(pos, frag_dir, m_fFragmentSpeed,
 		                                  m_fFragHit, m_fFragHitImpulse, Initiator(),
 		                                  cast_game_object()->ID(), m_eHitTypeFrag, m_fFragsRadius,
-		                                  cartridge, 1.f, SendHits);
+		                                  cartridge, 1.f, SendHits, false, i + 1);
 	}
 
 	if (cast_game_object()->Remote()) return;
 
 	/////////////////////////////////
-	//взрывная волна
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ
 	////////////////////////////////
 	//---------------------------------------------------------------------
 	xr_vector<ISpatial*> ISpatialResult;
@@ -503,7 +519,7 @@ void CExplosive::UpdateCL()
 		OnAfterExplosion();
 		return;
 	}
-	//время вышло, убираем объект взрывчатки
+	//пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	if (m_fExplodeDuration < 0.f && m_blasted_objects.empty())
 	{
 		m_explosion_flags.set(flExploded,TRUE);
@@ -527,7 +543,7 @@ void CExplosive::UpdateCL()
 		UpdateExplosionPos();
 		UpdateExplosionParticles();
 		ExplodeWaveProcess();
-		//обновить подсветку взрыва
+		//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 		if (m_pLight && m_pLight->get_active() && m_fLightTime > 0)
 		{
 			if (m_fExplodeDuration > (m_fExplodeDurationMax - m_fLightTime))
@@ -550,7 +566,7 @@ void CExplosive::OnAfterExplosion()
 		CParticlesObject::Destroy(m_pExpParticle);
 		m_pExpParticle = NULL;
 	}
-	//ликвидировать сам объект 
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ 
 	if (cast_game_object()->Local()) cast_game_object()->DestroyObject();
 
 	//	NET_Packet			P;
@@ -647,8 +663,8 @@ void CExplosive::FindNormal(Fvector& normal)
 	if (!result || RQ.O)
 	{
 		normal.set(0, 1, 0);
-		//если лежим на статике
-		//найти треугольник и вычислить нормаль по нему
+		//пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
+		//пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅ
 	}
 	else
 	{
@@ -703,7 +719,7 @@ void CExplosive::ExplodeWaveProcessObject(collide::rq_results& storage, CPhysics
 {
 	Fvector l_goPos;
 	if (l_pGO->Visual()) l_pGO->Center(l_goPos);
-	else return; //мне непонятно зачем наносить хит от взрыва по объектам не имеющим вижуал - поэтому игнорируем
+	else return; //пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ - пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 
 #ifdef DEBUG
 	if(ph_dbg_draw_mask.test(phDbgDrawExplosions))
@@ -724,8 +740,8 @@ void CExplosive::ExplodeWaveProcessObject(collide::rq_results& storage, CPhysics
 
 		float rmag = _sqrt(m_fUpThrowFactor * m_fUpThrowFactor + 1.f + 2.f * m_fUpThrowFactor * l_dir.y);
 		l_dir.y += m_fUpThrowFactor;
-		//rmag -модуль l_dir после l_dir.y += m_fUpThrowFactor, модуль=_sqrt(l_dir^2+y^2+2.*(l_dir,y)),y=(0,m_fUpThrowFactor,0) (до этого модуль l_dir =1)
-		l_dir.mul(1.f / rmag); //перенормировка
+		//rmag -пїЅпїЅпїЅпїЅпїЅпїЅ l_dir пїЅпїЅпїЅпїЅпїЅ l_dir.y += m_fUpThrowFactor, пїЅпїЅпїЅпїЅпїЅпїЅ=_sqrt(l_dir^2+y^2+2.*(l_dir,y)),y=(0,m_fUpThrowFactor,0) (пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ l_dir =1)
+		l_dir.mul(1.f / rmag); //пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 		NET_Packet P;
 		SHit HS;
 		HS.GenHeader(GE_HIT, l_pGO->ID()); //		cast_game_object()->u_EventGen		(P,GE_HIT,l_pGO->ID());

--- a/src/xrGame/Explosive.h
+++ b/src/xrGame/Explosive.h
@@ -1,4 +1,4 @@
-// Explosive.h: интерфейс для взврывающихся объектов
+// Explosive.h: пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -88,7 +88,7 @@ protected:
 	HUD_SOUND_COLLECTION_LAYERED m_layered_sounds;
 
 	CWalmarkManager m_wallmark_manager;
-	//ID персонажа который иницировал действие
+	//ID пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	u16 m_iCurrentParentID;
 
 	//bool						m_bReadyToExplode;
@@ -96,35 +96,35 @@ protected:
 	Fvector m_vExplodeSize;
 	Fvector m_vExplodeDir;
 
-	//параметры взрыва
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fBlastHit;
 	float m_fBlastHitImpulse;
 	float m_fBlastRadius;
 
-	//параметры и количество осколков
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fFragsRadius;
 	float m_fFragHit;
 	float m_fFragHitImpulse;
 	int m_iFragsNum;
 
-	//типы наносимых хитов
+	//пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ
 	ALife::EHitType m_eHitTypeBlast;
 	ALife::EHitType m_eHitTypeFrag;
 
-	//фактор подпроса предмета вверх взрывной волной 
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ 
 	float m_fUpThrowFactor;
 
-	//список пораженных объектов
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	BLASTED_OBJECTS_V m_blasted_objects;
 
-	//текущая продолжительность взрыва
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fExplodeDuration;
-	//общее время взрыва
+	//пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fExplodeDurationMax;
-	//Время, через которое надо сделать взрывчатку невиимой, если она не становится невидимой во время взрыва
+	//пїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fExplodeHideDurationMax;
 
-	//флаг состояния взрыва
+	//пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	enum
 	{
 		flExploding =1 << 0,
@@ -135,7 +135,7 @@ protected:
 
 	Flags8 m_explosion_flags;
 	///////////////////////////////////////////////
-	//Должен ли объект быть скрыт после взрыва: true - для всех кроме дымовой гранаты
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ: true - пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	BOOL m_bHideInExplosion;
 	bool m_bAlreadyHidden;
 	virtual void HideExplosive();
@@ -143,23 +143,32 @@ protected:
 	//bool						m_bExplodeEventSent;
 
 	//////////////////////////////////////////////
-	//для разлета осколков
+	//пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	float m_fFragmentSpeed;
 
-	//звуки
+	//пїЅпїЅпїЅпїЅпїЅ
 	ESoundTypes m_eSoundExplode;
 
-	//размер отметки на стенах
+	//пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	float fWallmarkSize;
 
-	//эффекты и подсветка
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	shared_str m_sExplodeParticles;
 
-	//подсветка взрыва
+	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ
 	ref_light m_pLight;
 	Fcolor m_LightColor;
 	float m_fLightRange;
 	float m_fLightTime;
+
+	// momopate: Extended shrapnel customization
+	float m_fFragAP;
+	float m_fFragAirRes;
+	bool m_bFragTracer;
+	bool m_bFrag4to1Tracer;
+	bool m_bFragMagneticBeamShot;
+	bool m_bFragAllowRicochet;
+	u8 u8FragColorID;
 
 	virtual void StartLight();
 	virtual void StopLight();
@@ -168,7 +177,7 @@ protected:
 	CParticlesObject* m_pExpParticle;
 	virtual void UpdateExplosionParticles();
 
-	// эффектор
+	// пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	struct
 	{
 		shared_str effect_sect_name;

--- a/src/xrGame/Tracer.cpp
+++ b/src/xrGame/Tracer.cpp
@@ -13,6 +13,7 @@ CTracer::CTracer()
 	LPCSTR sh_name = pSettings->r_string("bullet_manager", "tracer_shader");
 	LPCSTR tx_name = pSettings->r_string("bullet_manager", "tracer_texture");
 	m_circle_size_k = pSettings->r_float("bullet_manager", "fire_circle_k");
+	m_tracer_length_k = READ_IF_EXISTS(pSettings, r_float, "bullet_manager", "tracer_length_k", 1.0f);	// momopate: Allow for customizable tracer length
 
 	sh_Tracer->create(sh_name, tx_name);
 
@@ -133,6 +134,6 @@ void CTracer::Render(const Fvector& pos,
 			                  m_aColors[colorID]);
 		}
 
-		FillSprite_Line(center, dir, width * .5f, length * .5f, m_aColors[colorID]);
+		FillSprite_Line(center, dir, width * .5f, length * .5f * m_tracer_length_k, m_aColors[colorID]);
 	}
 }

--- a/src/xrGame/Tracer.h
+++ b/src/xrGame/Tracer.h
@@ -11,6 +11,7 @@ protected:
 	ui_shader sh_Tracer;
 	xr_vector<u32> m_aColors;
 	float m_circle_size_k;
+	float m_tracer_length_k;
 public:
 	CTracer();
 	void Render(const Fvector& pos,

--- a/src/xrGame/WeaponAmmo.cpp
+++ b/src/xrGame/WeaponAmmo.cpp
@@ -49,6 +49,8 @@ void CCartridge::Load(LPCSTR section, u8 LocalAmmoType, float ap_mod)
 	param_s.impair = pSettings->r_float(section, "impair");
 	param_s.fWallmarkSize = pSettings->r_float(section, "wm_size");
 
+	param_s.tracer_silenced = READ_IF_EXISTS(pSettings, r_bool, section, "tracer_silenced", false);
+
 	m_flags.set(cfCanBeUnlimited | cfRicochet, TRUE);
 	m_flags.set(cfMagneticBeam, FALSE);
 
@@ -177,15 +179,15 @@ void CWeaponAmmo::OnH_B_Independent(bool just_before_destroy)
 
 bool CWeaponAmmo::Useful() const
 {
-	// Если IItem еще не полностью использованый, вернуть true
+	// пїЅпїЅпїЅпїЅ IItem пїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅ true
 	return !!m_boxCurr;
 }
 
 /*
 s32 CWeaponAmmo::Sort(PIItem pIItem) 
 {
-	// Если нужно разместить IItem после this - вернуть 1, если
-	// перед - -1. Если пофиг то 0.
+	// пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ IItem пїЅпїЅпїЅпїЅпїЅ this - пїЅпїЅпїЅпїЅпїЅпїЅпїЅ 1, пїЅпїЅпїЅпїЅ
+	// пїЅпїЅпїЅпїЅпїЅ - -1. пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅ 0.
 	CWeaponAmmo *l_pA = smart_cast<CWeaponAmmo*>(pIItem);
 	if(!l_pA) return 0;
 	if(xr_strcmp(cNameSect(), l_pA->cNameSect())) return 0;

--- a/src/xrGame/WeaponAmmo.h
+++ b/src/xrGame/WeaponAmmo.h
@@ -10,6 +10,8 @@ struct SCartridgeParam
 	float fWallmarkSize;
 	u8 u8ColorID;
 
+	bool tracer_silenced;
+
 	IC void Init()
 	{
 		kDist = kDisp = kHit = kImpulse = kBulletSpeed = 1.0f;
@@ -21,6 +23,7 @@ struct SCartridgeParam
 		fWallmarkSize = 0.0f;
 		u8ColorID = 0;
 		k_cam_dispersion = 1.0f;
+		tracer_silenced = false;
 	}
 };
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -115,6 +115,10 @@ extern BOOL g_ai_die_in_anomaly; //Alundaio
 
 extern BOOL g_telekinetic_objects_include_corpses; // Tosox
 
+extern BOOL g_allow_weapon_control_inertion_factor; // momopate
+extern BOOL g_allow_outfit_control_inertion_factor;
+extern BOOL g_render_short_tracers;
+
 //demonized: new console vars
 extern BOOL firstPersonDeath;
 extern BOOL pseudogiantCanDamageObjects;
@@ -2690,6 +2694,12 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "pseudogiant_can_damage_objects_on_stomp", &pseudogiantCanDamageObjects, 0, 1);
 
 	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
+
+	CMD4(CCC_Integer, "allow_weapon_control_inertion_factor", &g_allow_weapon_control_inertion_factor, 0, 1); // momopate
+
+	CMD4(CCC_Integer, "allow_outfit_control_inertion_factor", &g_allow_outfit_control_inertion_factor, 0, 1);
+
+	CMD4(CCC_Integer, "render_short_tracers", &g_render_short_tracers, 0, 1);
 
 	CMD4(CCC_Float, "ai_aim_predict_time", &g_aim_predict_time, 0.f, 10.f);
 


### PR DESCRIPTION
- Added console commands:
++ allow_outfit_control_inertion_factor *
++ allow_weapon_control_inertion_factor *
++ render_short_tracers **

(*) Weapon and outfit control_inertion_factor can affect mouse sens, toggleable with their respective commands.
(**) Tracers will be capped to their minimum length instead of not rendering with this command enabled.

- Explosive shrapnel (frags) customization:
++ frags_ap
++ frags_air_resistance
++ frags_tracer
++ frags_4to1_tracer
++ frags_magnetic_beam_shot
++ frags_tracer_color_ID

- Outfit control_inertion_factor now read in-engine

- Silencers can hide bullet tracers, toggleable per ammo with the tracer_silenced ltx field

- Tracer length modifier added to the bullet_manager section, tracer_length_k