### PR TITLE
fearure(character-dialogs): Function To Get Character Dialogs

### DIFF
--- a/src/xrGame/InventoryOwner.cpp
+++ b/src/xrGame/InventoryOwner.cpp
@@ -411,7 +411,6 @@ DIALOG_ID_VECTOR CInventoryOwner::Dialogs() const
 	return CharacterInfo().ActorDialogs();
 }
 
-
 void CInventoryOwner::NewPdaContact(CInventoryOwner* pInvOwner)
 {
 }

--- a/src/xrGame/InventoryOwner.cpp
+++ b/src/xrGame/InventoryOwner.cpp
@@ -406,6 +406,12 @@ LPCSTR CInventoryOwner::IconName() const
 	return CharacterInfo().IconName().c_str();
 }
 
+DIALOG_ID_VECTOR CInventoryOwner::Dialogs() const
+{
+	return CharacterInfo().ActorDialogs();
+}
+
+
 void CInventoryOwner::NewPdaContact(CInventoryOwner* pInvOwner)
 {
 }

--- a/src/xrGame/InventoryOwner.h
+++ b/src/xrGame/InventoryOwner.h
@@ -113,6 +113,7 @@ public:
 	//игровое имя 
 	virtual LPCSTR Name() const;
 	LPCSTR IconName() const;
+	DIALOG_ID_VECTOR Dialogs() const;
 	u32 get_money() const { return m_money; }
 	void set_money(u32 amount, bool bSendEvent);
 	bool is_alive();

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -454,6 +454,7 @@ public:
 	LPCSTR CharacterName();
 	LPCSTR CharacterIcon();
 	LPCSTR CharacterCommunity();
+	luabind::object CharacterDialogs();
 	int CharacterRank();
 	int CharacterReputation();
 

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -902,6 +902,28 @@ int CScriptGameObject::CharacterRank()
 	return monster->Rank();
 }
 
+luabind::object CScriptGameObject::CharacterDialogs()
+{
+	CInventoryOwner* pInventoryOwner = smart_cast<CInventoryOwner*>(&object());
+
+	luabind::object table = luabind::newtable(ai().script_engine().lua());
+
+	if (!pInventoryOwner)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+			"CharacterDialogs available only for InventoryOwner");
+		return table;
+	}
+
+	int i = 0;
+	for (const auto& dialog_id : pInventoryOwner->Dialogs()) {
+		table[i+1] = dialog_id.c_str();
+		i++;
+	}
+
+	return table;
+}
+
 void CScriptGameObject::SetCharacterRank(int char_rank)
 {
 	CInventoryOwner* pInventoryOwner = smart_cast<CInventoryOwner*>(&object());

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -293,6 +293,7 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		.def("character_name", &CScriptGameObject::CharacterName)
 		.def("character_icon", &CScriptGameObject::CharacterIcon)
 		.def("character_rank", &CScriptGameObject::CharacterRank)
+		.def("character_dialogs", &CScriptGameObject::CharacterDialogs)
 		.def("set_character_rank", &CScriptGameObject::SetCharacterRank)
 		.def("change_character_rank", &CScriptGameObject::ChangeCharacterRank)
 		.def("character_reputation", &CScriptGameObject::CharacterReputation)


### PR DESCRIPTION
This PR adds code that defines and exports a new function to get the list of dialogs of an NPC.

The new function is called `character_dialogs`, can be executed on `game_object`, and returns a `table`.

Use like this : 
```lua
local obj = level.object_by_id(1234)
local dialogs = obj:character_dialogs()
printf("%s", utils_data.print_table(dialogs, false, true))
```
If called on Librarian (Clear Sky barman) for example,  it would print : 
```lua
{
  [1] = 'dm_init_batender',
  [2] = 'story_b_cs',
  [3] = 'story_dog',
  [4] = 'about_dog_marsh_part_two',
  [5] = 'drx_sl_task_completed_dialog',
  [6] = 'dm_ordered_task_completed_dialog',
  [7] = 'drx_sl_mar_base_stalker_barmen_meet_dialog',
  [8] = 'dm_ordered_task_dialog',
  [9] = 'mar_smart_terrain_base_barman_background',
  [10] = 'actor_break_dialog'
}
```