### PR TITLE
Fix HDR10 issues with HUD samplers and MSAA setting

### DIFF
--- a/gamedata/gamedata/shaders/r3/hud_cursor.s
+++ b/gamedata/gamedata/shaders/r3/hud_cursor.s
@@ -4,5 +4,5 @@ function normal(shader, t_base, t_second, t_detail)
 		:zb(false,false) -- depth_test, depth_write
 		:aref(true,0) -- do_alpha_test, alpha_ref
 	shader:dx10texture	("s_base", t_base)
-	shader:dx10sampler	("smp_base")
+	shader:dx10sampler	("smp_base"):clamp()
 end

--- a/gamedata/gamedata/shaders/r3/hud_default.s
+++ b/gamedata/gamedata/shaders/r3/hud_default.s
@@ -4,5 +4,5 @@ function normal(shader, t_base, t_second, t_detail)
 		:zb(false,false) -- depth_test, depth_write
 		:aref(true,0) -- do_alpha_test, alpha_ref
 	shader:dx10texture	("s_base", t_base)
-	shader:dx10sampler	("smp_base")
+	shader:dx10sampler	("smp_base"):clamp()
 end

--- a/src/Layers/xrRenderDX10/dx10ResourceManager_Scripting.cpp
+++ b/src/Layers/xrRenderDX10/dx10ResourceManager_Scripting.cpp
@@ -52,9 +52,10 @@ public:
 
 	adopt_dx10sampler(const adopt_dx10sampler& _C) : m_pC(_C.m_pC), m_SI(_C.m_SI) { if (u32(-1) == m_SI) m_pC = 0; }
 
+	// TODO: why are these commented out?
 	//	adopt_sampler&			_texture		(LPCSTR texture)		{ if (C) C->i_Texture	(stage,texture);											return *this;	}
 	//	adopt_sampler&			_projective		(bool _b)				{ if (C) C->i_Projective(stage,_b);													return *this;	}
-	//	adopt_sampler&			_clamp			()						{ if (C) C->i_Address	(stage,D3DTADDRESS_CLAMP);									return *this;	}
+		adopt_dx10sampler&	    _clamp			()						{ if (m_pC) m_pC->i_dx10Address	(m_SI,D3DTADDRESS_CLAMP);							return *this;	}
 	//	adopt_sampler&			_wrap			()						{ if (C) C->i_Address	(stage,D3DTADDRESS_WRAP);									return *this;	}
 	//	adopt_sampler&			_mirror			()						{ if (C) C->i_Address	(stage,D3DTADDRESS_MIRROR);									return *this;	}
 	//	adopt_sampler&			_f_anisotropic	()						{ if (C) C->i_Filter	(stage,D3DTEXF_ANISOTROPIC,D3DTEXF_LINEAR,D3DTEXF_ANISOTROPIC);	return *this;	}
@@ -369,9 +370,10 @@ void CResourceManager::LS_Load()
 
 
 		class_<adopt_dx10sampler>("_dx10sampler")
+		// TODO: why are these commented out?
 		//.def("texture",						&adopt_sampler::_texture		,return_reference_to(_1))
 		//.def("project",						&adopt_sampler::_projective		,return_reference_to(_1))
-		//.def("clamp",						&adopt_sampler::_clamp			,return_reference_to(_1))
+		.def("clamp",						&adopt_dx10sampler::_clamp			,return_reference_to(_1))
 		//.def("wrap",						&adopt_sampler::_wrap			,return_reference_to(_1))
 		//.def("mirror",						&adopt_sampler::_mirror			,return_reference_to(_1))
 		//.def("f_anisotropic",				&adopt_sampler::_f_anisotropic	,return_reference_to(_1))

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -397,7 +397,7 @@ void CRender::create()
 
 	//	MSAA option dependencies
 
-	o.dx10_msaa = !!ps_r3_msaa;
+	o.dx10_msaa = ps_r3_msaa && !ps_r4_hdr_on;
 	o.dx10_msaa_samples = (1 << ps_r3_msaa);
 
 	o.dx10_msaa_opt = ps_r2_ls_flags.test(R3FLAG_MSAA_OPT);


### PR DESCRIPTION
- Fixed the HUD samplers for `hud_default.s` and `hud_cursor.s`, they were using WRAP'd sampling instead of CLAMP'd so would break with certain texture configurations expecting CLAMP'd sampling
- Added `clamp()` method support to Lua shader configuration files to support this, there are others that might be useful which are commented out, but I'm hesitant to just implement them without anything using them since some of them may not work correctly, they must have been commented out for a reason, but at least the `clamp` option seems to work correctly
- Force disable MSAA in DX11 if HDR is enabled since it would break the renderer if both were enabled simultaneously, this may be confusing for users without any text in the HDR option saying it's incompatible with MSAA, is there a way to provide a tooltip or something to the Modded Exe's menu that could describe this?