### PR TITLE
Add callbacks for getting artefact_count of outfit and getting belt_size in inventory.

### DIFF
--- a/src/xrGame/CustomOutfit.cpp
+++ b/src/xrGame/CustomOutfit.cpp
@@ -316,6 +316,17 @@ u32 CCustomOutfit::ef_equipment_type() const
 	return (m_ef_equipment_type);
 }
 
+u32 CCustomOutfit::get_artefact_count() const
+{
+	u32 artefact_count = m_artefact_count;
+	luabind::functor<int> funct;
+		if (ai().script_engine().functor("_G.CCustomOutfit_get_artefact_count", funct))
+		{
+			artefact_count = funct(artefact_count);
+		}
+	return (artefact_count);
+}
+
 bool CCustomOutfit::install_upgrade_impl(LPCSTR section, bool test)
 {
 	bool result = inherited::install_upgrade_impl(section, test);

--- a/src/xrGame/CustomOutfit.h
+++ b/src/xrGame/CustomOutfit.h
@@ -62,7 +62,7 @@ public:
 	virtual BOOL BonePassBullet(int boneID);
 	float get_HitFracActor() const;
 	const shared_str& GetFullIconName() const { return m_full_icon_name; }
-	u32 get_artefact_count() const { return m_artefact_count; }
+	u32 get_artefact_count() const;
 
 	virtual BOOL net_Spawn(CSE_Abstract* DC);
 	virtual void net_Export(NET_Packet& P);

--- a/src/xrGame/Inventory.cpp
+++ b/src/xrGame/Inventory.cpp
@@ -1321,16 +1321,22 @@ bool CInventory::CanTakeItem(CInventoryItem* inventory_item) const
 
 u32 CInventory::BeltWidth() const
 {
+	u32 artefact_count = 0;
 	CActor* pActor = smart_cast<CActor*>(m_pOwner);
 	if (pActor)
 	{
 		CCustomOutfit* outfit = pActor->GetOutfit();
 		if (outfit)
 		{
-			return outfit->get_artefact_count();
+			artefact_count =  outfit->get_artefact_count();
 		}
 	}
-	return 0; //m_iMaxBelt;
+	luabind::functor<int> funct;
+		if (ai().script_engine().functor("actor_menu_inventory.CInventory_BeltWidth", funct))
+		{
+			artefact_count = funct(artefact_count);
+		}
+	return artefact_count; //m_iMaxBelt;
 }
 
 void CInventory::AddAvailableItems(TIItemContainer& items_container, bool for_trade, bool bOverride) const


### PR DESCRIPTION
Now possible to intercept these calls and put our own values instead.
For example we can add artefact slots for backpack with these changes or easily add additional slots to outfits without exiting the game.
Changed CustomOutfit and Inventory.cpp.
Script part:
AddScriptCallback("on_artefact_count_get")
_G.CCustomOutfit_get_artefact_count = function(artefact_count)
	local flags = { ret_value = artefact_count }
	SendScriptCallback("on_artefact_count_get", artefact_count, flags)
	return flags.ret_value
end

AddScriptCallback("on_belt_size_get")
actor_menu_inventory.CInventory_BeltWidth = function(artefact_count)
	local flags = { ret_value = artefact_count }
	SendScriptCallback("on_belt_size_get", artefact_count, flags)
	return flags.ret_value
end