### PR TITLE
Tested/Tweaked SSRS

### DIFF
--- a/src/xrGame/WeaponSSRS.cpp
+++ b/src/xrGame/WeaponSSRS.cpp
@@ -1,0 +1,395 @@
+﻿#include "stdafx.h"
+#include "WeaponSSRS.h"
+#include "entity.h"
+#include "explosiveRocket.h"
+#include "level.h"
+#include "../xrphysics/MathUtils.h"
+#include "actor.h"
+#include "GrenadeLauncher.h"
+#include "WeaponMagazined.h"
+#include "pch_script.h"
+#include "ParticlesObject.h"
+#include "Scope.h"
+#include "Silencer.h"
+#include "inventory.h"
+#include "InventoryOwner.h"
+#include "xrserver_objects_alife_items.h"
+#include "ActorEffector.h"
+#include "EffectorZoomInertion.h"
+#include "xr_level_controller.h"
+#include "UIGameCustom.h"
+#include "object_broker.h"
+#include "string_table.h"
+#include "MPPlayersBag.h"
+#include "ui/UIXmlInit.h"
+#include "ui/UIStatic.h"
+#include "game_object_space.h"
+#include "script_callback_ex.h"
+#include "script_game_object.h"
+#include "player_hud.h"
+#include "HudSound.h"
+
+#include "ai/stalker/ai_stalker.h"
+
+#ifdef DEBUG
+#	include "phdebug.h"
+#endif
+
+CWeaponSSRS::~CWeaponSSRS()
+{
+}
+
+BOOL CWeaponSSRS::net_Spawn(CSE_Abstract* DC)
+{
+	BOOL l_res = inheritedWM::net_Spawn(DC);
+	if (!l_res) return l_res;
+
+	if (iAmmoElapsed && !getCurrentRocket())
+	{
+		shared_str grenade_name = m_ammoTypes[0];
+		shared_str fake_grenade_name = pSettings->r_string(grenade_name, "fake_grenade_name");
+
+		if (fake_grenade_name.size())
+		{
+			int k = iAmmoElapsed;
+			while (k)
+			{
+				k--;
+				inheritedRL::SpawnRocket(*fake_grenade_name, this);
+			}
+		}
+	}
+
+	return l_res;
+};
+
+void CWeaponSSRS::Load(LPCSTR section)
+{
+	inheritedRL::Load(section);
+	inheritedWM::Load(section);
+	fAiOneShotTime = READ_IF_EXISTS(pSettings, r_float, section, "ai_rpm", fOneShotTime);
+}
+
+void CWeaponSSRS::FireStart()
+{
+	//Check if actor is AI
+	if (smart_cast<CAI_Stalker*>(H_Parent()))
+	{
+		fOneShotTime = 60.f / fAiOneShotTime;
+	}
+
+	inheritedWM::FireStart();
+}
+
+void CWeaponSSRS::OnEvent(NET_Packet& P, u16 type)
+{
+	inheritedWM::OnEvent(P, type);
+
+	u16 id;
+	switch (type)
+	{
+	case GE_OWNERSHIP_TAKE:
+		{
+			P.r_u16(id);
+			inheritedRL::AttachRocket(id, this);
+		}
+		break;
+	case GE_OWNERSHIP_REJECT:
+	case GE_LAUNCH_ROCKET:
+		{
+			bool bLaunch = (type == GE_LAUNCH_ROCKET);
+			P.r_u16(id);
+			inheritedRL::DetachRocket(id, bLaunch);
+		}
+		break;
+	}
+}
+
+#ifdef CROCKETLAUNCHER_CHANGE
+void CWeaponSSRS::UnloadRocket()
+{
+	while (getRocketCount() > 0)
+	{
+		Msg("%s:%d [%d]-[%s]", __FUNCTION__, __LINE__, getRocketCount(), getCurrentRocket()->cNameSect_str());
+		NET_Packet P;
+		u_EventGen(P, GE_OWNERSHIP_REJECT, ID());
+		P.w_u16(u16(getCurrentRocket()->ID()));
+		u_EventSend(P);
+        dropCurrentRocket();
+	}
+}
+#endif
+
+void CWeaponSSRS::ReloadMagazine()
+{
+	m_needReload = false;
+	m_BriefInfo_CalcFrame = 0;
+
+	//устранить осечку при перезарядке
+	if (IsMisfire())
+	{
+		bMisfire = false;
+		if (bClearJamOnly)
+		{
+			bClearJamOnly = false;
+			return;
+		}
+	}
+
+	if (!m_bLockType)
+	{
+		m_pCurrentAmmo = NULL;
+	}
+
+	if (!m_pInventory) return;
+
+	if (m_set_next_ammoType_on_reload != undefined_ammo_type)
+	{
+		m_ammoType = m_set_next_ammoType_on_reload;
+		m_set_next_ammoType_on_reload = undefined_ammo_type;
+	}
+
+	UnloadRocket();
+
+	if (!unlimited_ammo())
+	{
+		if (m_ammoTypes.size() <= m_ammoType)
+			return;
+
+		LPCSTR tmp_sect_name = m_ammoTypes[m_ammoType].c_str();
+
+		if (!tmp_sect_name)
+			return;
+
+		//попытаться найти в инвентаре патроны текущего типа
+		m_pCurrentAmmo = smart_cast<CWeaponAmmo*>(m_pInventory->GetAny(tmp_sect_name));
+
+		if (!m_pCurrentAmmo && !m_bLockType && iAmmoElapsed == 0)
+		{
+			shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
+			for (u8 i = 0; i < u8(m_ammoTypes.size()); ++i)
+			{
+				//проверить патроны всех подходящих типов
+				m_pCurrentAmmo = smart_cast<CWeaponAmmo*>(m_pInventory->GetAny(m_ammoTypes[i].c_str()));
+
+				if (m_pCurrentAmmo)
+				{
+					m_ammoType = i;
+					break;
+				}
+			}
+		}
+	}
+
+	//нет патронов для перезарядки
+	if (!m_pCurrentAmmo && !unlimited_ammo()) return;
+
+	//разрядить магазин, если загружаем патронами другого типа
+	if (!m_bLockType && !m_magazine.empty() &&
+		(!m_pCurrentAmmo || xr_strcmp(m_pCurrentAmmo->cNameSect(),
+			*m_magazine.back().m_ammoSect)))
+		UnloadMagazine(!unlimited_ammo());
+
+	VERIFY((u32)iAmmoElapsed == m_magazine.size());
+
+	if (m_DefaultCartridge.m_LocalAmmoType != m_ammoType)
+		m_DefaultCartridge.Load(m_ammoTypes[m_ammoType].c_str(), m_ammoType, m_APk);
+	CCartridge l_cartridge = m_DefaultCartridge;
+
+	shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
+	while (iAmmoElapsed < iMagazineSize)
+	{
+		if (!unlimited_ammo())
+		{
+			if (!m_pCurrentAmmo->Get(l_cartridge)) break;
+		}
+		++iAmmoElapsed;
+		l_cartridge.m_LocalAmmoType = m_ammoType;
+		m_magazine.push_back(l_cartridge);
+		inheritedRL::SpawnRocket(*fake_grenade_name, this);
+	}
+
+	VERIFY((u32)iAmmoElapsed == m_magazine.size());
+
+	//выкинуть коробку патронов, если она пустая
+	if (m_pCurrentAmmo && !m_pCurrentAmmo->m_boxCurr && OnServer())
+		m_pCurrentAmmo->SetDropManual(TRUE);
+
+	if (iMagazineSize > iAmmoElapsed)
+	{
+		m_bLockType = true;
+		ReloadMagazine();
+		m_bLockType = false;
+	}
+
+	VERIFY((u32)iAmmoElapsed == m_magazine.size());
+}
+
+void CWeaponSSRS::state_Fire(float dt)
+{
+	if (iAmmoElapsed > 0)
+	{
+		VERIFY(fOneShotTime > 0.f);
+		VERIFY(fAiOneShotTime > 0.f);
+
+		if (!H_Parent()) return;
+
+		if (smart_cast<CMPPlayersBag*>(H_Parent()) != NULL)
+		{
+			Msg("! WARNING: state_Fire of object [%d][%s] while parent is CMPPlayerBag...", ID(), cNameSect().c_str());
+			return;
+		}
+
+		CInventoryOwner* io = smart_cast<CInventoryOwner*>(H_Parent());
+		if (NULL == io->inventory().ActiveItem())
+		{
+			Log("current_state", GetState());
+			Log("next_state", GetNextState());
+			Log("item_sect", cNameSect().c_str());
+			Log("H_Parent", H_Parent()->cNameSect().c_str());
+			StopShooting();
+			return;
+			//Alundaio: This is not supposed to happen but it does. GSC was aware but why no return here? Known to cause crash on game load if npc immediatly enters combat.
+		}
+		Fvector p1, d;
+		p1.set(get_LastFP());
+		d.set(get_LastFD());
+		CEntity* E = smart_cast<CEntity*>(H_Parent());
+
+		if (!E->g_stateFire())
+			StopShooting();
+
+		if (m_iShotNum == 0)
+		{
+			m_vStartPos = p1;
+			m_vStartDir = d;
+		}
+
+		VERIFY(!m_magazine.empty());
+
+		while (!m_magazine.empty() && fShotTimeCounter < 0 && (IsWorking() || m_bFireSingleShot) && (m_iQueueSize < 0 ||
+			m_iShotNum < m_iQueueSize))
+		{
+			m_bFireSingleShot = false;
+
+			//Alundaio: Use fModeShotTime instead of fOneShotTime if current fire mode is 2-shot burst
+			//Alundaio: Cycle down RPM after two shots; used for Abakan/AN-94
+			// demonized: Add support for arbitrary shot burst at rpm_mode_2
+			if (GetCurrentFireMode() >= 2 || cycleDownCheck())
+			{
+				fShotTimeCounter = fModeShotTime;
+			}
+			else
+				fShotTimeCounter = fOneShotTime;
+			//Alundaio: END
+
+#ifdef CROCKETLAUNCHER_CHANGE
+			LPCSTR ammo_name = m_ammoTypes[m_ammoType].c_str();
+			float launch_speed = READ_IF_EXISTS(pSettings, r_float, ammo_name, "ammo_grenade_vel", CRocketLauncher::m_fLaunchSpeed);
+#endif
+			if (E)
+			{
+				CInventoryOwner* io = smart_cast<CInventoryOwner*>(H_Parent());
+				if (NULL == io->inventory().ActiveItem())
+				{
+					Log("current_state", GetState());
+					Log("next_state", GetNextState());
+					Log("item_sect", cNameSect().c_str());
+					Log("H_Parent", H_Parent()->cNameSect().c_str());
+				}
+				E->g_fireParams(this, p1, d);
+			}
+
+			Fmatrix launch_matrix;
+			launch_matrix.identity();
+			launch_matrix.k.set(d);
+			Fvector::generate_orthonormal_basis(launch_matrix.k, launch_matrix.j, launch_matrix.i);
+			launch_matrix.c.set(p1);
+
+			if (IsGameTypeSingle() && IsZoomed() && smart_cast<CActor*>(H_Parent()))
+			{
+				H_Parent()->setEnabled(FALSE);
+				setEnabled(FALSE);
+
+				collide::rq_result RQ;
+				BOOL HasPick = Level().ObjectSpace.RayPick(p1, d, 300.0f, collide::rqtStatic, RQ, this);
+
+				setEnabled(TRUE);
+				H_Parent()->setEnabled(TRUE);
+
+				if (HasPick)
+				{
+					Fvector Transference;
+					Transference.mul(d, RQ.range);
+					Fvector res[2];
+
+#ifdef CROCKETLAUNCHER_CHANGE
+					u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, launch_speed, EffectiveGravity(), res);
+#else
+					u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, CRocketLauncher::m_fLaunchSpeed,
+						EffectiveGravity(), res);
+#endif
+					if (canfire0 != 0)
+					{
+						d = res[0];
+					};
+				}
+			};
+			d.normalize();
+#ifdef CROCKETLAUNCHER_CHANGE
+			d.mul(launch_speed);
+#else
+			d.mul(m_fLaunchSpeed);
+#endif
+			VERIFY2(_valid(launch_matrix), "CWeaponSSRS::state_Fire. Invalid launch_matrix");
+			inheritedRL::LaunchRocket(launch_matrix, d, zero_vel);
+			CExplosiveRocket* pGrenade = smart_cast<CExplosiveRocket*>(getCurrentRocket());
+			VERIFY(pGrenade);
+			pGrenade->SetInitiator(H_Parent()->ID());
+			if (OnServer())
+			{
+				NET_Packet P;
+				u_EventGen(P, GE_LAUNCH_ROCKET, ID());
+				P.w_u16(u16(getCurrentRocket()->ID()));
+				u_EventSend(P);
+			}
+			dropCurrentRocket();
+
+			++m_iShotNum;
+
+			CheckForMisfire();
+			OnShot();
+
+			if (m_iShotNum > m_iBaseDispersionedBulletsCount)
+				FireTrace(p1, d);
+			else
+				FireTrace(m_vStartPos, m_vStartDir);
+
+			if (bMisfire)
+			{
+				CGameObject* object = smart_cast<CGameObject*>(H_Parent());
+				if (object)
+					object->callback(GameObject::eOnWeaponJammed)(object->lua_game_object(), this->lua_game_object());
+				StopShooting();
+				return;
+			}
+		}
+
+		if (m_iShotNum == m_iQueueSize)
+			m_bStopedAfterQueueFired = true;
+
+		UpdateSounds();
+	}
+
+	if (fShotTimeCounter < 0)
+	{
+		if (iAmmoElapsed == 0)
+			OnMagazineEmpty();
+
+		StopShooting();
+	}
+	else
+	{
+		fShotTimeCounter -= dt;
+	}
+}

--- a/src/xrGame/WeaponSSRS.cpp
+++ b/src/xrGame/WeaponSSRS.cpp
@@ -28,6 +28,7 @@
 #include "script_game_object.h"
 #include "player_hud.h"
 #include "HudSound.h"
+#include "WeaponSSRS.h"
 
 #include "ai/stalker/ai_stalker.h"
 

--- a/src/xrGame/WeaponSSRS.h
+++ b/src/xrGame/WeaponSSRS.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "rocketlauncher.h"
+#include "WeaponMagazined.h"
+#include "script_export_space.h"
+
+class CWeaponSSRS : public CRocketLauncher,
+                    public CWeaponMagazined
+{
+	typedef CRocketLauncher inheritedRL;
+	typedef CWeaponMagazined inheritedWM;
+
+public:
+	virtual ~CWeaponSSRS();
+	virtual BOOL net_Spawn(CSE_Abstract* DC);
+	virtual void Load(LPCSTR section);
+	virtual void OnEvent(NET_Packet& P, u16 type);
+
+#ifdef CROCKETLAUNCHER_CHANGE
+	virtual void UnloadRocket();
+#endif
+
+protected:
+	virtual void FireStart();
+	virtual void ReloadMagazine();
+	virtual void state_Fire(float dt);
+	float fAiOneShotTime;
+
+DECLARE_SCRIPT_REGISTER_FUNCTION
+};
+
+add_to_type_list(CWeaponSSRS)
+#undef script_type_list
+#define script_type_list save_type_list(CWeaponSSRS)

--- a/src/xrGame/WeaponSSRS.h
+++ b/src/xrGame/WeaponSSRS.h
@@ -3,6 +3,7 @@
 #include "rocketlauncher.h"
 #include "WeaponMagazined.h"
 #include "script_export_space.h"
+#include "WeaponSSRS.h"
 
 class CWeaponSSRS : public CRocketLauncher,
                     public CWeaponMagazined

--- a/src/xrGame/WeaponSSRS_script.cpp
+++ b/src/xrGame/WeaponSSRS_script.cpp
@@ -1,0 +1,14 @@
+#include "pch_script.h"
+#include "WeaponSSRS.h"
+
+using namespace luabind;
+
+#pragma optimize("s",on)
+void CWeaponSSRS::script_register(lua_State* L)
+{
+	module(L)
+	[
+		class_<CWeaponSSRS, CGameObject>("CWeaponSSRS")
+		.def(constructor<>())
+	];
+}

--- a/src/xrGame/vs2022/xrGame.vcxproj
+++ b/src/xrGame/vs2022/xrGame.vcxproj
@@ -1896,6 +1896,7 @@
     <ClInclude Include="..\WeaponRG6.h" />
     <ClInclude Include="..\WeaponRPG7.h" />
     <ClInclude Include="..\WeaponShotgun.h" />
+    <ClInclude Include="..\WeaponSSRS.h" />
     <ClInclude Include="..\WeaponStatMgun.h" />
     <ClInclude Include="..\HolderEntityObject.h" />
     <ClInclude Include="..\WeaponSVD.h" />
@@ -4151,6 +4152,17 @@
     <ClCompile Include="..\weaponshotgun_script.cpp">
       <PrecompiledHeaderFile>pch_script.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
+    </ClCompile>
+    <ClCompile Include="..\WeaponSSRS.cpp" />
+    <ClCompile Include="..\WeaponSSRS_script.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Verified|x64'">pch_script.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='VerifiedDX11|x64'">pch_script.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release-AVX|x64'">pch_script.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">pch_script.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Verified|x64'">$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='VerifiedDX11|x64'">$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Release-AVX|x64'">$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
     <ClCompile Include="..\WeaponStatMgun.cpp" />
     <ClCompile Include="..\HolderEntityObject.cpp" />

--- a/src/xrGame/vs2022/xrGame.vcxproj.filters
+++ b/src/xrGame/vs2022/xrGame.vcxproj.filters
@@ -4123,6 +4123,7 @@
     <ClInclude Include="..\new_sds.h" />
     <ClInclude Include="..\NewZoomFlag.h" />
     <ClInclude Include="..\LevelDebugScript.h" />
+    <ClInclude Include="..\WeaponSSRS.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xrServerEntities\alife_human_brain.cpp" />
@@ -5351,6 +5352,8 @@
     <ClCompile Include="..\ZudaArtifact.cpp" />
     <ClCompile Include="..\WeaponMagazineExtended.cpp" />
     <ClCompile Include="..\LevelDebugScript.cpp" />
+    <ClCompile Include="..\WeaponSSRS.cpp" />
+    <ClCompile Include="..\WeaponSSRS_script.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\ai\monsters\chimera\chimera_attack_state.h" />

--- a/src/xrServerEntities/clsid_game.h
+++ b/src/xrServerEntities/clsid_game.h
@@ -93,6 +93,7 @@
 #define CLSID_OBJECT_W_KNIFE		MK_CLSID('W','_','K','N','I','F','E',' ')
 #define CLSID_OBJECT_W_BM16			MK_CLSID('W','_','B','M','1','6',' ',' ')
 #define CLSID_OBJECT_W_RG6			MK_CLSID('W','_','R','G','6',' ',' ',' ')
+#define CLSID_OBJECT_W_SSRS			MK_CLSID('_','W','_','S','S','R','S',' ')
 
 #define	CLSID_OBJECT_W_STATMGUN		MK_CLSID('W','_','S','T','M','G','U','N')
 // Weapons Ammo

--- a/src/xrServerEntities/object_factory_register.cpp
+++ b/src/xrServerEntities/object_factory_register.cpp
@@ -324,6 +324,7 @@ void CObjectFactory::register_classes()
 	ADD(CWeaponKnife, CSE_ALifeItemWeapon, CLSID_OBJECT_W_KNIFE, "wpn_knife");
 	ADD(CWeaponBM16, CSE_ALifeItemWeaponShotGun, CLSID_OBJECT_W_BM16, "wpn_bm16");
 	ADD(CWeaponRG6, CSE_ALifeItemWeaponShotGun, CLSID_OBJECT_W_RG6, "wpn_rg6");
+	ADD(CWeaponSSRS, CSE_ALifeItemWeaponMagazined, CLSID_OBJECT_W_SSRS, "_wp_ssrs");
 	//-----------------------------------------------------------------------------------------------------
 	ADD(CWeaponAmmo, CSE_ALifeItemAmmo, CLSID_OBJECT_AMMO, "wpn_ammo");
 	ADD(CWeaponAmmo, CSE_ALifeItemAmmo, CLSID_OBJECT_A_VOG25, "wpn_ammo_vog25");
@@ -449,6 +450,7 @@ void CObjectFactory::register_classes()
 	ADD(CWeaponKnife, CSE_ALifeItemWeapon, TEXT2CLSID("WP_KNIFE"), "wpn_knife_s");
 	ADD(CWeaponPM, CSE_ALifeItemWeaponMagazined, TEXT2CLSID("WP_PM"), "wpn_pm_s");
 	ADD(CWeaponRG6, CSE_ALifeItemWeaponShotGun, TEXT2CLSID("WP_RG6"), "wpn_rg6_s");
+	ADD(CWeaponSSRS, CSE_ALifeItemWeaponMagazined, TEXT2CLSID("_WP_SSRS"), "wpn_ssrs_s");
 	ADD(CWeaponRPG7, CSE_ALifeItemWeaponMagazined, TEXT2CLSID("WP_RPG7"), "wpn_rpg7_s");
 	ADD(CWeaponShotgun, CSE_ALifeItemWeaponShotGun, TEXT2CLSID("WP_SHOTG"), "wpn_shotgun_s");
 	ADD(CWeaponSVU, CSE_ALifeItemWeaponMagazined, TEXT2CLSID("WP_SVU"), "wpn_svu_s");

--- a/src/xrServerEntities/object_factory_register.cpp
+++ b/src/xrServerEntities/object_factory_register.cpp
@@ -95,6 +95,7 @@
 #	include "weaponknife.h"
 #	include "weaponBM16.h"
 #	include "weaponRG6.h"
+#	include "weaponSSRS.h"
 #	include "WeaponStatMgun.h"
 
 #	include "scope.h"

--- a/src/xrServerEntities/script_engine_export.h
+++ b/src/xrServerEntities/script_engine_export.h
@@ -130,6 +130,7 @@
 #	include "WeaponLR300.h"
 #	include "WeaponPM.h"
 #	include "WeaponRG6.h"
+#	include "WeaponSSRS.h"
 #	include "WeaponRPG7.h"
 #	include "WeaponShotgun.h"
 #	include "WeaponSVD.h"


### PR DESCRIPTION
Between the last PR about the SSRS and this one there was a testing period where I did some manual testing focusing on how the code/world/npcs interact with the new addition.

I found some stuff that needed tweaking + the previous PR had missing features like: 

Features/Fixes:
- A properly working full auto mode + the burst modes.
- Empty magazine click.
- Code for jamming (I now call `CWeaponMagazined.FireStart()` instead of using the ripped/modified code from `CWeaponRG6`)

Balance:
- The NPCs were way too overpowered using the  `.ltx rpm` setting so I added a new setting: `ai_rpm`. In the `CWeaponSSRS::FireStart()` method I check if the parent is AI and switch the `fOneShotTime`'s calculation from 
`fOneShotTime = 60.f / fOneShotTime;` to `fOneShotTime = 60.f / fAiOneShotTime;`.

Other:
- Changed the `clsid` as requested.