### PR TITLE
Aim factor for hud_fov

### DIFF
--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -379,6 +379,8 @@ Fvector4 ps_s3ds_param_2 = { 0, 0, 0, 0 };
 Fvector4 ps_s3ds_param_3 = { 0, 0, 0, 0 };
 Fvector4 ps_s3ds_param_4 = { 0, 0, 0, 0 };
 
+float hud_fov_aim_factor = 0;
+
 // Screen Space Shaders Stuff
 float ps_ssfx_hud_hemi = 0.15f; // HUD Hemi Offset
 
@@ -1308,6 +1310,8 @@ void xrRender_initconsole()
 	CMD4(CCC_Vector4, "s3ds_param_2", &ps_s3ds_param_2, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "s3ds_param_3", &ps_s3ds_param_3, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "s3ds_param_4", &ps_s3ds_param_4, tw2_min, tw2_max);
+
+	CMD4(CCC_Float, "hud_fov_aim_factor", &hud_fov_aim_factor, 0.0f, 1.0f);
 	
 	// Screen Space Shaders
 	CMD4(CCC_Float, "ssfx_hud_hemi", &ps_ssfx_hud_hemi, 0.0f, 1.0f);

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -176,6 +176,8 @@ extern ECORE_API float ps_r2_ss_sunshafts_length;
 extern ECORE_API float ps_r2_ss_sunshafts_radius;
 extern u32 ps_sunshafts_mode;
 
+extern ECORE_API float hud_fov_aim_factor;
+
 //--DSR-- SilencerOverheat_start
 extern ECORE_API float sil_glow_max_temp;
 extern ECORE_API float sil_glow_shot_temp;

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -432,9 +432,18 @@ void CWeapon::SetZoomType(u8 new_zoom_type)
 
 extern float g_ironsights_factor;
 
+inline float smoothstep(float x)
+{
+	return x * x * (3 - 2 * x);
+}
+
 float CWeapon::GetHudFov()
 {
 	float base = inherited::GetHudFov();
+
+	float x = smoothstep(m_zoom_params.m_fZoomRotationFactor);
+	float factor = hud_fov_aim_factor > 0 ? hud_fov_aim_factor : 1;
+	base = (base * factor) * x + base * (1 - x);
 
 	/*
 	if (m_zoom_params.m_fBaseZoomFactor == 0.f)


### PR DESCRIPTION
Adds parameter which lowers hud_fov in ads. Useful for 3D scopes. Default off