### PR TITLE
Update Actor_Weapon.cpp

### DIFF
--- a/src/xrGame/Actor_Flags.h
+++ b/src/xrGame/Actor_Flags.h
@@ -21,7 +21,8 @@ enum
 	AF_FREELOOK_TOGGLE = (1 << 17),
 	AF_SIMPLE_PDA = (1 << 18),
 	AF_AIM_TOGGLE = (1 << 19),
-	AF_3D_PDA = (1 << 20)
+	AF_3D_PDA = (1 << 20),
+	AF_FIREPOS_ZOOM =(1 << 21),
 };
 
 extern Flags32 psActorFlags;

--- a/src/xrGame/Actor_Weapon.cpp
+++ b/src/xrGame/Actor_Weapon.cpp
@@ -126,7 +126,7 @@ void CActor::g_fireParams(const CHudItem* pHudItem, Fvector& fire_pos, Fvector& 
 			dir.setHP(-angle_normalize_signed(old_torso_yaw), pitch > 0.f ? ((pWeapon->GetState() == CWeapon::eFire || cam_freelook == eflDisabling) ? pitch : pitch * .6f) : pitch * .8f);
 			fire_dir = dir;
 		}
-		else if ((psActorFlags.test(AF_FIREPOS)) /* && (pWeapon->GetZRotatingFactor() != 1.f /*|| dist < 1.f)*/)
+		else if (((psActorFlags.test(AF_FIREPOS) || (mstate_real & mcAnyMove)) && (pWeapon->GetZRotatingFactor() != 1.f /*|| dist < 1.f*/)) || psActorFlags.test(AF_FIREPOS_ZOOM))
 		{
 			//correct barrel direction
 			fire_dir = fire_mat.k; //pWeapon->get_lastFD() doesn't seem to work, returns (0,0,1) for all weapons except pistols/shotguns

--- a/src/xrGame/Actor_Weapon.cpp
+++ b/src/xrGame/Actor_Weapon.cpp
@@ -119,7 +119,6 @@ void CActor::g_fireParams(const CHudItem* pHudItem, Fvector& fire_pos, Fvector& 
 		const Fmatrix& fire_mat = pWeapon->get_ParticlesXFORM();
 		//collide::rq_result& RQ = pWeapon->GetRQ();
 		//float dist = RQ.range / 3.f;
-
 		if (cam_freelook != eflDisabled)
 		{
 			Fvector dir;
@@ -127,7 +126,7 @@ void CActor::g_fireParams(const CHudItem* pHudItem, Fvector& fire_pos, Fvector& 
 			dir.setHP(-angle_normalize_signed(old_torso_yaw), pitch > 0.f ? ((pWeapon->GetState() == CWeapon::eFire || cam_freelook == eflDisabling) ? pitch : pitch * .6f) : pitch * .8f);
 			fire_dir = dir;
 		}
-		else if ((psActorFlags.test(AF_FIREPOS) || (mstate_real & mcAnyMove)) && (pWeapon->GetZRotatingFactor() != 1.f /*|| dist < 1.f*/))
+		else if ((psActorFlags.test(AF_FIREPOS)) /* && (pWeapon->GetZRotatingFactor() != 1.f /*|| dist < 1.f)*/)
 		{
 			//correct barrel direction
 			fire_dir = fire_mat.k; //pWeapon->get_lastFD() doesn't seem to work, returns (0,0,1) for all weapons except pistols/shotguns

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2471,6 +2471,7 @@ void CCC_RegisterCommands()
 		CMD1(CCC_PHGravity, "ph_gravity");
 		CMD3(CCC_Mask, "log_missing_ini", &FS.m_Flags, FS.flPrintLTX);
 		CMD3(CCC_Mask, "g_firepos", &psActorFlags, AF_FIREPOS);
+		CMD3(CCC_Mask, "g_firepos_zoom", &psActorFlags, AF_FIREPOS_ZOOM);
 		CMD4(CCC_Float, "g_end_modif", &g_end_modif, 0.f, 10.f);
 	}
 #endif // MASTER_GOLD


### PR DESCRIPTION
Changed else if to make firepos work while aiming. Not sure if it doesn't break anything
pWeapon->GetZRotatingFactor() != 1.f was preventing g_firepos from working while player is aiming