### PR TITLE
Zoom step count adjustment and slight refactor

### DIFF
--- a/src/xrGame/NewZoomFlag.h
+++ b/src/xrGame/NewZoomFlag.h
@@ -6,7 +6,6 @@ enum
 	SDS_ZOOM = (1 << 1),
 	SDS_SPEED = (1 << 3),
 	SDS = (1 << 4),
-
 };
 
 extern Flags32 zoomFlags;

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -365,6 +365,7 @@ protected:
 	struct SZoomParams
 	{
         float m_fMinBaseZoomFactor;
+		float m_fZoomStepCount;
 		bool m_bZoomEnabled;
 		bool m_bHideCrosshairInZoom;
 		bool m_bZoomDofEnabled;


### PR DESCRIPTION
- Added "zoom_step_count" option for weapons to customize steps range for dynamic scopes. Default fallback to original 3
- Hided "new zoom" feature for binoculars under its flag
- In "new zoom" deleted multiplication of step fov delta by (zoom / def_fov). I have no explanation why it was there, in all my tests this multiplier just makes zoom_step_count console parameter introduced by this feature useless 
- Slight zoom logic refactor to make it easier to read