### PR TITLE
Allow addons to hide loading tips

### DIFF
--- a/src/xrGame/GamePersistent.cpp
+++ b/src/xrGame/GamePersistent.cpp
@@ -919,6 +919,10 @@ void CGamePersistent::LoadTitle(bool change_tip, shared_str map_name)
 			R_ASSERT(ai().script_engine().functor("loadscreen.get_mp_tip_number", m_functor));
 			tip_num = m_functor(map_name.c_str());
 		}
+
+		if (tip_num < 1)
+			return;
+
 		//		tip_num = 83;
 		xr_sprintf(buff, "%s%d:", CStringTable().translate("ls_tip_number").c_str(), tip_num);
 		shared_str tmp = buff;


### PR DESCRIPTION
Addons are able to customize the number and contents of loading screen tips via scripts and XML files, but they are not able to remove the tips altogether because empty strings are not allowed as resource strings and the engine always prints out a tip number followed by a hardcoded colon character.

With this minor change,  `loadscreen.script` is able to return `0` for `get_tip_number` which will hide the loading tips.

Here is the best that can be done _without_ custom binaries:
![image](https://github.com/user-attachments/assets/0fbf22be-3703-4833-96d2-93acf84e8888)

Tip number (`0`) is always displayed, along with the following colon (`:`)
The dots are coming from `ui_st_loadscreen.xml` where empty strings or invisible whitespace characters cannot be used. 

Here's the result of the same addon with binaries customized with this commit:

![image](https://github.com/user-attachments/assets/94b2cc9c-8d35-4ded-9742-182e59a6c529)

Minimal addon to make this work is as follows:

## `ui_st_loadscreen.xml`
```xml
<?xml version="1.0" encoding="windows-1251"?>
<string_table>
	<string id="ls_header">
		<text>S.T.A.L.K.E.R. Anomaly 1.5.3</text>
	</string>
	<string id="ls_tip_number">
		<text>‎.</text>
	</string>
	<string id="ls_tip_0">
		<text>.</text>
	</string>
</string_table>
```

## `loadscreen.script`
```lua
function get_tip_number(level_name)
	return 0
end

function get_mp_tip_number(level_name)
	return 0
end
```