### PR TITLE
Feature/ubgl alt aim separated keybinds

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -165,6 +165,9 @@
 	<string id="ui_mm_modded_exes_qol_crash_save_count">
 		<text>Crash Saves Count (crash_save_count)</text>
 	</string>
+  <string id="ui_mm_modded_exes_qol_aimmode_remember">
+    <text>Aimmode remember (aimmode_remember)</text>
+  </string>
 	
 	
 	<!-- Sounds -->

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -50,6 +50,7 @@
         apply_pdm_to_ads // Enables PDM (handling) values to be applied properly during ADS
         smooth_ads_transition // Smoothly applies the ADS accuracy bonus instead of only being applied when fully ADS
         allow_silencer_hide_tracer // Controls wether or not silencers can hide tracers at all
+        aimmode_remember // When switching to UBGL the weapon will remember what mode you switched from and will put you back in that mode
 		
 		viewport_near [0.0, 1.0] // Adjust the camera near value
 

--- a/gamedata/scripts/modxml_inject_keybinds.script
+++ b/gamedata/scripts/modxml_inject_keybinds.script
@@ -1,0 +1,43 @@
+function on_xml_read()
+
+	-- Serious: add new keybinds for separated UBGL/Canted switching
+	RegisterUBGLKeybindSeparationInjector()
+end
+
+function RegisterUBGLKeybindSeparationInjector()
+	RegisterScriptCallback("on_xml_read", function(xml_file_name, xml_obj)
+        if xml_file_name == [[ui\ui_keybinding.xml]] then
+            local group_nodes = xml_obj:query("group[name=kb_grp_weapons]")
+            
+            if group_nodes[1] then
+                local group_node = group_nodes[1]
+                local new_command = [[<command id="kb_switch_ubgl"					exe="custom16"/>]]
+
+                xml_obj:insertFromXMLString(new_command, group_node, #group_node.kids)
+            end
+        end
+
+		if xml_file_name == [[text\eng\ui_st_keybinding.xml]] then
+			local string_nodes = xml_obj:query("string[id=kb_func] > text")
+
+			if string_nodes[1] then
+				local string_node = string_nodes[1]
+				local target_text = xml_obj:getText(string_node)
+				if target_text then
+
+					local text_overwrite = "Sight Aim Mode Toggle"
+					xml_obj:setText(string_node, text_overwrite)
+				end
+			end
+
+			local new_node = 
+			[[
+			<string id="kb_switch_ubgl">
+				<text>Switch To Under-Barrel Launcher</text>
+			</string>
+			]]
+
+			xml_obj:insertFromXMLString(new_node)
+		end
+    end)
+end

--- a/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/scripts/ui_options_modded_exes.script
@@ -419,6 +419,14 @@ function init_opt_base()
 						step = 1,
 						cmd = "crash_save_count",
 					},
+					{
+						id = "aimmode_remember",
+						type = "list",
+						val = 1,
+						curr = {function() return get_console_cmd(0, "aimmode_remember") end},
+						content = {function() return {{"1", "ON"}, {"0", "OFF"}} end},
+						cmd = "aimmode_remember",
+					},
 				}
 			},
 

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -433,10 +433,6 @@ void CWeapon::SwitchZoomType()
 	{
 		SetZoomTypeAndParams(0);
 	}
-	else if (m_zoomtype == 2)
-	{
-		SetZoomTypeAndParams(zoomTypeBeforeLauncher);
-	}
 
 	UpdateUIScope();
 }
@@ -3066,7 +3062,7 @@ u8 CWeapon::GetCurrentHudOffsetIdx()
 		return 3;
 	else
 		return 1;
-}
+	}
 
 void CWeapon::render_hud_mode()
 {

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -104,7 +104,8 @@ CWeapon::CWeapon()
 
 	m_Offset.identity();
 	m_StrapOffset.identity();
-
+	isGrenadeLauncherActive = false;
+	
 	m_iAmmoCurrentTotal = 0;
 	m_BriefInfo_CalcFrame = 0;
 
@@ -404,7 +405,6 @@ void CWeapon::UpdateUIScope()
 			CUIXmlInit::InitWindow(*pWpnScopeXml, scope_tex_name.c_str(), 0, m_UIScope);
 		}		
 	}
-
 	UpdateZoomParams();
 }
 
@@ -420,23 +420,55 @@ void CWeapon::SetUIScope(LPCSTR scope_texture)
 
 void CWeapon::SwitchZoomType()
 {
+	if (isGrenadeLauncherActive) // The IsGrenadeLauncherAttached() check is handled by ToggleGrenadeLauncher
+	{
+		ToggleGrenadeLauncher();
+	}
+
 	if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode))
 	{
-        SetZoomType(1);
-        m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Alt || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom_alt", false);
+		SetZoomTypeAndParams(1);
 	}
-	else if (IsGrenadeLauncherAttached())
+	else if (m_zoomtype == 1)
 	{
-		SwitchState(eSwitch);
-		return;
+		SetZoomTypeAndParams(0);
 	}
-	else if (m_zoomtype != 0)
+	else if (m_zoomtype == 2)
 	{
-        SetZoomType(0);
-        m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Primary || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
+		SetZoomTypeAndParams(zoomTypeBeforeLauncher);
 	}
 
 	UpdateUIScope();
+}
+
+void CWeapon::ToggleGrenadeLauncher()
+{
+	if (!isGrenadeLauncherActive)
+	{
+		zoomTypeBeforeLauncher = m_zoomtype;
+	}
+
+	if (IsGrenadeLauncherAttached())
+	{
+		isGrenadeLauncherActive = !isGrenadeLauncherActive;
+		SwitchState(eSwitch);
+		return;
+	}
+}
+
+void CWeapon::SetZoomTypeAndParams(u8 zoomType)
+{
+	if (zoomType == 1)
+	{
+		SetZoomType(1);
+		m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Alt || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom_alt", false);
+	}
+
+	if (zoomType == 0)
+	{
+		SetZoomType(0);
+		m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Primary || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom", false);
+	}
 }
 
 void CWeapon::SetZoomType(u8 new_zoom_type)
@@ -1466,6 +1498,15 @@ bool CWeapon::Action(u16 cmd, u32 flags)
 			}
 			return true;
 		}
+	case kCUSTOM16:
+		if (flags & CMD_START && !IsPending())
+		{
+			if (pActor && pActor->is_safemode())
+				pActor->set_safemode(false);
+			
+			ToggleGrenadeLauncher();
+		}
+		return true;
 	break;
 	}
 	return false;
@@ -1854,6 +1895,7 @@ void CWeapon::UpdateAddonsVisibility()
 		{
 			if (!pWeaponVisual->LL_GetBoneVisible(bone_id))
 				pWeaponVisual->LL_SetBoneVisible(bone_id, TRUE, TRUE);
+			isGrenadeLauncherActive = false;
 		}
 		else
 		{

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -494,6 +494,8 @@ protected:
 	Fmatrix m_StrapOffset;
 	bool m_strapped_mode;
 	bool m_can_be_strapped;
+	bool isGrenadeLauncherActive = false;
+	u8 zoomTypeBeforeLauncher = 0;
 	float m_fSafeModeRotateTime;
 	SafemodeAnm m_safemode_anm[2];
 
@@ -530,7 +532,9 @@ protected:
 	virtual void UpdateFireDependencies_internal();
 	void UpdateUIScope();
 	void SwitchZoomType();
+	void ToggleGrenadeLauncher();
     void SetZoomType(u8 new_zoom_type);
+	void SetZoomTypeAndParams(u8 zoomType);
 	float GetHudFov();
 	virtual void UpdatePosition(const Fmatrix& transform); //.
 	virtual void UpdateXForm();

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -28,6 +28,8 @@ CWeaponMagazinedWGrenade::~CWeaponMagazinedWGrenade()
 {
 }
 
+BOOL g_aimmode_remember = 1;
+
 void CWeaponMagazinedWGrenade::Load(LPCSTR section)
 {
 	inherited::Load(section);
@@ -212,7 +214,14 @@ void CWeaponMagazinedWGrenade::PerformSwitchGL()
 {
 	m_bGrenadeMode = !m_bGrenadeMode;
 
-    SetZoomType(m_bGrenadeMode ? 2 : zoomTypeBeforeLauncher);
+	u8 newzoomtype = 0;
+
+	if (g_aimmode_remember)
+	{
+		newzoomtype = zoomTypeBeforeLauncher;
+	}
+
+    SetZoomType(m_bGrenadeMode ? 2 : newzoomtype);
 
 	UpdateUIScope();
 

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -212,7 +212,7 @@ void CWeaponMagazinedWGrenade::PerformSwitchGL()
 {
 	m_bGrenadeMode = !m_bGrenadeMode;
 
-    SetZoomType(m_bGrenadeMode ? 2 : 0);
+    SetZoomType(m_bGrenadeMode ? 2 : zoomTypeBeforeLauncher);
 
 	UpdateUIScope();
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -143,6 +143,7 @@ extern int KEYBOARDBUFFERSIZE;
 extern BOOL print_bone_warnings;
 extern BOOL poltergeist_spawn_corpse_on_death;
 extern BOOL useNewZoomDeltaAlgorithm;
+extern BOOL g_aimmode_remember;
 
 ENGINE_API extern float g_console_sensitive;
 
@@ -2833,4 +2834,9 @@ void CCC_RegisterCommands()
     CMD3(CCC_Mask, "sds_enable", &zoomFlags, SDS);
 
     CMD4(CCC_Float, "zoom_step_count", &n_zoom_step_count, 1.0f, 10.0f);
+
+	// UBGL/Aim mode switch separation
+	// When switching to UBGL the weapon will remember what mode you switched from and will put you back in that mode. 
+	// For example: You were aiming down with a canted sight when you switched to UBGL. When you switch back it will put you back into Canted sight aim and not the scope.
+	CMD4(CCC_Integer, "aimmode_remember", &g_aimmode_remember, 0, 1);
 }


### PR DESCRIPTION
Adds the ability to separately set keybinds for UBGL (Under Barrel Grenade Launcher) and alternat aim switch (Canted, Laser, etc).

Also adds a feature:
- The gun will "remember" what aim mode you were using before switching to the UBGL, so when you switch back it will know what aim mode to place you in.
- Added console (aimmode_remember) command to toggle this feature since the animation can get a bit weird. I can provide example video if requested. The command is also added to options menu.

Example: I have a Scope, Canted sight and UBGL on my gun. I press the alt aim keybind so now I'm aiming down the canted sight. Then I press the key to switch to the UBGL and then I either press the UBGL switch again (to put UBGL away) or press the alt aim keybind and I will end up aiming down in my canted sight again.