### PR TITLE
Fix Grass Patterns due to Bad PRNG Seeding

### DIFF
--- a/src/Layers/xrRender/DetailManager_Decompress.cpp
+++ b/src/Layers/xrRender/DetailManager_Decompress.cpp
@@ -71,6 +71,13 @@ bool det_render_debug = false;
 
 #include "../../xrEngine/gamemtllib.h"
 
+static inline u32 hash2(u32 x, u32 y)
+{
+	u64 a = ((u64)x << 32) | (u64)y;
+	u64 r = 9199940308585234877ull * a + 9199940308585234877ull;
+	return (u32)(r >> 32);
+}
+
 //#define		DBG_SWITCHOFF_RANDOMIZE
 void CDetailManager::cache_Decompress(Slot* S)
 {
@@ -117,7 +124,7 @@ void CDetailManager::cache_Decompress(Slot* S)
 	u32 d_size = iCeil(dm_slot_size / density);
 	svector<int, dm_obj_in_slot> selected;
 
-	u32 p_rnd = D.sx * D.sz; // нужно для того чтобы убрать полосы(ряды)
+	u32 p_rnd = hash2((u32)D.sx, (u32)D.sz);
 	CRandom r_selection(0x12071980 ^ p_rnd);
 	CRandom r_jitter(0x12071980 ^ p_rnd);
 	CRandom r_yaw(0x12071980 ^ p_rnd);


### PR DESCRIPTION
See this GAMMA Discord discussion and comparison for example:
https://discord.com/channels/912320241713958912/1279805292472832101/1295062734836338858

Basically: The seeding procedure before had too much symmetry (e.g. if `D.sx = A` and `D.sz = B` then the configuration `D.sx = B` and `D.sz = A` would produce the same seed value) and when either were 0 it would produce the same seed along the entire axis (in world coordinates).

Using a 64-bit LCG iteration as a hash function, and combining `D.sx` and `D.sz` into a `u64` in this way removes symmetries and solves the 0 problem. More info on LCGs here:
https://en.wikipedia.org/wiki/Linear_congruential_generator
https://www.pcg-random.org/posts/does-it-beat-the-minimal-standard.html (this is where I got the 64-bit constant from)