### PR TITLE
DX11 DWM vsync fix for windowed modes + fix for broken blur passes + TODO with explanation of issue for MSAA w/ volumetrics error

### DIFF
--- a/src/Layers/xrRender/HW.h
+++ b/src/Layers/xrRender/HW.h
@@ -21,7 +21,7 @@
 
 class CHW
 #if defined(USE_DX10) || defined(USE_DX11)
-	:	public pureAppActivate, 
+	:	public pureAppActivate,
 		public pureAppDeactivate
 #endif	//	USE_DX10
 {
@@ -78,6 +78,7 @@ public:
     HWND                            m_hWnd;
 	bool							m_bUsePerfhud;
 	D3D_FEATURE_LEVEL				FeatureLevel;
+	bool 							m_SupportsVRR; // whether we can use DXGI_PRESENT_ALLOW_TEARING etc.
 #elif defined(USE_DX10)
 public:
 	IDXGIAdapter*			m_pAdapter;	//	pD3D equivalent

--- a/src/Layers/xrRender/dxRenderDeviceRender.cpp
+++ b/src/Layers/xrRender/dxRenderDeviceRender.cpp
@@ -58,7 +58,7 @@ void dxRenderDeviceRender::Reset(HWND hWnd, u32& dwWidth, u32& dwHeight, float& 
 {
 #ifdef DEBUG
     _SHOW_REF("*ref -CRenderDevice::ResetTotal: DeviceREF:",HW.pDevice);
-#endif // DEBUG	
+#endif // DEBUG
 
 	Resources->reset_begin();
 	Memory.mem_compact();
@@ -303,7 +303,7 @@ dxRenderDeviceRender::DeviceState dxRenderDeviceRender::GetDeviceState()
 	HW.Validate();
 #if defined(USE_DX10) || defined(USE_DX11)
     HRESULT _hr = HW.m_pSwapChain->Present(0, DXGI_PRESENT_TEST);
-	
+
 	if (FAILED(_hr))
 	{
 		//LV: Check if it's correct. If so - that should be fix for AMD issues. Thank me later. Yo
@@ -317,7 +317,7 @@ dxRenderDeviceRender::DeviceState dxRenderDeviceRender::GetDeviceState()
 	}
 #else	//	USE_DX10
 	HRESULT _hr = HW.pDevice->TestCooperativeLevel();
-	
+
 	if (FAILED(_hr))
 	{
 		// If the device was lost, do not render until we get it back
@@ -389,19 +389,20 @@ void dxRenderDeviceRender::End()
 	DoAsyncScreenshot();
 
 #if defined(USE_DX10) || defined(USE_DX11)
-    UINT flags = 0;
+    UINT present_flags = 0;
+	bool use_vsync = !!psDeviceFlags.test(rsVSync);
+	UINT present_interval = (use_vsync) ? 1 : 0;
 
-	UINT use_vsync = !!psDeviceFlags.test(rsVSync);
 # if defined(USE_DX11)
+	// NOTE: https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays
     BOOL is_windowed = HW.m_ChainDescFullscreen.Windowed;
-
-	if (is_windowed && !use_vsync) {
-        flags |= DXGI_PRESENT_ALLOW_TEARING;
+	if (is_windowed && !use_vsync && HW.m_SupportsVRR) {
+        present_flags |= DXGI_PRESENT_ALLOW_TEARING;
 	}
 # endif
 
 	if (!Device.m_SecondViewport.IsSVPFrame() && !Device.m_SecondViewport.isCamReady) {
-		HW.m_pSwapChain->Present(use_vsync, flags);
+		HW.m_pSwapChain->Present(present_interval, present_flags);
 	}
 #else //!USE_DX10 || USE_DX11
 	CHK_DX(HW.pDevice->EndScene());

--- a/src/Layers/xrRender/dxRenderDeviceRender.cpp
+++ b/src/Layers/xrRender/dxRenderDeviceRender.cpp
@@ -389,8 +389,20 @@ void dxRenderDeviceRender::End()
 	DoAsyncScreenshot();
 
 #if defined(USE_DX10) || defined(USE_DX11)
-	if (!Device.m_SecondViewport.IsSVPFrame() && !Device.m_SecondViewport.isCamReady)
-		HW.m_pSwapChain->Present(!!psDeviceFlags.test(rsVSync), 0);
+    UINT flags = 0;
+
+	UINT use_vsync = !!psDeviceFlags.test(rsVSync);
+# if defined(USE_DX11)
+    BOOL is_windowed = HW.m_ChainDescFullscreen.Windowed;
+
+	if (is_windowed && !use_vsync) {
+        flags |= DXGI_PRESENT_ALLOW_TEARING;
+	}
+# endif
+
+	if (!Device.m_SecondViewport.IsSVPFrame() && !Device.m_SecondViewport.isCamReady) {
+		HW.m_pSwapChain->Present(use_vsync, flags);
+	}
 #else //!USE_DX10 || USE_DX11
 	CHK_DX(HW.pDevice->EndScene());
 

--- a/src/Layers/xrRender/rendertarget_phase_blur.cpp
+++ b/src/Layers/xrRender/rendertarget_phase_blur.cpp
@@ -15,7 +15,7 @@ void CRenderTarget::phase_blur()
 	float h = float(Device.dwHeight);
 
 	Fvector2 p0, p1;
-#if defined(USE_DX10) || defined(USE_DX11)	
+#if defined(USE_DX10) || defined(USE_DX11)
 	p0.set(0.0f, 0.0f);
 	p1.set(1.0f, 1.0f);
 #else
@@ -29,7 +29,11 @@ void CRenderTarget::phase_blur()
 	w = float(Device.dwWidth) * 0.5f;
 	h = float(Device.dwHeight) * 0.5f;
 
-	u_setrt(rt_blur_h_2, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_h_2, 0, 0, rt_blur_2_zb->pZRT);
+#else
+	u_setrt(rt_blur_h_2, 0, 0, rt_blur_2_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 
@@ -49,7 +53,11 @@ void CRenderTarget::phase_blur()
 	///////////////////////////////////////////////////////////////////////////////////
 	////Final blur
 	///////////////////////////////////////////////////////////////////////////////////
-	u_setrt(rt_blur_2, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_2, 0, 0, rt_blur_2_zb->pZRT);
+#else
+	u_setrt(rt_blur_2, 0, 0, rt_blur_2_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 
@@ -72,7 +80,11 @@ void CRenderTarget::phase_blur()
 	w = float(Device.dwWidth) * 0.25f;
 	h = float(Device.dwHeight) * 0.25f;
 
-	u_setrt(rt_blur_h_4, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_h_4, 0, 0, rt_blur_4_zb->pZRT);
+#else
+	u_setrt(rt_blur_h_4, 0, 0, rt_blur_4_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 
@@ -92,7 +104,11 @@ void CRenderTarget::phase_blur()
 	///////////////////////////////////////////////////////////////////////////////////
 	////Final blur
 	///////////////////////////////////////////////////////////////////////////////////
-	u_setrt(rt_blur_4, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_4, 0, 0, rt_blur_4_zb->pZRT);
+#else
+	u_setrt(rt_blur_4, 0, 0, rt_blur_4_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 
@@ -115,7 +131,11 @@ void CRenderTarget::phase_blur()
 	w = float(Device.dwWidth) * 0.125f;
 	h = float(Device.dwHeight) * 0.125f;
 
-	u_setrt(rt_blur_h_8, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_h_8, 0, 0, rt_blur_8_zb->pZRT);
+#else
+	u_setrt(rt_blur_h_8, 0, 0, rt_blur_8_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 
@@ -135,7 +155,11 @@ void CRenderTarget::phase_blur()
 	///////////////////////////////////////////////////////////////////////////////////
 	////Final blur
 	///////////////////////////////////////////////////////////////////////////////////
-	u_setrt(rt_blur_8, 0, 0, HW.pBaseZB);
+#if defined(USE_DX10) || defined(USE_DX11)
+	u_setrt(rt_blur_8, 0, 0, rt_blur_8_zb->pZRT);
+#else
+	u_setrt(rt_blur_8, 0, 0, rt_blur_8_zb);
+#endif
 	RCache.set_CullMode(CULL_NONE);
 	RCache.set_Stencil(FALSE);
 

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -383,6 +383,7 @@ void CHW::CreateDevice(HWND hwnd, bool move_window)
 
     //	Additional set up
     sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    sd.Flags       = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 
     UINT createDeviceFlags = 0;
 #ifdef DEBUG
@@ -661,7 +662,7 @@ void CHW::Reset(HWND hwnd)
         cd.Width,
         cd.Height,
         cd.Format,
-        DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH));
+        DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING));
 #elif defined(USE_DX10)
 	CHK_DX(m_pSwapChain->ResizeBuffers(
 		cd.BufferCount,
@@ -898,7 +899,7 @@ void CHW::OnAppActivate()
             cd.Width,
             cd.Height,
             cd.Format,
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH);
+            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
 
         UpdateViews();
 #endif
@@ -930,7 +931,7 @@ void CHW::OnAppDeactivate()
             cd.Width,
             cd.Height,
             cd.Format,
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH);
+            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
 
         UpdateViews();
 #endif

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -8,7 +8,7 @@
 #include <d3dx9.h>
 #ifdef USE_DX11
 # include <d3d11_4.h>
-# include <dxgi1_4.h>
+# include <dxgi1_5.h>
 #endif
 #pragma warning(default:4995)
 #include "../xrRender/HW.h"
@@ -129,6 +129,38 @@ void CHW::CreateD3D()
 #endif
     }
 
+#if defined(USE_DX11)
+    // when using FLIP_* present modes, to disable DWM vsync we have to use DXGI_PRESENT_ALLOW_TEARING with ->Present()
+    // when vsync is off (PresentInterval = 0) and only when in window mode
+    // store whether we can use the flag for later use (swapchain creation, buffer resize, present call)
+
+    // TODO: On some PC configurations (versions of Windows, graphics drivers, currently unknown what exactly) this isn't
+    // sufficient to disable the DWM vsync when the game is launched in a windowed mode, however if the user switches from
+    // borderless/windowed -> exclusive fullscreen -> borderless/windowed then it seems to work correctly.
+    // Worth investigating why this is occurring
+    //
+    // Configuration where this occurs:
+    // - Windows 10 Enterprise LTSC, 21H2, 19044.4894
+    // - NVIDIA driver version 560.94
+    {
+        HRESULT hr;
+
+        IDXGIFactory5* factory5 = nullptr;
+        hr = m_pFactory->QueryInterface(&factory5);
+
+        if (SUCCEEDED(hr) && factory5) {
+            BOOL supports_vrr = FALSE;
+            hr = factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &supports_vrr, sizeof(supports_vrr));
+
+            m_SupportsVRR = (SUCCEEDED(hr) && supports_vrr);
+
+            factory5->Release();
+        } else {
+            m_SupportsVRR = false;
+        }
+    }
+#endif
+
 #ifdef USE_DX10
     pFactory->Release();
 #endif
@@ -148,6 +180,11 @@ void CHW::DestroyD3D()
 
     _SHOW_REF("refCount:m_pAdapter", m_pAdapter);
     _RELEASE(m_pAdapter);
+
+#if defined(USE_DX11)
+    _SHOW_REF("refCount:m_pFactory", m_pFactory);
+    _RELEASE(m_pFactory);
+#endif
 
     //	FreeLibrary(hD3D);
 }
@@ -383,7 +420,13 @@ void CHW::CreateDevice(HWND hwnd, bool move_window)
 
     //	Additional set up
     sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    sd.Flags       = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+    sd.Flags       = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+
+#if defined(USE_DX11)
+    if (m_SupportsVRR) {
+        sd.Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+    }
+#endif
 
     UINT createDeviceFlags = 0;
 #ifdef DEBUG
@@ -401,6 +444,13 @@ void CHW::CreateDevice(HWND hwnd, bool move_window)
         // D3D_FEATURE_LEVEL_10_0,
     };
 
+    UINT create_device_flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    if (strstr(Core.Params, "--dxgi-dbg")) {
+        // enables d3d11 debug layer validation and output
+        // viewable in VS debugger `Output > Debug` view or using a tool like Sysinternals DebugView
+        create_device_flags |= D3D11_CREATE_DEVICE_DEBUG;
+    }
+
     // create device
     ID3D11Device* device;
     ID3D11DeviceContext* context;
@@ -408,7 +458,7 @@ void CHW::CreateDevice(HWND hwnd, bool move_window)
         nullptr,
         D3D_DRIVER_TYPE_HARDWARE,
         nullptr,
-        D3D11_CREATE_DEVICE_BGRA_SUPPORT, // D3D11_CREATE_DEVICE_DEBUG is useful for debugging
+        create_device_flags,
         pFeatureLevels,
         1,
         D3D11_SDK_VERSION,
@@ -657,12 +707,17 @@ void CHW::Reset(HWND hwnd)
     _RELEASE(pBaseRT);
 
 #if defined(USE_DX11)
+    UINT flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+    if (m_SupportsVRR) {
+        flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+    }
+
     CHK_DX(m_pSwapChain->ResizeBuffers(
         cd.BufferCount,
         cd.Width,
         cd.Height,
         cd.Format,
-        DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING));
+        flags));
 #elif defined(USE_DX10)
 	CHK_DX(m_pSwapChain->ResizeBuffers(
 		cd.BufferCount,
@@ -894,12 +949,18 @@ void CHW::OnAppActivate()
         _RELEASE(pBaseRT);
 
         const auto& cd = m_ChainDesc;
+
+        UINT flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        if (m_SupportsVRR) {
+            flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+        }
+
         m_pSwapChain->ResizeBuffers(
             cd.BufferCount,
             cd.Width,
             cd.Height,
             cd.Format,
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+            flags);
 
         UpdateViews();
 #endif
@@ -926,12 +987,18 @@ void CHW::OnAppDeactivate()
         _RELEASE(pBaseRT);
 
         const auto& cd = m_ChainDesc;
+
+        UINT flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        if (m_SupportsVRR) {
+            flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+        }
+
         m_pSwapChain->ResizeBuffers(
             cd.BufferCount,
             cd.Width,
             cd.Height,
             cd.Format,
-            DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+            flags);
 
         UpdateViews();
 #endif

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget.cpp
@@ -241,8 +241,8 @@ CRenderTarget::CRenderTarget()
 	b_combine = xr_new<CBlender_combine>();
 	///////////////////////////////////lvutner
 	b_sunshafts = xr_new<CBlender_sunshafts>();
-	b_blur = xr_new<CBlender_blur>();	
-	b_pp_bloom = xr_new<CBlender_pp_bloom>();		
+	b_blur = xr_new<CBlender_blur>();
+	b_pp_bloom = xr_new<CBlender_pp_bloom>();
 	b_dof = xr_new<CBlender_dof>();
 	b_gasmask_drops = xr_new<CBlender_gasmask_drops>();
 	b_gasmask_dudv = xr_new<CBlender_gasmask_dudv>();
@@ -291,26 +291,28 @@ CRenderTarget::CRenderTarget()
 		rt_ui_pda.create(r2_RT_ui, w, h, D3DFMT_A8R8G8B8);
 
 		rt_fakescope.create(r2_RT_scopert, w, h, D3DFMT_A8R8G8B8, 1); //crookr fakescope
-		
+
 		//--DSR-- HeatVision_start
 		rt_Heat.create(r2_RT_heat, w, h, D3DFMT_A8R8G8B8, 1);
 		//--DSR-- HeatVision_end
 
 		// RT Blur
 		rt_blur_h_2.create(r2_RT_blur_h_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
-		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);		
+		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
+		R_CHK(HW.pDevice->CreateDepthStencilSurface(u32(w/2), u32(h/2), D3DFMT_D24S8, D3DMULTISAMPLE_NONE, 0, TRUE, &rt_blur_2_zb, NULL));
 
 		rt_blur_h_4.create(r2_RT_blur_h_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
-		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);		
-		
+		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
+		R_CHK(HW.pDevice->CreateDepthStencilSurface(u32(w/4), u32(h/4), D3DFMT_D24S8, D3DMULTISAMPLE_NONE, 0, TRUE, &rt_blur_4_zb, NULL));
+
 		rt_blur_h_8.create(r2_RT_blur_h_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
-		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);	
-		
+		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
+		R_CHK(HW.pDevice->CreateDepthStencilSurface(u32(w/8), u32(h/8), D3DFMT_D24S8, D3DMULTISAMPLE_NONE, 0, TRUE, &rt_blur_8_zb, NULL));
 
 		rt_dof.create(r2_RT_dof, w, h, D3DFMT_A8R8G8B8);
-		
+
 		rt_pp_bloom.create(r2_RT_pp_bloom, w, h, D3DFMT_A8R8G8B8);
-		
+
 		// RT - KD
 		rt_sunshafts_0.create(r2_RT_sunshafts0, w, h, D3DFMT_A8R8G8B8);
 		rt_sunshafts_1.create(r2_RT_sunshafts1, w, h, D3DFMT_A8R8G8B8);
@@ -328,13 +330,13 @@ CRenderTarget::CRenderTarget()
 
 	s_blur.create(b_blur, "r2\\blur");
 	s_dof.create(b_dof, "r2\\dof");
-	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");	
+	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");
 	s_gasmask_drops.create(b_gasmask_drops, "r2\\gasmask_drops");
 	s_gasmask_dudv.create(b_gasmask_dudv, "r2\\gasmask_dudv");
 	s_nightvision.create(b_nightvision, "r2\\nightvision");
 	s_fakescope.create(b_fakescope, "r2\\fakescope"); //crookr
 	s_heatvision.create(b_heatvision, "r2\\heatvision"); //--DSR-- HeatVision
-	s_lut.create(b_lut, "r2\\lut");	
+	s_lut.create(b_lut, "r2\\lut");
 	// OCCLUSION
 	s_occq.create(b_occq, "r2\\occq");
 
@@ -427,10 +429,10 @@ CRenderTarget::CRenderTarget()
 	{
 		u32 w = Device.dwWidth;
 		u32 h = Device.dwHeight;
-	
+
 		rt_smaa_edgetex.create(r2_RT_smaa_edgetex, w, h, D3DFMT_A8R8G8B8);
 		rt_smaa_blendtex.create(r2_RT_smaa_blendtex, w, h, D3DFMT_A8R8G8B8);
-		
+
 		s_smaa.create(b_smaa, "r3\\smaa");
 	}
 
@@ -695,7 +697,7 @@ CRenderTarget::CRenderTarget()
 	HW.pBaseRT->GetDesc(&desc);
 	HW.pDevice->CreateOffscreenPlainSurface(Device.dwWidth, Device.dwHeight, desc.Format, D3DPOOL_SYSTEMMEM, &pFB,NULL);
 
-	// 
+	//
 	dwWidth = Device.dwWidth;
 	dwHeight = Device.dwHeight;
 }
@@ -735,6 +737,10 @@ CRenderTarget::~CRenderTarget()
 
 	_RELEASE(rt_smap_ZB);
 
+	_RELEASE(rt_blur_2_zb);
+	_RELEASE(rt_blur_4_zb);
+	_RELEASE(rt_blur_8_zb);
+
 	// Jitter
 	for (int it = 0; it < TEX_jitter_count; it++)
 	{
@@ -745,7 +751,7 @@ CRenderTarget::~CRenderTarget()
 		_RELEASE(t_noise_surf[it]);
 	}
 
-	// 
+	//
 	accum_spot_geom_destroy();
 	accum_omnip_geom_destroy();
 	accum_point_geom_destroy();
@@ -763,15 +769,15 @@ CRenderTarget::~CRenderTarget()
 	xr_delete(b_accum_direct_cascade);
 
 	////////////lvutner
-	xr_delete(b_blur);		
+	xr_delete(b_blur);
 	xr_delete(b_dof);
-	xr_delete(b_pp_bloom);		
+	xr_delete(b_pp_bloom);
 	xr_delete(b_gasmask_drops);
 	xr_delete(b_gasmask_dudv);
 	xr_delete(b_nightvision);
 	xr_delete(b_fakescope); //crookr
 	xr_delete(b_heatvision); //--DSR-- HeatVision
-	xr_delete(b_lut);	
+	xr_delete(b_lut);
 	xr_delete(b_smaa);
 
 	xr_delete(b_accum_mask);

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget.h
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget.h
@@ -19,7 +19,7 @@ private:
 	u32 dwAccumulatorClearMark;
 public:
 	u32 dwLightMarkerID;
-	// 
+	//
 	IBlender* b_occq;
 	IBlender* b_accum_mask;
 	IBlender* b_accum_direct;
@@ -35,15 +35,15 @@ public:
 
 	IBlender* b_blur;
 	IBlender* b_dof;
-	IBlender* b_pp_bloom;	
+	IBlender* b_pp_bloom;
 	IBlender* b_gasmask_drops;
 	IBlender* b_gasmask_dudv;
 	IBlender* b_nightvision;
 	IBlender* b_fakescope; //crookr
 	IBlender* b_heatvision; //--DSR-- HeatVision
 	IBlender* b_lut;
-	
-	IBlender* b_smaa;	
+
+	IBlender* b_smaa;
 #ifdef DEBUG
 	struct		dbg_line_t		{
 		Fvector	P0,P1;
@@ -60,7 +60,7 @@ public:
 	ref_rt rt_Normal; // 64bit,	fat	(x,y,z,hemi)			(eye-space)
 	ref_rt rt_Color; // 64/32bit,fat	(r,g,b,specular-gloss)	(or decompressed MET-8-8-8-8)
 
-	// 
+	//
 	ref_rt rt_Accumulator; // 64bit		(r,g,b,specular)
 	ref_rt rt_Accumulator_temp; // only for HW which doesn't feature fp16 blend
 	ref_rt rt_sunshafts_0; // ss0
@@ -75,21 +75,24 @@ public:
 
 	ref_rt rt_dof;
 	ref_rt rt_Heat; //--DSR-- HeatVision
-	
+
 	ref_rt rt_blur_h_2;
 	ref_rt rt_blur_2;
+	IDirect3DSurface9* rt_blur_2_zb;
 
 	ref_rt rt_blur_h_4;
 	ref_rt rt_blur_4;
-	
+	IDirect3DSurface9* rt_blur_4_zb;
+
 	ref_rt rt_blur_h_8;
 	ref_rt rt_blur_8;
+	IDirect3DSurface9* rt_blur_8_zb;
 
 	ref_rt rt_pp_bloom;
 
 	ref_rt rt_smaa_edgetex;
 	ref_rt rt_smaa_blendtex;
-	
+
 	//	Igor: for volumetric lights
 	ref_rt rt_Generic_2; // 32bit		(r,g,b,a)				// post-process, intermidiate results, etc.
 	ref_rt rt_Bloom_1; // 32bit, dim/4	(r,g,b,?)
@@ -110,7 +113,7 @@ public:
 
 	// smap
 	ref_rt rt_smap_surf; // 32bit,		color
-	ref_rt rt_smap_depth; // 24(32) bit,	depth 
+	ref_rt rt_smap_depth; // 24(32) bit,	depth
 	IDirect3DSurface9* rt_smap_ZB; //
 
 	// Textures
@@ -131,14 +134,14 @@ private:
 	ref_shader s_fakescope; //crookr
 	ref_shader s_heatvision; //--DSR-- HeatVision
 
-	ref_shader s_blur;	
+	ref_shader s_blur;
 	ref_shader s_dof;
 	ref_shader s_pp_bloom;
 
 	ref_shader s_lut;
-	
+
     ref_shader s_smaa;
-    	
+
 	// Accum
 	ref_shader s_accum_mask;
 	ref_shader s_accum_direct;
@@ -262,17 +265,17 @@ public:
 	void phase_occq();
 
 	//////lvutner
-	void phase_blur();	
+	void phase_blur();
 	void phase_dof();
-	void phase_pp_bloom();		
+	void phase_pp_bloom();
 	void phase_gasmask_drops();
 	void phase_gasmask_dudv();
 	void phase_nightvision();
 	void phase_fakescope(); //crookr
 	void phase_heatvision(); //--DSR-- HeatVision
-	void phase_lut();	
+	void phase_lut();
 	void phase_smaa();
-		
+
 	void phase_wallmarks();
 	void phase_smap_direct(light* L, u32 sub_phase);
 	void phase_smap_direct_tsh(light* L, u32 sub_phase);
@@ -354,12 +357,12 @@ public:
 	IC void						dbg_addbox(const Fvector &c, float rx, float ry, float rz, u32 color)
 	{
 		Fvector p1, p2, p3, p4, p5, p6, p7, p8;
-		
+
 		p1.set(c.x+rx, c.y+ry, c.z+rz);
 		p2.set(c.x+rx, c.y-ry, c.z+rz);
 		p3.set(c.x-rx, c.y-ry, c.z+rz);
 		p4.set(c.x-rx, c.y+ry, c.z+rz);
-		
+
 		p5.set(c.x+rx, c.y+ry, c.z-rz);
 		p6.set(c.x+rx, c.y-ry, c.z-rz);
 		p7.set(c.x-rx, c.y-ry, c.z-rz);

--- a/src/Layers/xrRenderPC_R2/r2_types.h
+++ b/src/Layers/xrRenderPC_R2/r2_types.h
@@ -49,7 +49,7 @@
 #define		r2_RT_secondVP		"$user$viewport2"		// --#SM+#-- +SecondVP+ O?aíeo ea?oeíeó nî âoî?îaî âü?iî?oa
 
 #define		r2_RT_blur_h_2	"$user$blur_h_2"
-#define		r2_RT_blur_2		"$user$blur_2"
+#define		r2_RT_blur_2	"$user$blur_2"
 
 #define		r2_RT_blur_h_4	"$user$blur_h_4"
 #define		r2_RT_blur_4	"$user$blur_4"

--- a/src/Layers/xrRenderPC_R3/r2_types.h
+++ b/src/Layers/xrRenderPC_R3/r2_types.h
@@ -57,13 +57,16 @@
 
 
 #define		r2_RT_blur_h_2	"$user$blur_h_2"
-#define		r2_RT_blur_2		"$user$blur_2"
+#define		r2_RT_blur_2	"$user$blur_2"
+#define 	r2_RT_blur_2_zb "$user$blur_2_zb"
 
 #define		r2_RT_blur_h_4	"$user$blur_h_4"
 #define		r2_RT_blur_4	"$user$blur_4"
+#define 	r2_RT_blur_4_zb "$user$blur_4_zb"
 
 #define		r2_RT_blur_h_8	"$user$blur_h_8"
 #define		r2_RT_blur_8	"$user$blur_8"
+#define 	r2_RT_blur_8_zb "$user$blur_8_zb"
 
 #define		r2_RT_pp_bloom	"$user$pp_bloom"
 

--- a/src/Layers/xrRenderPC_R3/r3_rendertarget.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_rendertarget.cpp
@@ -345,8 +345,8 @@ CRenderTarget::CRenderTarget()
 
 	///////////////////////////////////lvutner
 	b_sunshafts = xr_new<CBlender_sunshafts>();
-	b_blur = xr_new<CBlender_blur>();	
-	b_pp_bloom = xr_new<CBlender_pp_bloom>();	
+	b_blur = xr_new<CBlender_blur>();
+	b_pp_bloom = xr_new<CBlender_pp_bloom>();
 	b_dof = xr_new<CBlender_dof>();
 	b_gasmask_drops = xr_new<CBlender_gasmask_drops>();
 	b_gasmask_dudv = xr_new<CBlender_gasmask_dudv>();
@@ -445,26 +445,29 @@ CRenderTarget::CRenderTarget()
 
 		rt_secondVP.create(r2_RT_secondVP, w, h, D3DFMT_A8R8G8B8, 1); //--#SM+#-- +SecondVP+
 		rt_ui_pda.create(r2_RT_ui, w, h, D3DFMT_A8R8G8B8, 1);
-		
+
 		rt_dof.create(r2_RT_dof, w, h, D3DFMT_A8R8G8B8);
-		
+
 		// RT - KD
 		rt_sunshafts_0.create(r2_RT_sunshafts0, w, h, D3DFMT_A8R8G8B8);
 		rt_sunshafts_1.create(r2_RT_sunshafts1, w, h, D3DFMT_A8R8G8B8);
 
 		// RT Blur
 		rt_blur_h_2.create(r2_RT_blur_h_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
-		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);		
+		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
+		rt_blur_2_zb.create(r2_RT_blur_2_zb, u32(w/2), u32(h/2), D3DFMT_D24S8);
 
 		rt_blur_h_4.create(r2_RT_blur_h_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
-		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);		
-		
+		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
+		rt_blur_4_zb.create(r2_RT_blur_4_zb, u32(w/4), u32(h/4), D3DFMT_D24S8);
+
 		rt_blur_h_8.create(r2_RT_blur_h_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
-		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);		
-		
+		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
+		rt_blur_8_zb.create(r2_RT_blur_8_zb, u32(w/8), u32(h/8), D3DFMT_D24S8);
+
 		rt_pp_bloom.create(r2_RT_pp_bloom, w, h, D3DFMT_A8R8G8B8);
-			
-		
+
+
 		if (RImplementation.o.dx10_msaa)
 		{
 			rt_Generic_0_r.create(r2_RT_generic0_r, w, h, D3DFMT_A8R8G8B8, SampleCount);
@@ -480,14 +483,14 @@ CRenderTarget::CRenderTarget()
 
 	s_sunshafts.create(b_sunshafts, "r2\\sunshafts");
 	s_blur.create(b_blur, "r2\\blur");
-	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");		
+	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");
 	s_dof.create(b_dof, "r2\\dof");
 	s_gasmask_drops.create(b_gasmask_drops, "r2\\gasmask_drops");
 	s_gasmask_dudv.create(b_gasmask_dudv, "r2\\gasmask_dudv");
 	s_nightvision.create(b_nightvision, "r2\\nightvision");
 	s_fakescope.create(b_fakescope, "r2\\fakescope"); //crookr
 	s_heatvision.create(b_heatvision, "r2\\heatvision"); //--DSR-- HeatVision
-	s_lut.create(b_lut, "r2\\lut");	
+	s_lut.create(b_lut, "r2\\lut");
 	// OCCLUSION
 	s_occq.create(b_occq, "r2\\occq");
 
@@ -680,10 +683,10 @@ CRenderTarget::CRenderTarget()
 	{
 		u32 w = Device.dwWidth;
 		u32 h = Device.dwHeight;
-	
+
 		rt_smaa_edgetex.create(r2_RT_smaa_edgetex, w, h, D3DFMT_A8R8G8B8);
 		rt_smaa_blendtex.create(r2_RT_smaa_blendtex, w, h, D3DFMT_A8R8G8B8);
-		
+
 		s_smaa.create(b_smaa, "r3\\smaa");
 	}
 
@@ -804,7 +807,7 @@ CRenderTarget::CRenderTarget()
 		}
 		// Build material(s)
 		{
-			//	Create immutable texture. 
+			//	Create immutable texture.
 			//	So we need to init data _before_ the creation.
 			// Surface
 			//R_CHK						(D3DXCreateVolumeTexture(HW.pDevice,TEX_material_LdotN,TEX_material_LdotH,4,1,0,D3DFMT_A8L8,D3DPOOL_MANAGED,&t_material_surf));
@@ -1074,7 +1077,7 @@ CRenderTarget::CRenderTarget()
 	s_menu.create("distort");
 	g_menu.create(FVF::F_TL, RCache.Vertex.Buffer(), RCache.QuadIB);
 
-	// 
+	//
 	dwWidth = Device.dwWidth;
 	dwHeight = Device.dwHeight;
 }
@@ -1131,7 +1134,7 @@ CRenderTarget::~CRenderTarget()
 #endif // DEBUG
 	_RELEASE(t_noise_surf_mipped);
 
-	// 
+	//
 	accum_spot_geom_destroy();
 	accum_omnip_geom_destroy();
 	accum_point_geom_destroy();
@@ -1148,15 +1151,15 @@ CRenderTarget::~CRenderTarget()
 	xr_delete(b_ssao);
 
 	////////////lvutner
-	xr_delete(b_blur);	
+	xr_delete(b_blur);
 	xr_delete(b_dof);
-	xr_delete(b_pp_bloom);	
+	xr_delete(b_pp_bloom);
 	xr_delete(b_gasmask_drops);
 	xr_delete(b_gasmask_dudv);
 	xr_delete(b_nightvision);
 	xr_delete(b_fakescope); //crookr
 	xr_delete(b_heatvision); //--DSR-- HeatVision
-	xr_delete(b_lut);	
+	xr_delete(b_lut);
 	xr_delete(b_smaa);
 
 

--- a/src/Layers/xrRenderPC_R3/r3_rendertarget.h
+++ b/src/Layers/xrRenderPC_R3/r3_rendertarget.h
@@ -27,7 +27,7 @@ public:
 	};
 
 	u32 dwLightMarkerID;
-	// 
+	//
 	IBlender* b_occq;
 	IBlender* b_accum_mask;
 	IBlender* b_accum_direct;
@@ -54,15 +54,15 @@ public:
 
 	IBlender* b_blur;
 	IBlender* b_dof;
-	IBlender* b_pp_bloom;	
+	IBlender* b_pp_bloom;
 	IBlender* b_gasmask_drops;
 	IBlender* b_gasmask_dudv;
 	IBlender* b_nightvision;
 	IBlender* b_fakescope; //crookr
 	IBlender* b_heatvision; //--DSR-- HeatVision
 	IBlender* b_lut;
-	
-	IBlender* b_smaa;	
+
+	IBlender* b_smaa;
 #ifdef DEBUG
 	struct		dbg_line_t		{
 		Fvector	P0,P1;
@@ -82,7 +82,7 @@ public:
 	ref_rt rt_Position; // 64bit,	fat	(x,y,z,?)				(eye-space)
 	ref_rt rt_Color; // 64/32bit,fat	(r,g,b,specular-gloss)	(or decompressed MET-8-8-8-8)
 
-	// 
+	//
 	ref_rt rt_Accumulator; // 64bit		(r,g,b,specular)
 	ref_rt rt_Accumulator_temp; // only for HW which doesn't feature fp16 blend
 	ref_rt rt_sunshafts_0; // ss0
@@ -97,25 +97,28 @@ public:
 
 
 	ref_rt rt_fakescope; //crookr
-	
+
 	ref_rt rt_Heat; //--DSR-- HeatVision
 
 	ref_rt rt_dof;
 
 	ref_rt rt_blur_h_2;
 	ref_rt rt_blur_2;
+	ref_rt rt_blur_2_zb;
 
 	ref_rt rt_blur_h_4;
 	ref_rt rt_blur_4;
-	
+	ref_rt rt_blur_4_zb;
+
 	ref_rt rt_blur_h_8;
 	ref_rt rt_blur_8;
+	ref_rt rt_blur_8_zb;
 
 	ref_rt rt_pp_bloom;
 
 	ref_rt rt_smaa_edgetex;
 	ref_rt rt_smaa_blendtex;
-	
+
 	//	Igor: for volumetric lights
 	ref_rt rt_Generic_2; // 32bit		(r,g,b,a)				// post-process, intermidiate results, etc.
 	ref_rt rt_Bloom_1; // 32bit, dim/4	(r,g,b,?)
@@ -133,7 +136,7 @@ public:
 
 	// smap
 	ref_rt rt_smap_surf; // 32bit,		color
-	ref_rt rt_smap_depth; // 24(32) bit,	depth 
+	ref_rt rt_smap_depth; // 24(32) bit,	depth
 	ref_rt rt_smap_depth_minmax; //	is used for min/max sm
 	//	TODO: DX10: CHeck if we need old-style SMAP
 	//	IDirect3DSurface9*			rt_smap_ZB;		//
@@ -161,7 +164,7 @@ private:
 	ref_shader s_ssao_msaa[8];
 
 
-	
+
 	// Accum
 	ref_shader s_accum_mask;
 	ref_shader s_accum_direct;
@@ -172,18 +175,18 @@ private:
 	ref_shader s_accum_reflected;
 	ref_shader s_accum_volume;
 
-	ref_shader s_blur;	
+	ref_shader s_blur;
 	ref_shader s_dof;
-	ref_shader s_pp_bloom;	
+	ref_shader s_pp_bloom;
 	ref_shader s_gasmask_drops;
 	ref_shader s_gasmask_dudv;
 	ref_shader s_nightvision;
 	ref_shader s_fakescope; //crookr
 	ref_shader s_heatvision; //--DSR-- HeatVision
-	ref_shader s_lut;	
+	ref_shader s_lut;
 
     ref_shader s_smaa;
-	
+
 	//	generate min/max
 	ref_shader s_create_minmax_sm;
 
@@ -302,15 +305,15 @@ public:
 	void phase_sunshafts();
 
 	void phase_blur();
-	void phase_pp_bloom();	
+	void phase_pp_bloom();
 	void phase_dof();
 	void phase_gasmask_drops();
 	void phase_gasmask_dudv();
 	void phase_nightvision();
 	void phase_fakescope(); //crookr
 	void phase_heatvision(); //--DSR-- HeatVision
-	void phase_lut();	
-	void phase_smaa();	
+	void phase_lut();
+	void phase_smaa();
 
 	void phase_scene_prepare();
 	void phase_scene_begin();

--- a/src/Layers/xrRenderPC_R4/r2_types.h
+++ b/src/Layers/xrRenderPC_R4/r2_types.h
@@ -56,13 +56,16 @@
 #define		r2_RT_secondVP		"$user$viewport2"		// --#SM+#-- +SecondVP+ O?aíeo ea?oeíeó nî âoî?îaî âü?iî?oa
 
 #define		r2_RT_blur_h_2	"$user$blur_h_2"
-#define		r2_RT_blur_2		"$user$blur_2"
+#define		r2_RT_blur_2	"$user$blur_2"
+#define 	r2_RT_blur_2_zb "$user$blur_2_zb"
 
 #define		r2_RT_blur_h_4	"$user$blur_h_4"
 #define		r2_RT_blur_4	"$user$blur_4"
+#define 	r2_RT_blur_4_zb "$user$blur_4_zb"
 
 #define		r2_RT_blur_h_8	"$user$blur_h_8"
 #define		r2_RT_blur_8	"$user$blur_8"
+#define     r2_RT_blur_8_zb "$user$blur_8_zb"
 
 #define		r2_RT_pp_bloom	"$user$pp_bloom"
 

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget.cpp
@@ -359,8 +359,8 @@ CRenderTarget::CRenderTarget()
 	b_ssao = xr_new<CBlender_SSAO_noMSAA>();
 	///////////////////////////////////lvutner
 	b_sunshafts = xr_new<CBlender_sunshafts>();
-	b_blur = xr_new<CBlender_blur>();	
-	b_pp_bloom = xr_new<CBlender_pp_bloom>();	
+	b_blur = xr_new<CBlender_blur>();
+	b_pp_bloom = xr_new<CBlender_pp_bloom>();
 	b_dof = xr_new<CBlender_dof>();
 	b_gasmask_drops = xr_new<CBlender_gasmask_drops>();
 	b_gasmask_dudv = xr_new<CBlender_gasmask_dudv>();
@@ -497,16 +497,19 @@ CRenderTarget::CRenderTarget()
 
 		// RT Blur
 		rt_blur_h_2.create(r2_RT_blur_h_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
-		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);		
+		rt_blur_2.create(r2_RT_blur_2, u32(w/2), u32(h/2), D3DFMT_A8R8G8B8);
+		rt_blur_2_zb.create(r2_RT_blur_2_zb, u32(w/2), u32(h/2), D3DFMT_D24S8);
 
 		rt_blur_h_4.create(r2_RT_blur_h_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
-		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);		
-		
+		rt_blur_4.create(r2_RT_blur_4, u32(w/4), u32(h/4), D3DFMT_A8R8G8B8);
+		rt_blur_4_zb.create(r2_RT_blur_4_zb, u32(w/4), u32(h/4), D3DFMT_D24S8);
+
 		rt_blur_h_8.create(r2_RT_blur_h_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
-		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);	
-		
+		rt_blur_8.create(r2_RT_blur_8, u32(w/8), u32(h/8), D3DFMT_A8R8G8B8);
+		rt_blur_8_zb.create(r2_RT_blur_8_zb, u32(w/8), u32(h/8), D3DFMT_D24S8);
+
 		rt_pp_bloom.create(r2_RT_pp_bloom, w, h, D3DFMT_A8R8G8B8);
-		
+
 		// Screen Space Shaders Stuff
 		rt_ssfx.create(r2_RT_ssfx, w, h, D3DFMT_A8R8G8B8); // Temp RT
 		rt_ssfx_temp.create(r2_RT_ssfx_temp, w, h, D3DFMT_A8R8G8B8); // Temp RT
@@ -524,7 +527,7 @@ CRenderTarget::CRenderTarget()
 		rt_ssfx_prevPos.create(r2_RT_ssfx_prevPos, w, h, D3DFMT_A16B16G16R16F, SampleCount);
 
 		rt_ssfx_hud.create(r2_RT_ssfx_hud, w, h, D3DFMT_A16B16G16R16F); // HUD mask & Velocity buffer
-		
+
 		if (RImplementation.o.dx10_msaa)
 		{
             rt_Generic_0_r.create(r2_RT_generic0_r, w, h, ps_r4_hdr_on ? D3DFMT_A16B16G16R16F : D3DFMT_A8R8G8B8, SampleCount);
@@ -540,7 +543,7 @@ CRenderTarget::CRenderTarget()
 
 	s_sunshafts.create(b_sunshafts, "r2\\sunshafts");
 	s_blur.create(b_blur, "r2\\blur");
-	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");		
+	s_pp_bloom.create(b_pp_bloom, "r2\\pp_bloom");
 	s_dof.create(b_dof, "r2\\dof");
 	s_gasmask_drops.create(b_gasmask_drops, "r2\\gasmask_drops");
 	s_gasmask_dudv.create(b_gasmask_dudv, "r2\\gasmask_dudv");
@@ -549,14 +552,14 @@ CRenderTarget::CRenderTarget()
 	s_fakescope.create(b_fakescope, "r2\\fakescope"); //crookr
 
 	s_heatvision.create(b_heatvision, "r2\\heatvision"); //--DSR-- HeatVision
-	s_lut.create(b_lut, "r2\\lut");	
+	s_lut.create(b_lut, "r2\\lut");
 	// OCCLUSION
 	s_occq.create(b_occq, "r2\\occq");
 
 	// Screen Space Shaders Stuff
 	s_ssfx_ssr.create(b_ssfx_ssr, "r2\\ssfx_ssr"); // SSR
 	s_ssfx_volumetric_blur.create(b_ssfx_volumetric_blur, "r2\\ssfx_volumetric_blur"); // Volumetric Blur
-	
+
 	s_ssfx_water_ssr.create("ssfx_water_ssr"); // Water SSR
 	s_ssfx_water.create("ssfx_water"); // Water
 
@@ -757,13 +760,13 @@ CRenderTarget::CRenderTarget()
 	{
 		u32 w = Device.dwWidth;
 		u32 h = Device.dwHeight;
-	
+
 		rt_smaa_edgetex.create(r2_RT_smaa_edgetex, w, h, D3DFMT_A8R8G8B8);
 		rt_smaa_blendtex.create(r2_RT_smaa_blendtex, w, h, D3DFMT_A8R8G8B8);
-		
+
 		s_smaa.create(b_smaa, "r3\\smaa");
 	}
-	
+
 	// TONEMAP
 	{
 		rt_LUM_64.create(r2_RT_luminance_t64, 64, 64, D3DFMT_A16B16G16R16F);
@@ -893,7 +896,7 @@ CRenderTarget::CRenderTarget()
 		}
 		// Build material(s)
 		{
-			//	Create immutable texture. 
+			//	Create immutable texture.
 			//	So we need to init data _before_ the creation.
 			// Surface
 			//R_CHK						(D3DXCreateVolumeTexture(HW.pDevice,TEX_material_LdotN,TEX_material_LdotH,4,1,0,D3DFMT_A8L8,D3DPOOL_MANAGED,&t_material_surf));
@@ -1162,7 +1165,7 @@ CRenderTarget::CRenderTarget()
 	s_menu.create("distort");
 	g_menu.create(FVF::F_TL, RCache.Vertex.Buffer(), RCache.QuadIB);
 
-	// 
+	//
 	dwWidth = Device.dwWidth;
 	dwHeight = Device.dwHeight;
 }
@@ -1219,7 +1222,7 @@ CRenderTarget::~CRenderTarget()
 #endif // DEBUG
 	_RELEASE(t_noise_surf_mipped);
 
-	// 
+	//
 	accum_spot_geom_destroy();
 	accum_omnip_geom_destroy();
 	accum_point_geom_destroy();
@@ -1234,17 +1237,17 @@ CRenderTarget::~CRenderTarget()
 	xr_delete(b_accum_point);
 	xr_delete(b_accum_direct);
 	xr_delete(b_ssao);
-	
+
 	////////////lvutner
-	xr_delete(b_blur);		
+	xr_delete(b_blur);
 	xr_delete(b_dof);
-	xr_delete(b_pp_bloom);	
+	xr_delete(b_pp_bloom);
 	xr_delete(b_gasmask_drops);
 	xr_delete(b_gasmask_dudv);
 	xr_delete(b_nightvision);
 	xr_delete(b_fakescope); //crookr
 	xr_delete(b_heatvision); //--DSR-- HeatVision
-	xr_delete(b_lut);	
+	xr_delete(b_lut);
 	xr_delete(b_smaa);
 
 	// [ SSS Stuff ]
@@ -1273,7 +1276,7 @@ CRenderTarget::~CRenderTarget()
 			xr_delete(b_ssao_msaa[i]);
 		}
 		xr_delete(b_postprocess_msaa);
-		xr_delete(b_bloom_msaa); 
+		xr_delete(b_bloom_msaa);
 	}
 	xr_delete(b_accum_mask);
 	xr_delete(b_occq);

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget.h
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget.h
@@ -27,7 +27,7 @@ public:
 	};
 
 	u32 dwLightMarkerID;
-	// 
+	//
 	IBlender* b_occq;
 	IBlender* b_accum_mask;
 	IBlender* b_accum_direct;
@@ -51,10 +51,10 @@ public:
 	IBlender* b_accum_reflected_msaa[8];
 	IBlender* b_ssao;
 	IBlender* b_ssao_msaa[8];
-	
-	IBlender* b_blur;	
+
+	IBlender* b_blur;
 	IBlender* b_dof;
-	IBlender* b_pp_bloom;	
+	IBlender* b_pp_bloom;
 	IBlender* b_gasmask_drops;
 	IBlender* b_gasmask_dudv;
 	IBlender* b_nightvision;
@@ -94,16 +94,16 @@ public:
 	ref_rt rt_Heat;
 	//--DSR-- HeatVision_end
 
-	// 
+	//
 	ref_rt rt_Accumulator; // 64bit		(r,g,b,specular)
 	ref_rt rt_Accumulator_temp; // only for HW which doesn't feature fp16 blend
 	ref_rt rt_sunshafts_0; // ss0
 	ref_rt rt_sunshafts_1; // ss1
 	ref_rt rt_Generic_0; // 32bit		(r,g,b,a)				// post-process, intermidiate results, etc.
 	ref_rt rt_Generic_1; // 32bit		(r,g,b,a)				// post-process, intermidiate results, etc.
-	
+
 	resptr_core<CRT, resptrcode_crt> rt_Generic_temp;
-	
+
 	ref_rt rt_secondVP;	// 32bit		(r,g,b,a) --//#SM+#-- +SecondVP+
 
 
@@ -111,21 +111,24 @@ public:
 
 	ref_rt rt_dof;
 	ref_rt rt_ui_pda;
-	
+
 	ref_rt rt_blur_h_2;
 	ref_rt rt_blur_2;
+	ref_rt rt_blur_2_zb;
 
 	ref_rt rt_blur_h_4;
 	ref_rt rt_blur_4;
-	
+	ref_rt rt_blur_4_zb;
+
 	ref_rt rt_blur_h_8;
 	ref_rt rt_blur_8;
+	ref_rt rt_blur_8_zb;
 
 	ref_rt rt_pp_bloom;
 
 	ref_rt rt_smaa_edgetex;
 	ref_rt rt_smaa_blendtex;
-	
+
 	//	Igor: for volumetric lights
 	ref_rt rt_Generic_2; // 32bit		(r,g,b,a)				// post-process, intermidiate results, etc.
 	ref_rt rt_Bloom_1; // 32bit, dim/4	(r,g,b,?)
@@ -143,7 +146,7 @@ public:
 
 	// smap
 	ref_rt rt_smap_surf; // 32bit,		color
-	ref_rt rt_smap_depth; // 24(32) bit,	depth 
+	ref_rt rt_smap_depth; // 24(32) bit,	depth
 	ref_rt rt_smap_depth_minmax; //	is used for min/max sm
 	//	TODO: DX10: CHeck if we need old-style SMAP
 	//	IDirect3DSurface9*			rt_smap_ZB;		//
@@ -173,7 +176,7 @@ public:
 	Fmatrix Matrix_HUD_previous, Matrix_HUD_current;
 	Fvector3 Position_previous;
 	bool RVelocity;
-	
+
 	ref_rt rt_tempzb; // Redotix99: for 3D Shader Based Scopes
 
 	ref_shader s_ssfx_dumb;
@@ -202,7 +205,7 @@ private:
 	ref_shader s_hdao_cs;
 	ref_shader s_hdao_cs_msaa;
 
-	
+
 
 	// Accum
 	ref_shader s_accum_mask;
@@ -213,9 +216,9 @@ private:
 	ref_shader s_accum_spot;
 	ref_shader s_accum_reflected;
 	ref_shader s_accum_volume;
-	ref_shader s_blur;	
+	ref_shader s_blur;
 	ref_shader s_dof;
-	ref_shader s_pp_bloom;	
+	ref_shader s_pp_bloom;
 	ref_shader s_gasmask_drops;
 	ref_shader s_gasmask_dudv;
 	ref_shader s_nightvision;
@@ -345,7 +348,7 @@ public:
 	void u_DBT_disable();
 	void phase_sunshafts();
 	void phase_blur();
-	void phase_pp_bloom();	
+	void phase_pp_bloom();
 	void phase_dof();
 	void phase_gasmask_drops();
 	void phase_gasmask_dudv();
@@ -353,7 +356,7 @@ public:
 	void phase_fakescope(); //crookr
 	void phase_heatvision(); //--DSR-- HeatVision
 	void phase_3DSSReticle(); // Redotix99: for 3D Shader Based Scopes
-	void phase_lut();		
+	void phase_lut();
 	void phase_smaa();
 	void phase_scene_prepare();
 	void phase_scene_begin();

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_accumulator.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_accumulator.cpp
@@ -43,9 +43,9 @@ void CRenderTarget::phase_accumulator()
 		//	render this after sun to avoid troubles with sun
 		/*
 		// Render emissive geometry, stencil - write 0x0 at pixel pos
-		RCache.set_xform_project					(Device.mProject); 
+		RCache.set_xform_project					(Device.mProject);
 		RCache.set_xform_view						(Device.mView);
-		// Stencil - write 0x1 at pixel pos - 
+		// Stencil - write 0x1 at pixel pos -
 		RCache.set_Stencil							( TRUE,D3DCMP_ALWAYS,0x01,0xff,0xff,D3DSTENCILOP_KEEP,D3DSTENCILOP_REPLACE,D3DSTENCILOP_KEEP);
 		//RCache.set_Stencil						(TRUE,D3DCMP_ALWAYS,0x00,0xff,0xff,D3DSTENCILOP_KEEP,D3DSTENCILOP_REPLACE,D3DSTENCILOP_KEEP);
 		RCache.set_CullMode							(CULL_CCW);
@@ -64,6 +64,22 @@ void CRenderTarget::phase_accumulator()
 
 void CRenderTarget::phase_vol_accumulator()
 {
+	// TODO: there is a bug in this function when MSAA is enabled, if you run with the D3D debug layer enabled, you'll get this error:
+	// ID3D11DeviceContext::OMSetRenderTargets: The RenderTargetView at slot 0 is not compatible with the DepthStencilView. DepthStencilViews may only be used with RenderTargetViews if the effective dimensions of the Views are equal, as well as the Resource types, multisample count, and multisample quality. The RenderTargetView at slot 0 has (w:2560,h:1440,as:1), while the Resource is a Texture2D with (mc:4,mq:4294967295). The DepthStencilView has (w:2560,h:1440,as:1), while the Resource is a Texture2D with (mc:1,mq:0).
+	// this seems to be because the pBaseZB target is always (SampleCount, SampleQuality) = (1, 0) (see dx10HW.cpp) but the
+	// `rt_Generic_2` render target is a multisampled rendertarget
+	// Not sure how to fix it correctly, if it doesn't need a depth buffer then just pass NULL, if it does
+	// we probably need to create a multisampled depth target (e.g. `rt_Generic_2_zb`)
+	//
+	// The best way I've found to see this happen is to launch the DX11 exe with `--dxgi-dbg` to enable the debug layer,
+	// then launch the game in RenderDoc with `Enable API Validation` and `Collect Callstacks` enabled, take a capture
+	// then go to `Tools > Load Symbols` to load the callstack symbols. In the bottom left of the main RenderDoc window
+	// there's a little status message that you can click on to see all the debug layer errors/warnings that lets you jump
+	// directly to the render event where the error occurred.
+	//
+	// This will let you go to the precise render event that caused the debug layer to log an error, and let you see the
+	// callstack where the Render() call occurred
+
 	if (!m_bHasActiveVolumetric)
 	{
 		m_bHasActiveVolumetric = true;


### PR DESCRIPTION
Sorry for bundling all this in one PR, I tried to break up the commits to make it easier to see what changes are relevant for each issue. Also sorry for trailing whitespace changes, but probably better they're gone now :)

## DX11 DWM vsync issue:
- By default, windowed mode applications in `FLIP` presentation modes vsync to the DWM, so if your desktop refresh rate was 60Hz and the game was in a windowed mode (borderless/windowed) the renderer would be locked to 60Hz even if it could run at a higher framerate (even with the in-game vsync disabled)
- DX11 has a way to turn this off, but is a relatively new feature, so some configurations may not support it. It also requires some swapchain flags to enable, and a flag to the `Present` call
- Now, by default (if vsync is disabled) we try to enable this option `DXGI_PRESENT_ALLOW_TEARING` to unlock the framerate in windowed modes
- Still has an issue on my PC in particular, I put a TODO in to figure out why since it works for you without issue. For anyone reading this in the future, the issue is that if I launch the game in a windowed mode it's still vsync'd by the DWM, but if I switch into exclusive fullscreen then back to windowed/borderless it is no longer vsync'd
  - [PresentMon](https://github.com/GameTechDev/PresentMon) provided no useful insight into why, but could be useful in the future for similar issues

## New DXGI debug argument:
- I added `--dxgi-dbg` to enable the D3D debug layer without requiring recompilation (currently only for DX11)
- This lets the graphics API tell you if you're doing something (it uses `OutputDebugString` so you either need to run the game in a debugger that displays that output, or use a tool like [DebugView](https://learn.microsoft.com/en-us/sysinternals/downloads/debugview)) wrong and can help a lot with debugging
- Best way I've found to use it is to:
  1. Launch the game in RenderDoc with `--dxgi-dbg` as an argument, with `Enable API Validation` and `Collect Callstacks` enabled
  2. Take a capture of a frame, open the capture
  3. Go to `Tools > Load Symbols` to load debug symbols for callstack view
  4. Look at the API validation errors in RenderDoc, it will show you the Render Event where the issue occurred and the callstack that the render call came from (helps a lot with finding where the broken thing is in the code)
- Some issues, like the weirdness with `ResizeBuffers` don't happen within a frame so you'll just have to look at the debug output log

## Fixing broken blur render passes:
- Using the process described above, I found that the blur passes were broken because they were trying to use a color target with a different resolution than the associated depth target
- Fixed this by creating separate depth targets for DX9/DX10/DX11
- Not actually sure that these passes require a depth/stencil buffer, in which case we could save some VRAM by not creating these targets and passing NULL for the depth buffer argument to `u_setrt` to disable binding one

## MSAA volumetrics error:
- Similarly, with the debug layer, I found that when MSAA is enabled in DX11 we're trying to use a multisampled color target (`rt_Generic_2`) with a non-multisampled depth buffer (`HW.pBaseZB`) which is a hard API error
- I put a TODO in because I'm not really sure what the right fix is, since it can use NULL if `RImplementation.o.ssfx_volumetric` is enabled, so maybe we could just pass NULL? Otherwise I think we would use `rt_MSAADepth->pZRT` or a new depth target, but this might require a multisample resolve