### PR TITLE
A handful of miscellaneous changes

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -77,6 +77,13 @@
 		<text>Particle update rate (1 - 30hz, 0.5 - 60hz, etc) (particle_update_mod)</text>
 	</string>
 
+	<string id="ui_mm_modded_exes_render_short_tracers">
+		<text>Cap and render tracers to their minimum length (render_short_tracers)</text>
+	</string>
+	<string id="ui_mm_modded_exes_allow_silencer_hide_tracer">
+		<text>Allow silencers to hide tracers (allow_silencer_hide_tracer)</text>
+	</string>
+
 	<string id="ui_mm_modded_exes_pda_map_zoom_in_to_mouse">
 		<text>PDA Map Zoom In Relative To Mouse (pda_map_zoom_in_to_mouse)</text>
 	</string>
@@ -146,6 +153,23 @@
 	<string id="ui_mm_modded_exes_keyboard_buffer_size">
 		<text>Keyboard Input Buffer Size (keyboard_buffer_size)</text>
 	</string>
+
+	<string id="ui_mm_modded_exes_allow_outfit_control_inertion_factor">
+		<text>Enable outfits affecting mouse sensitivity (allow_outfit_control_inertion_factor)</text>
+	</string>
+	<string id="ui_mm_modded_exes_allow_weapon_control_inertion_factor">
+		<text>Enable weapons affecting mouse sensitivity (allow_weapon_control_inertion_factor)</text>
+	</string>
+	<string id="ui_mm_modded_exes_fix_avelocity_spread">
+		<text>Fix moving the camera not affecting accuracy (fix_avelocity_spread)</text>
+	</string>
+	<string id="ui_mm_modded_exes_apply_pdm_to_ads">
+		<text>Apply PDM (handling) values when ADS (apply_pdm_to_ads)</text>
+	</string>
+	<string id="ui_mm_modded_exes_smooth_ads_transition">
+		<text>Smoothly apply the ADS accuracy bonus (smooth_ads_transition)</text>
+	</string>
+
 	<!-- HDR10 -->
 	<string id="ui_mm_modded_exes_hdr10_enabled">
 		<text>Enable HDR10 (Requires Restart) (r4_hdr10_on)</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -77,6 +77,13 @@
 		<text>„астота партиклей (1 - 30гц, 0.5 - 60гц и т.д.) (particle_update_mod)</text>
 	</string>
 
+	<string id="ui_mm_modded_exes_render_short_tracers">
+		<text>ќграничьте и отрисуйте трассеры до их минимальной длины (render_short_tracers)</text>
+	</string>
+	<string id="ui_mm_modded_exes_allow_silencer_hide_tracer">
+		<text>ѕозвол€ют глушител€м скрывать трассирующие элементы (allow_silencer_hide_tracer)</text>
+	</string>
+
 	<string id="ui_mm_modded_exes_pda_map_zoom_in_to_mouse">
 		<text>«ум на карту относительно курсора (pda_map_zoom_in_to_mouse)</text>
 	</string>
@@ -146,6 +153,23 @@
 	<string id="ui_mm_modded_exes_keyboard_buffer_size">
 		<text>Ѕуфер ввода дл€ клавиатуры (keyboard_buffer_size)</text>
 	</string>
+
+	<string id="ui_mm_modded_exes_allow_outfit_control_inertion_factor">
+		<text>¬ключить нар€ды, вли€ющие на чувствительность мыши (allow_outfit_control_inertion_factor)</text>
+	</string>
+	<string id="ui_mm_modded_exes_allow_weapon_control_inertion_factor">
+		<text>¬ключить оружие, вли€ющее на чувствительность мыши (allow_weapon_control_inertion_factor)</text>
+	</string>
+	<string id="ui_mm_modded_exes_fix_avelocity_spread">
+		<text>»справьте перемещение камеры, не вли€ющее на точность (fix_avelocity_spread)</text>
+	</string>
+	<string id="ui_mm_modded_exes_apply_pdm_to_ads">
+		<text>ѕримен€йте значени€ PDM (обработки) при размещении рекламы (apply_pdm_to_ads)</text>
+	</string>
+	<string id="ui_mm_modded_exes_smooth_ads_transition">
+		<text>ѕлавно примен€йте бонус за точность рекламы (smooth_ads_transition)</text>
+	</string>
+
 	<!-- HDR10 -->
 	<string id="ui_mm_modded_exes_hdr10_enabled">
 		<text>¬ключить HDR10 (требуетс€ перезагрузка) (r4_hdr10_on)</text>

--- a/gamedata/scripts/ltx_help_ex.script
+++ b/gamedata/scripts/ltx_help_ex.script
@@ -16,19 +16,20 @@
         base_hud_offset_pos_16x9 - Editable variables that allow weapon position adjustements that don't require aim tweaks
         base_hud_offset_rot - Editable variables that allow weapon position adjustements that don't require aim tweaks
         base_hud_offset_rot_16x9 - Editable variables that allow weapon position adjustements that don't require aim tweaks
+        silenced_tracers - Option to disable silencers hiding the tracer on a per weapon basis
 
     Grenades
-        frags_ap - Explosive shrapnel (frags) customization
-        frags_air_resistance - Explosive shrapnel (frags) customization
-        frags_tracer - Explosive shrapnel (frags) customization
-        frags_4to1_tracer - Explosive shrapnel (frags) customization
-        frags_magnetic_beam_shot - Explosive shrapnel (frags) customization
-        frags_tracer_color_ID - Explosive shrapnel (frags) customization
+        frags_ap - AP power for shrapnel
+        frags_air_resistance - Air resistance for shrapnel
+        frags_tracer - Tracer flag for shrapnel
+        frags_4to1_tracer - 4 to 1 tracer flag for shrapnel
+        frags_magnetic_beam_shot - Magnetic beam flag for shrapnel
+        frags_tracer_color_ID - Tracer color ID for shrapnel
         ammo_grenade_vel - Specify velocity of underbarrel grenade launcher ammo
         explode_effector_sect_name - customizable explode_effector per grenade section
 
     Ammo
-        tracer_silenced - Silencers can hide bullet tracers
+        tracer_silenced - Silencers can hide bullet tracers on a per ammo type basis
         tracer_length_k - Tracer length modifier
 
     Detectors

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -45,7 +45,11 @@
 
         allow_outfit_control_inertion_factor 
         allow_weapon_control_inertion_factor // Weapon and outfit control_inertion_factor can affect mouse sens
-        render_short_tracers // Tracers will be capped to their minimum length instead of not rendering 
+        render_short_tracers // Tracers will be capped to their minimum length instead of not rendering
+        fix_avelocity_spread // Fixes moving the camera around not worsening accuracy
+        apply_pdm_to_ads // Enables PDM (handling) values to be applied properly during ADS
+        smooth_ads_transition // Smoothly applies the ADS accuracy bonus instead of only being applied when fully ADS
+        allow_silencer_hide_tracer // Controls wether or not silencers can hide tracers at all
 		
 		viewport_near [0.0, 1.0] // Adjust the camera near value
 
@@ -201,6 +205,7 @@
         //        power = 1,
         //        impulse = 1,
         //        sender = AC_ID,
+        //        senderweapon = db.actor:active_item():id(),   // Defaults to what's set for sender if not specified
         //        hit_type = 1,
         //        max_dist = 100,
         //        ammo_sect = "ammo_5.56x45_fmj",
@@ -313,6 +318,8 @@
         function update_weight()
         function get_total_weight_force_update()
         function get_talking_npc()
+        function set_actor_position(vector pos, bool bskip_collision_correct, bool bkeep_speed)
+        function set_movement_speed(vector)
 
         // Stalker NPCs
         function get_enable_anomalies_pathfinding()
@@ -460,6 +467,10 @@
         }
         table get_scope_ui() 
         function set_scope_ui(string)
+        
+        // Get and set the zoom_rotate_time (time in seconds to fully ADS) field for a given weapon
+        function GetZoomRotateTime()
+        function SetZoomRotateTime(float)
     }
 
     enum rq_target { (sum them up to target multiple types)

--- a/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/scripts/ui_options_modded_exes.script
@@ -200,6 +200,20 @@ function init_opt_base()
 				step = 0.01,
 				cmd = "particle_update_mod",
 			},
+			{
+				id = "render_short_tracers",
+				type = "check",
+				val = 1,
+				def = true,
+				cmd = "render_short_tracers",
+			}
+			{
+				id = "allow_silencer_hide_tracer",
+				type = "check",
+				val = 1,
+				def = true,
+				cmd = "allow_silencer_hide_tracer",
+			},
 
 			{ id = "divider", type = "line" },
 
@@ -369,6 +383,41 @@ function init_opt_base()
 				curr = {function() return get_console_cmd(0, "telekinetic_objects_include_corpses") end},
 				content = {function() return {{"1", "ON"}, {"0", "OFF"}} end},
 				cmd = "telekinetic_objects_include_corpses",
+			},
+			{
+				id = "allow_outfit_control_inertion_factor",
+				type = "check",
+				val = 1,
+				def = false,
+				cmd = "allow_outfit_control_inertion_factor",
+			},
+			{
+				id = "allow_weapon_control_inertion_factor",
+				type = "check",
+				val = 1,
+				def = false,
+				cmd = "allow_weapon_control_inertion_factor",
+			},
+			{
+				id = "fix_avelocity_spread",
+				type = "check",
+				val = 1,
+				def = false,
+				cmd = "fix_avelocity_spread",
+			},
+			{
+				id = "apply_pdm_to_ads",
+				type = "check",
+				val = 1,
+				def = false,
+				cmd = "apply_pdm_to_ads",
+			},
+			{
+				id = "smooth_ads_transition",
+				type = "check",
+				val = 1,
+				def = false,
+				cmd = "smooth_ads_transition",
 			},
 
 			{ id = "divider", type = "line" },

--- a/src/xrGame/Level_Bullet_Manager.cpp
+++ b/src/xrGame/Level_Bullet_Manager.cpp
@@ -43,6 +43,7 @@ SBullet::~SBullet()
 {
 }
 
+BOOL g_allow_silencer_hide_tracer = 1;
 u32 SBullet::bulletCount = 0;
 
 void SBullet::Init(const Fvector& position,
@@ -102,14 +103,14 @@ void SBullet::Init(const Fvector& position,
 	//-Alundaio
 
 	// demonized: hide tracer when weapon has silencer
-	if (!cartridge.param_s.tracer_silenced)		// momopate: Make it optional
+	if (!cartridge.param_s.tracer_silenced && g_allow_silencer_hide_tracer)		// momopate: Make it optional
 	{
 		CObject* g_obj = Level().Objects.net_Find(weapon_id);
 		if (g_obj) 
 		{
 			CWeapon* weapon = smart_cast<CWeapon*>(g_obj);
 			if (weapon && weapon->IsSilencerAttached())
-				flags.allow_tracer = false;
+				flags.allow_tracer = (weapon->GetSilencedTracers());	// momopate: customize per weapon
 		}
 	}
 

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -753,6 +753,9 @@ void CWeapon::Load(LPCSTR section)
 	m_bHasTracers = !!READ_IF_EXISTS(pSettings, r_bool, section, "tracers", true);
 	m_u8TracerColorID = READ_IF_EXISTS(pSettings, r_u8, section, "tracers_color_ID", u8(-1));
 
+	// momopate
+	m_bSilencedTracers = READ_IF_EXISTS(pSettings, r_bool, section, "silenced_tracers", false);
+
 	string256 temp;
 	for (int i = egdNovice; i < egdCount; ++i)
 	{

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -971,6 +971,11 @@ public:
 	{
 		m_first_bullet_controller.set_fire_dispertion(val);
 	};
+
+	// momopate
+	float GetZoomRotateTime() { return m_zoom_params.m_fZoomRotateTime; }
+	virtual void SetZoomRotateTime(float val) { m_zoom_params.m_fZoomRotateTime = val; }
+
 protected:
 	int iAmmoElapsed; // ammo in magazine, currently
 	int iMagazineSize; // size (in bullets) of magazine
@@ -995,6 +1000,7 @@ public:
 	CWeaponAmmo* m_pCurrentAmmo;
 	u8 m_ammoType;
 	bool m_bHasTracers;
+	bool m_bSilencedTracers;
 	u8 m_u8TracerColorID;
 	u8 m_set_next_ammoType_on_reload;
 	// Multitype ammo support
@@ -1002,6 +1008,8 @@ public:
 	CCartridge m_DefaultCartridge;
 	CCartridge m_lastCartridge;
 	float m_fCurrentCartirdgeDisp;
+
+	virtual bool GetSilencedTracers() { return m_bSilencedTracers; }
 
 	bool unlimited_ammo();
 	IC bool can_be_strapped() const

--- a/src/xrGame/WeaponAK74.cpp
+++ b/src/xrGame/WeaponAK74.cpp
@@ -129,6 +129,10 @@ void CWeaponAK74::script_register	(lua_State *L)
 			.def("SetHitImpulse", &CWeapon::SetHitImpulse)
 			.def("SetFireDistance", &CWeapon::SetFireDistance)
 
+			// momopate
+			.def("GetZoomRotateTime", &CWeapon::GetZoomRotateTime)
+			.def("SetZoomRotateTime", &CWeapon::SetZoomRotateTime)
+
 			// demonized: World model on stalkers adjustments
 			.def("Set_mOffset", &CWeapon::set_mOffset)
 			.def("Set_mStrapOffset", &CWeapon::set_mStrapOffset)

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -118,6 +118,10 @@ extern BOOL g_telekinetic_objects_include_corpses; // Tosox
 extern BOOL g_allow_weapon_control_inertion_factor; // momopate
 extern BOOL g_allow_outfit_control_inertion_factor;
 extern BOOL g_render_short_tracers;
+extern BOOL g_fix_avelocity_spread;
+extern BOOL g_apply_pdm_to_ads;
+extern BOOL g_smooth_ads_transition;
+extern BOOL g_allow_silencer_hide_tracer;
 
 //demonized: new console vars
 extern BOOL firstPersonDeath;
@@ -2700,10 +2704,12 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
 
 	CMD4(CCC_Integer, "allow_weapon_control_inertion_factor", &g_allow_weapon_control_inertion_factor, 0, 1); // momopate
-
 	CMD4(CCC_Integer, "allow_outfit_control_inertion_factor", &g_allow_outfit_control_inertion_factor, 0, 1);
-
 	CMD4(CCC_Integer, "render_short_tracers", &g_render_short_tracers, 0, 1);
+	CMD4(CCC_Integer, "fix_avelocity_spread", &g_fix_avelocity_spread, 0, 1);
+	CMD4(CCC_Integer, "apply_pdm_to_ads", &g_apply_pdm_to_ads, 0, 1);
+	CMD4(CCC_Integer, "smooth_ads_transition", &g_smooth_ads_transition, 0, 1);
+	CMD4(CCC_Integer, "allow_silencer_hide_tracer", &g_allow_silencer_hide_tracer, 0, 1);
 
 	CMD4(CCC_Float, "ai_aim_predict_time", &g_aim_predict_time, 0.f, 10.f);
 

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1551,9 +1551,14 @@ void AddBullet(luabind::object t)
 		LPCSTR ammo_sect = luabind::object_cast<LPCSTR>(t["ammo_sect"]);
 		float air_resistance = luabind::object_cast<float>(t["air_resistance"]);
 
+		// momopate: add senderweapon id to the table as to not break most damage mods, defaults to sender
+		u16 senderweapon = sender;
+		if (luabind::object_cast<u16>(t["senderweapon"]))
+			senderweapon = luabind::object_cast<u16>(t["senderweapon"]);
+
 		CCartridge* _temp = xr_new<CCartridge>();
 		_temp->Load(ammo_sect, 0);
-		Level().BulletManager().AddBullet(pos, dir, speed, power, impulse, sender, sender, hit_type, max_dist, *_temp, air_resistance, true);
+		Level().BulletManager().AddBullet(pos, dir, speed, power, impulse, sender, senderweapon, hit_type, max_dist, *_temp, air_resistance, true);
 		delete_data(_temp);
 	} else {
 		Msg("!AddBullet(luabind::object t): argument is not a table");

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -256,7 +256,7 @@ public:
 	void AddAction(const CScriptEntityAction* tpEntityAction, bool bHighPriority = false);
 	void ResetActionQueue();
 	// Actor only
-	void SetActorPosition(Fvector pos, bool bskip_collision_correct = false);
+	void SetActorPosition(Fvector pos, bool bskip_collision_correct = false, bool bkeep_speed = false);	// momopate: allow movespeed to be kept if bskip_collision_correct == true
 	void SetActorDirection(float dir);
 	void SetActorDirection(float dir, float pitch);
 	void SetActorDirection(float dir, float pitch, float roll);
@@ -265,6 +265,7 @@ public:
 	void DisableHitMarks(bool disable);
 	bool DisableHitMarks() const;
 	Fvector GetMovementSpeed() const;
+	void SetMovementSpeed(Fvector vel);		// momopate: db.actor:set_movement_speed(vector vel)
 
 	// CCustomMonster
 	bool CheckObjectVisibility(const CScriptGameObject* tpLuaGameObject);

--- a/src/xrGame/script_game_object2.cpp
+++ b/src/xrGame/script_game_object2.cpp
@@ -356,7 +356,7 @@ void CScriptGameObject::RestoreDefaultStartDialog()
 	pDialogManager->RestoreDefaultStartDialog();
 }
 
-void CScriptGameObject::SetActorPosition(Fvector pos, bool bskip_collision_correct)
+void CScriptGameObject::SetActorPosition(Fvector pos, bool bskip_collision_correct, bool bkeep_speed)
 {
 	CActor* actor = smart_cast<CActor*>(&object());
 	if (actor)
@@ -369,7 +369,8 @@ void CScriptGameObject::SetActorPosition(Fvector pos, bool bskip_collision_corre
 			if (actor->character_physics_support()->movement()->CharacterExist())
 			{
 				actor->character_physics_support()->movement()->SetPosition(F.c);
-				actor->character_physics_support()->movement()->SetVelocity(0.f, 0.f, 0.f);
+				if (!bkeep_speed)	// momopate: allow movespeed to be kept if bskip_collision_correct == true
+					actor->character_physics_support()->movement()->SetVelocity(0.f, 0.f, 0.f);
 			}
 		}
 		else
@@ -465,6 +466,19 @@ Fvector CScriptGameObject::GetMovementSpeed() const
 	}
 	//return actor->GetMovementSpeed();
 	return actor->character_physics_support()->movement()->GetVelocity();
+}
+
+// momopate: db.actor:set_movement_speed(vector vel)
+void CScriptGameObject::SetMovementSpeed(Fvector vel)
+{
+	CActor* actor = smart_cast<CActor*>(&object());
+	if (!actor)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "ScriptGameObject : attempt to call SetMovementSpeed method for non-actor object");
+		return;
+	}
+	actor->character_physics_support()->movement()->SetVelocity(vel.x, vel.y, vel.z);
 }
 
 CHolderCustom* CScriptGameObject::get_current_holder()

--- a/src/xrGame/script_game_object_script2.cpp
+++ b/src/xrGame/script_game_object_script2.cpp
@@ -329,6 +329,7 @@ class_<CScriptGameObject>& script_register_game_object1(class_<CScriptGameObject
 		.def("disable_hit_marks", (void (CScriptGameObject::*)(bool))&CScriptGameObject::DisableHitMarks)
 		.def("disable_hit_marks", (bool (CScriptGameObject::*)() const)&CScriptGameObject::DisableHitMarks)
 		.def("get_movement_speed", &CScriptGameObject::GetMovementSpeed)
+		.def("set_movement_speed", &CScriptGameObject::SetMovementSpeed)	// momopate: db.actor:set_momvement_speed(vector vel)
 
 		.def("set_npc_position", &CScriptGameObject::SetNpcPosition)
 


### PR DESCRIPTION
- Added console commands:
	1. fix_avelocity_spread -> Bool; Fixes moving the camera not affecting accuracy.
	2. apply_pdm_to_ads -> Bool; Makes it so that PDM values from the weapon are properly applied when aiming down sights.
	3. smooth_ads_transition -> Bool; Makes it so that going in and out of ADS smoothly changes the accuracy bonus instead of changing only at full ADS.
	4. allow_silencer_hide_tracer -> Bool; Optionally disables silencers being able to hide tracers completely. (Defaults to true)

- Added silenced_tracers (bool) field to weapons sections. If the ammo type can be hidden when using a silenced weapon, setting this field to true makes the tracer visible again.
- Added GetZoomRotateTime() and SetZoomRotateTime(float val).
- Added senderweapon to the table used for level.add_bullet() to improve compatibility with modding. Defaults to sender.
- Added bkeep_speed to SetActorPosition().
- Added SetMovementSpeed(). Exported as set_movement_speed(vector vel) for scripting.