### PR TITLE
Stutter improvement, disable running 'net_Relcase' on scripts

### DIFF
--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -952,8 +952,11 @@ u32 CGameObject::ef_detector_type() const
 void CGameObject::net_Relcase(CObject* O)
 {
 	inherited::net_Relcase(O);
+	// demonized: Causes more allocations for lua gc. Pretty much all scripts never use this and should never.
+	/*
 	if (!g_dedicated_server)
 		CScriptBinder::net_Relcase(O);
+	*/
 }
 
 CGameObject::CScriptCallbackExVoid& CGameObject::callback(GameObject::ECallbackType type) const


### PR DESCRIPTION
There is a script function called `net_Relcase` that LUA objects could implement, but nobody ever does and also they shouldn't. The original stalker and anomaly do nothing with it, and all the scripts GAMMA uses do not use it. 

`net_Relcase` is meant for properly disconnecting from objects that are linked when the object gets destroyed. There isn't a use-case for this in scripting, and again is never used.

However, it still gets called and can cause a lot of work for the GC which will cause stuttering. Here is the profile of the stutter issue I was able to reproduce:

![image](https://github.com/user-attachments/assets/5030a225-3667-4e13-b84f-89d51daf9571)
