### PR TITLE
Change item `max_uses` and `remaining_uses` from u8 to u16

### DIFF
--- a/src/xrGame/eatable_item.cpp
+++ b/src/xrGame/eatable_item.cpp
@@ -45,7 +45,7 @@ void CEatableItem::Load(LPCSTR section)
 {
 	inherited::Load(section);
 
-	m_iRemainingUses = m_iMaxUses = READ_IF_EXISTS(pSettings, r_u8, section, "max_uses", 1);
+	m_iRemainingUses = m_iMaxUses = READ_IF_EXISTS(pSettings, r_u16, section, "max_uses", 1);
 	m_bRemoveAfterUse = READ_IF_EXISTS(pSettings, r_bool, section, "remove_after_use", TRUE);
 	m_fWeightFull = m_weight;
 	m_fWeightEmpty = READ_IF_EXISTS(pSettings, r_float, section, "empty_weight", 0.0f);
@@ -64,14 +64,14 @@ void CEatableItem::load(IReader& packet)
 {
 	inherited::load(packet);
 
-	m_iRemainingUses = packet.r_u8();
+	m_iRemainingUses = packet.r_u16();
 }
 
 void CEatableItem::save(NET_Packet& packet)
 {
 	inherited::save(packet);
 
-	packet.w_u8(m_iRemainingUses);
+	packet.w_u16(m_iRemainingUses);
 }
 
 BOOL CEatableItem::net_Spawn(CSE_Abstract* DC)

--- a/src/xrGame/eatable_item.h
+++ b/src/xrGame/eatable_item.h
@@ -19,8 +19,8 @@ private:
 protected:
 	CPhysicItem* m_physic_item;
 
-	u8 m_iMaxUses;
-	u8 m_iRemainingUses;
+	u16 m_iMaxUses;
+	u16 m_iRemainingUses;
 	BOOL m_bRemoveAfterUse;
 	float m_fWeightFull;
 	float m_fWeightEmpty;
@@ -44,9 +44,9 @@ public:
 
 	bool Empty() const { return m_iRemainingUses == 0; };
 	bool CanDelete() const { return m_bRemoveAfterUse == 1; };
-	u8 GetMaxUses() const { return m_iMaxUses; };
-	u8 GetRemainingUses() const { return m_iRemainingUses; };
-	void SetRemainingUses(u8 value) { if (value <= m_iMaxUses) m_iRemainingUses = value; };
+	u16 GetMaxUses() const { return m_iMaxUses; };
+	u16 GetRemainingUses() const { return m_iRemainingUses; };
+	void SetRemainingUses(u16 value) { if (value <= m_iMaxUses) m_iRemainingUses = value; };
 	virtual float Weight() const;
 
 	DECLARE_SCRIPT_REGISTER_FUNCTION

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1037,9 +1037,9 @@ public:
 	void SetArtefactAdditionalInventoryWeight(float value);
 
 	//Eatable items
-	void SetRemainingUses(u8 value);
-	u8 GetRemainingUses();
-	u8 GetMaxUses();
+	void SetRemainingUses(u16 value);
+	u16 GetRemainingUses();
+	u16 GetMaxUses();
 
 	//Phantom
 	void PhantomSetEnemy(CScriptGameObject*);

--- a/src/xrGame/script_game_object3.cpp
+++ b/src/xrGame/script_game_object3.cpp
@@ -1749,7 +1749,7 @@ Fvector CScriptGameObject::Angle()
 	return ang;
 }
 
-void CScriptGameObject::SetRemainingUses(u8 value)
+void CScriptGameObject::SetRemainingUses(u16 value)
 {
 	CInventoryItem* IItm = object().cast_inventory_item();
 	if (!IItm)
@@ -1762,7 +1762,7 @@ void CScriptGameObject::SetRemainingUses(u8 value)
 	eItm->SetRemainingUses(value);
 }
 
-u8 CScriptGameObject::GetRemainingUses()
+u16 CScriptGameObject::GetRemainingUses()
 {
 	CInventoryItem* IItm = object().cast_inventory_item();
 	if (!IItm)
@@ -1775,7 +1775,7 @@ u8 CScriptGameObject::GetRemainingUses()
 	return eItm->GetRemainingUses();
 }
 
-u8 CScriptGameObject::GetMaxUses()
+u16 CScriptGameObject::GetMaxUses()
 {
 	CInventoryItem* IItm = object().cast_inventory_item();
 	if (!IItm)

--- a/src/xrGame/trade2.cpp
+++ b/src/xrGame/trade2.cpp
@@ -284,8 +284,8 @@ u32 CTrade::GetItemPrice(PIItem pItem, bool b_buying, bool b_free)
 	CEatableItem* eatable_item = pItem->cast_eatable_item();
 	if (eatable_item && eatable_item->GetMaxUses())
 	{
-		u8 max_uses = eatable_item->GetMaxUses();
-		u8 remaining_uses = eatable_item->GetRemainingUses();
+		u16 max_uses = eatable_item->GetMaxUses();
+		u16 remaining_uses = eatable_item->GetRemainingUses();
 		result = result * remaining_uses / max_uses;
 		if (result < 1) result = 1;
 	}

--- a/src/xrGame/ui/UICellItem.cpp
+++ b/src/xrGame/ui/UICellItem.cpp
@@ -224,11 +224,11 @@ void CUICellItem::UpdateConditionProgressBar()
 			CEatableItem* eitm = smart_cast<CEatableItem*>(itm);
 			if (eitm)
 			{
-				u8 max_uses = eitm->GetMaxUses();
+				u16 max_uses = eitm->GetMaxUses();
 
 				if (max_uses > 0)
 				{
-					u8 remaining_uses = eitm->GetRemainingUses();
+					u16 remaining_uses = eitm->GetRemainingUses();
 
 					if (max_uses < 10)
 					{


### PR DESCRIPTION
This allows for items to have have a maximum of 65535 `(u16)` charges, instead of 256 `(u8)`.

This will not influence base game or existing mods.