### PR TITLE
Modular Attachment System

### DIFF
--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -881,6 +881,10 @@ attachable_hud_item* CHudItem::HudItemData()
 	if (hi && hi->m_parent_hud_item == this)
 		return hi;
 
+	hi = g_player_hud->attached_item(SCOPE_ATTACH_IDX);
+	if (hi && hi->m_parent_hud_item == this)
+		return hi;
+
 	return NULL;
 }
 
@@ -922,3 +926,11 @@ float CHudItem::GetHudFov()
 
 	return m_nearwall_last_hud_fov;
 }
+
+CAnonHudItem::CAnonHudItem() { }
+
+CAnonHudItem::~CAnonHudItem() { }
+
+void CAnonHudItem::UpdateXForm() { }
+
+void CAnonHudItem::on_renderable_Render() { }

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -157,7 +157,7 @@ public:
 
 	virtual void PlayAnimIdle();
 	virtual bool TryPlayAnimBore();
-	bool TryPlayAnimIdle();
+	virtual bool TryPlayAnimIdle();
 	virtual bool MovingAnimAllowedNow() { return true; }
 
 	virtual bool NeedBlendAnm();
@@ -254,4 +254,18 @@ public:
 	virtual CHudItem* cast_hud_item() { return this; }
 	virtual bool PlayAnimCrouchIdleMoving(); //AVO: new crouch idle animation
 	bool HudAnimationExist(LPCSTR anim_name);
+};
+
+class CAnonHudItem : public CHudItem
+{
+private:
+	typedef CHudItem inherited;
+public:
+	CAnonHudItem();
+	virtual ~CAnonHudItem();
+	virtual void UpdateXForm();
+	virtual void on_renderable_Render();
+	virtual bool TryPlayAnimIdle() { return false; }
+	virtual void UpdateHudAdditional(Fmatrix& trans) { }
+	DECLARE_SCRIPT_REGISTER_FUNCTION
 };

--- a/src/xrGame/Scope.cpp
+++ b/src/xrGame/Scope.cpp
@@ -28,3 +28,5 @@ void CScope::script_register(lua_State* L)
 		.def(constructor<>())
 	];
 }
+
+

--- a/src/xrGame/Scope.h
+++ b/src/xrGame/Scope.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "inventory_item_object.h"
+#include "hud_item_object.h"
 #include "script_export_space.h"
 
 class CScope : public CInventoryItemObject

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -685,10 +685,23 @@ void CWeapon::Load(LPCSTR section)
 	m_zoom_params.m_fZoomRotateTime = pSettings->r_float(section, "zoom_rotate_time");
 	m_fZoomRotateModifier = READ_IF_EXISTS(pSettings, r_float, section, "zoom_rotate_modifier", 1);
 	m_zoom_params.m_fBaseZoomFactor = READ_IF_EXISTS(pSettings, r_float, cNameSect(), "scope_zoom_factor", 0);
+	m_modular_attachments = READ_IF_EXISTS(pSettings, r_bool, section, "modular_attachments", false);
 
 	if (m_eScopeStatus == ALife::eAddonAttachable)
 	{
-		if (pSettings->line_exist(section, "scopes_sect"))
+		if (m_modular_attachments)
+		{
+			LPCSTR scope_group = pSettings->r_string(section, "modular_scope_group");
+			LPCSTR scopes = pSettings->r_string(scope_group, "scopes");
+
+			for (int i = 0, count = _GetItemCount(scopes); i < count; ++i)
+			{
+				string128 scope;
+				_GetItem(scopes, i, scope);
+				m_scopes.push_back(scope);
+			}
+		}
+		else if (pSettings->line_exist(section, "scopes_sect"))
 		{
 			LPCSTR str = pSettings->r_string(section, "scopes_sect");
 			for (int i = 0, count = _GetItemCount(str); i < count; ++i)
@@ -1191,6 +1204,9 @@ bool CWeapon::NeedBlendAnm()
 		return true;
 
 	if (IsZoomed() && psDeviceFlags2.test(rsAimSway))
+		return true;
+
+	if (psDeviceFlags2.test(rsAimSway))
 		return true;
 
 	return inherited::NeedBlendAnm();
@@ -1745,6 +1761,8 @@ bool CWeapon::SilencerAttachable()
 #define WPN_SCOPE "wpn_scope"
 #define WPN_SILENCER "wpn_silencer"
 #define WPN_GRENADE_LAUNCHER "wpn_launcher"
+#define WPN_SCOPED_HIDE "wpn_scoped_hide"
+#define WPN_SCOPED_UNHIDE "wpn_scoped_unhide"
 
 void CWeapon::UpdateHUDAddonsVisibility()
 {
@@ -1754,20 +1772,32 @@ void CWeapon::UpdateHUDAddonsVisibility()
 	static shared_str wpn_scope = WPN_SCOPE;
 	static shared_str wpn_silencer = WPN_SILENCER;
 	static shared_str wpn_grenade_launcher = WPN_GRENADE_LAUNCHER;
+	static shared_str wpn_scoped_hide = WPN_SCOPED_HIDE;
+	static shared_str wpn_scoped_unhide = WPN_SCOPED_UNHIDE;
 
 	//.	return;
 
-	if (ScopeAttachable())
-	{
-		HudItemData()->set_bone_visible(wpn_scope, IsScopeAttached());
-	}
-
-	if (m_eScopeStatus == ALife::eAddonDisabled)
-	{
+	if (m_modular_attachments) {
 		HudItemData()->set_bone_visible(wpn_scope, FALSE, TRUE);
+		if (ScopeAttachable())
+		{
+			HudItemData()->set_bone_visible(wpn_scoped_hide, !IsScopeAttached(), TRUE);
+			HudItemData()->set_bone_visible(wpn_scoped_unhide, IsScopeAttached(), TRUE);
+		}
 	}
-	else if (m_eScopeStatus == ALife::eAddonPermanent)
-		HudItemData()->set_bone_visible(wpn_scope, TRUE, TRUE);
+	else {
+		if (ScopeAttachable())
+		{
+			HudItemData()->set_bone_visible(wpn_scope, IsScopeAttached());
+		}
+
+		if (m_eScopeStatus == ALife::eAddonDisabled)
+		{
+			HudItemData()->set_bone_visible(wpn_scope, FALSE, TRUE);
+		}
+		else if (m_eScopeStatus == ALife::eAddonPermanent)
+			HudItemData()->set_bone_visible(wpn_scope, TRUE, TRUE);
+	}
 
 	if (SilencerAttachable())
 	{
@@ -1807,7 +1837,7 @@ void CWeapon::UpdateAddonsVisibility()
 	pWeaponVisual->CalculateBones_Invalidate();
 
 	bone_id = pWeaponVisual->LL_BoneID(wpn_scope);
-	if (ScopeAttachable())
+    if (ScopeAttachable())
 	{
 		if (IsScopeAttached())
 		{
@@ -2286,6 +2316,7 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		OnZoomOut();
 
 	attachable_hud_item* hi = HudItemData();
+	attachable_hud_item* si = g_player_hud->attached_item(SCOPE_ATTACH_IDX);
 	R_ASSERT(hi);
 
 	/*PP.RQ.O = 0;
@@ -2319,7 +2350,25 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 	{
 		Fvector curr_offs, curr_rot;
 
-		if (g_player_hud->m_adjust_mode)
+		if (idx == 1 && m_modular_attachments) {
+			if (si) {
+				curr_offs.set(hi->attach_base_offset_pos());
+				curr_rot.set(hi->attach_base_offset_rot());
+
+				curr_offs.sub(hi->attach_mount_offset_pos());
+				curr_rot.sub(hi->attach_mount_offset_rot());
+
+				curr_offs.add(si->aim_offset_pos());
+				curr_rot.add(si->aim_offset_rot());
+			} else {
+				curr_offs.set(hi->attach_base_offset_pos());
+				curr_rot.set(hi->attach_base_offset_rot());
+
+				curr_offs.add(hi->aim_offset_pos());
+				curr_rot.add(hi->aim_offset_rot());
+			}
+		}
+		else if (g_player_hud->m_adjust_mode)
 		{
 			if (idx == 0)
 			{
@@ -2344,7 +2393,7 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 				curr_rot = hi->m_measures.m_hands_offset[1][idx]; //rot,aim
 			}
 		}
-
+		
 		float factor;
 		
 		if (idx == 4 || last_idx == 4)
@@ -2362,7 +2411,7 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		{
 			Fvector diff;
 			diff.set(curr_offs);
-			diff.sub(m_hud_offset[0]);
+		    diff.sub(m_hud_offset[0]);
 			diff.mul(factor * 2.5f);
 			m_hud_offset[0].add(diff);
 		}

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -88,7 +88,6 @@ public:
 	IC float GetSecondVPZoomFactor() const { return m_zoom_params.m_fSecondVPFovFactor; }
 	IC float IsSecondVPZoomPresent() const { return GetSecondVPZoomFactor() > 0.005f; }
 
-
 	// Up
 	// Magazine system & etc
 	xr_vector<shared_str> bullets_bones;
@@ -318,6 +317,9 @@ public:
 		{
 			return {};
 		}
+		if (m_modular_attachments) {
+			return m_scopes[m_cur_scope];
+		}
 		return pSettings->r_string(m_scopes[m_cur_scope], "scope_name");
 	}
 
@@ -509,6 +511,7 @@ public:
 	Fvector vLoadedFirePoint2;
 	Fvector vLoadedFirePointSilencer;
 	bool m_bCanBeLowered;
+	bool m_modular_attachments;
 
 private:
 	firedeps m_current_firedeps;

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -64,6 +64,11 @@ CWeaponMagazined::CWeaponMagazined(ESoundTypes eSoundType) : CWeapon()
 
 CWeaponMagazined::~CWeaponMagazined()
 {
+	if (m_scopeItem) {
+		g_player_hud->detach_item(m_scopeItem);
+		xr_delete(m_scopeItem);
+	}
+
 	// sounds
 }
 
@@ -615,6 +620,24 @@ void CWeaponMagazined::OnStateSwitch(u32 S, u32 oldState)
 	case eHidden:
 		switch2_Hidden();
 		break;
+	}
+}
+
+void CWeaponMagazined::on_a_hud_attach()
+{
+	inherited::on_a_hud_attach();
+
+	if (m_scopeItem) {
+		g_player_hud->attach_item(m_scopeItem);
+	}
+}
+
+void CWeaponMagazined::on_b_hud_detach()
+{
+	inherited::on_b_hud_detach();
+
+	if (m_scopeItem) {
+		g_player_hud->detach_item(m_scopeItem);
 	}
 }
 
@@ -1250,8 +1273,13 @@ bool CWeaponMagazined::CanAttach(PIItem pIItem)
 		SCOPES_VECTOR_IT it = m_scopes.begin();
 		for (; it != m_scopes.end(); it++)
 		{
-			if (pSettings->r_string((*it), "scope_name") == pIItem->object().cNameSect())
-				return true;
+			if (m_modular_attachments) {
+				if (*it == pIItem->object().cNameSect())
+					return true;
+			} else {
+				if (pSettings->r_string((*it), "scope_name") == pIItem->object().cNameSect())
+					return true;
+			}
 		}
 		return false;
 	}
@@ -1272,16 +1300,24 @@ bool CWeaponMagazined::CanAttach(PIItem pIItem)
 bool CWeaponMagazined::CanDetach(const char* item_section_name)
 {
 	if (m_eScopeStatus == ALife::eAddonAttachable &&
-		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope)) /* &&
+		0 != (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope)
+		&& (!m_modular_attachments || m_scopes[m_cur_scope] == item_section_name)) /* &&
 																		   (m_scopes[cur_scope]->m_sScopeName	== item_section_name))*/
 	{
 		SCOPES_VECTOR_IT it = m_scopes.begin();
 		for (; it != m_scopes.end(); it++)
 		{
-			LPCSTR iter_scope_name = pSettings->r_string((*it), "scope_name");
-			if (!xr_strcmp(iter_scope_name, item_section_name))
-			{
-				return true;
+			if (m_modular_attachments) {
+				if (!xr_strcmp(*it, item_section_name))
+				{
+					return true;
+				}
+			} else {
+				LPCSTR iter_scope_name = pSettings->r_string((*it), "scope_name");
+				if (!xr_strcmp(iter_scope_name, item_section_name))
+				{
+					return true;
+				}
 			}
 		}
 		return false;
@@ -1314,10 +1350,23 @@ bool CWeaponMagazined::Attach(PIItem pIItem, bool b_send_event)
 		SCOPES_VECTOR_IT it = m_scopes.begin();
 		for (; it != m_scopes.end(); it++)
 		{
-			if (pSettings->r_string((*it), "scope_name") == pIItem->object().cNameSect())
-				m_cur_scope = u8(it - m_scopes.begin());
+			if (m_modular_attachments) {
+				if (*it == pIItem->object().cNameSect())
+					m_cur_scope = u8(it - m_scopes.begin());
+			} else {
+				if (pSettings->r_string((*it), "scope_name") == pIItem->object().cNameSect())
+					m_cur_scope = u8(it - m_scopes.begin());
+			}
 		}
 		m_flagsAddOnState |= CSE_ALifeItemWeapon::eWeaponAddonScope;
+		if (m_modular_attachments) {
+			LoadScopeKoeffs();
+			m_scopeItem = xr_new<CAnonHudItem>();
+			m_scopeItem->Load(pIItem->object().cNameSect().c_str());
+			if (HudItemData()) {
+				g_player_hud->attach_item(m_scopeItem);
+			}
+		}
 		result = true;
 	}
 	else if (pSilencer &&
@@ -1361,11 +1410,19 @@ bool CWeaponMagazined::DetachScope(const char* item_section_name, bool b_spawn_i
 	SCOPES_VECTOR_IT it = m_scopes.begin();
 	for (; it != m_scopes.end(); it++)
 	{
-		LPCSTR iter_scope_name = pSettings->r_string((*it), "scope_name");
-		if (!xr_strcmp(iter_scope_name, item_section_name))
-		{
-			m_cur_scope = NULL;
-			detached = true;
+		if (m_modular_attachments) {
+			if (!xr_strcmp(*it, item_section_name))
+			{
+				m_cur_scope = NULL;
+				detached = true;
+			}
+		} else {
+			LPCSTR iter_scope_name = pSettings->r_string((*it), "scope_name");
+			if (!xr_strcmp(iter_scope_name, item_section_name))
+			{
+				m_cur_scope = NULL;
+				detached = true;
+			}
 		}
 	}
 	return detached;
@@ -1382,6 +1439,11 @@ bool CWeaponMagazined::Detach(const char* item_section_name, bool b_spawn_item)
 			return true;
 		}
 		m_flagsAddOnState &= ~CSE_ALifeItemWeapon::eWeaponAddonScope;
+
+		if (m_scopeItem) {
+			g_player_hud->detach_item(m_scopeItem);
+			xr_delete(m_scopeItem);
+		}
 
 		UpdateAddonsVisibility();
 		InitAddons();
@@ -1518,7 +1580,8 @@ void CWeaponMagazined::LoadSilencerKoeffs()
 
 void CWeaponMagazined::LoadScopeKoeffs()
 {
-	if (m_eScopeStatus == ALife::eAddonAttachable)
+	if (m_eScopeStatus == ALife::eAddonAttachable
+		&& (!m_modular_attachments || (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope)))
 	{
 		LPCSTR sect = GetScopeName().c_str();
 		m_scope_koef.cam_dispersion = READ_IF_EXISTS(pSettings, r_float, sect, "cam_dispersion_k", 1.0f);
@@ -1623,6 +1686,9 @@ void CWeaponMagazined::PlayAnimAim()
 void CWeaponMagazined::PlayAnimIdle()
 {
 	if (GetState() != eIdle) return;
+	if (m_scopeItem) {
+		m_scopeItem->PlayAnimIdle();
+	}
 	if (IsZoomed())
 	{
 		PlayAnimAim();

--- a/src/xrGame/WeaponMagazined.h
+++ b/src/xrGame/WeaponMagazined.h
@@ -5,6 +5,7 @@
 #include "ai_sounds.h"
 
 class ENGINE_API CMotionDef;
+class CAnonHudItem;
 
 //размер очереди считается бесконечность
 //заканчиваем стрельбу, только, если кончились патроны
@@ -36,6 +37,8 @@ protected:
 	// General
 	//кадр момента пересчета UpdateSounds
 	u32 dwUpdateSounds_Frame;
+
+	CAnonHudItem* m_scopeItem = NULL;
 protected:
 	virtual void OnMagazineEmpty();
 
@@ -48,6 +51,9 @@ protected:
 
 	virtual void switch2_StartAim();
 	virtual void switch2_EndAim();
+
+	virtual void on_a_hud_attach();
+	virtual void on_b_hud_detach();
 
 	virtual void OnShot();
 	virtual void PlaySoundShot();

--- a/src/xrGame/WeaponUpgrade.cpp
+++ b/src/xrGame/WeaponUpgrade.cpp
@@ -251,6 +251,18 @@ bool CWeapon::install_upgrade_addon(LPCSTR section, bool test)
 
 			if (m_eScopeStatus == ALife::eAddonAttachable)
 			{
+				if (m_modular_attachments)
+				{
+					LPCSTR scope_group = pSettings->r_string(section, "modular_scope_group");
+					LPCSTR scopes = pSettings->r_string(scope_group, "scopes");
+
+					for (int i = 0, count = _GetItemCount(scopes); i < count; ++i)
+					{
+						string128 scope;
+						_GetItem(scopes, i, scope);
+						m_scopes.push_back(scope);
+					}
+				}
 				if (pSettings->line_exist(section, "scopes_sect"))
 				{
 					LPCSTR str = pSettings->r_string(section, "scopes_sect");

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -124,6 +124,54 @@ Fvector& attachable_hud_item::hands_offset_rot()
 	return m_measures.m_hands_offset[1][idx];
 }
 
+Fvector& attachable_hud_item::aim_offset_pos()
+{
+	if (g_player_hud->m_adjust_mode) {
+		if (m_attach_place_idx == SCOPE_ATTACH_IDX)
+			return g_player_hud->m_adjust_offset[0][8];
+		return g_player_hud->m_adjust_offset[0][1];
+	}
+	return m_measures.m_hands_offset[0][1];
+}
+
+Fvector& attachable_hud_item::aim_offset_rot()
+{
+	if (g_player_hud->m_adjust_mode) {
+		if (m_attach_place_idx == SCOPE_ATTACH_IDX)
+			return g_player_hud->m_adjust_offset[1][8];
+		return g_player_hud->m_adjust_offset[1][1];
+	}
+	return m_measures.m_hands_offset[1][1];
+}
+
+Fvector& attachable_hud_item::attach_base_offset_pos()
+{
+	if (g_player_hud->m_adjust_mode)
+		return g_player_hud->m_adjust_offset[0][6];
+	return m_measures.m_hands_offset[0][6];
+}
+
+Fvector& attachable_hud_item::attach_base_offset_rot()
+{
+	if (g_player_hud->m_adjust_mode)
+		return g_player_hud->m_adjust_offset[1][6];
+	return m_measures.m_hands_offset[1][6];
+}
+
+Fvector& attachable_hud_item::attach_mount_offset_pos()
+{
+	if (g_player_hud->m_adjust_mode)
+		return g_player_hud->m_adjust_offset[0][7];
+	return m_measures.m_hands_offset[0][7];
+}
+
+Fvector& attachable_hud_item::attach_mount_offset_rot()
+{
+	if (g_player_hud->m_adjust_mode)
+		return g_player_hud->m_adjust_offset[1][7];
+	return m_measures.m_hands_offset[1][7];
+}
+
 void attachable_hud_item::set_bone_visible(const shared_str& bone_name, BOOL bVisibility, BOOL bSilent)
 {
 	u16 bone_id;
@@ -154,8 +202,29 @@ void attachable_hud_item::update(bool bForce)
 	m_attach_offset.setHPB(ypr.x, ypr.y, ypr.z);
 	m_attach_offset.translate_over(m_parent->m_adjust_mode ? m_parent->m_adjust_obj[0] : m_measures.m_item_attach[0]);
 
-	m_parent->calc_transform(m_attach_place_idx, m_attach_offset, m_item_transform, m_measures.m_bLeadGunLeftHand);
-	m_upd_firedeps_frame = Device.dwFrame;
+	if (m_attach_place_idx == SCOPE_ATTACH_IDX) {
+		m_item_transform.set(m_parent->attached_item(0)->m_item_transform);
+
+		Fmatrix hud_rotation;
+		hud_rotation.identity();
+		hud_rotation.rotateX(m_parent->attached_item(0)->attach_mount_offset_rot().x);
+
+		Fmatrix hud_rotation_y;
+		hud_rotation_y.identity();
+		hud_rotation_y.rotateY(m_parent->attached_item(0)->attach_mount_offset_rot().y);
+		hud_rotation.mulA_43(hud_rotation_y);
+
+		hud_rotation_y.identity();
+		hud_rotation_y.rotateZ(m_parent->attached_item(0)->attach_mount_offset_rot().z);
+		hud_rotation.mulA_43(hud_rotation_y);
+
+		hud_rotation.translate_over(m_parent->attached_item(0)->attach_mount_offset_pos());
+		m_item_transform.mulB_43(hud_rotation);
+	}
+	else {
+		m_parent->calc_transform(m_attach_place_idx, m_attach_offset, m_item_transform, m_measures.m_bLeadGunLeftHand);
+		m_upd_firedeps_frame = Device.dwFrame;
+	}
 
 	IKinematicsAnimated* ka = m_model->dcast_PKinematicsAnimated();
 	if (ka)
@@ -414,6 +483,16 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 
 	//--#SM+# End--
 
+	strconcat(sizeof(val_name), val_name, "attach_base_hud_offset_pos", _prefix);
+	m_hands_offset[0][6] = READ_IF_EXISTS(pSettings, r_fvector3, sect_name, val_name, vZero);
+	strconcat(sizeof(val_name), val_name, "attach_base_hud_offset_rot", _prefix);
+	m_hands_offset[1][6] = READ_IF_EXISTS(pSettings, r_fvector3, sect_name, val_name, vZero);
+
+	strconcat(sizeof(val_name), val_name, "attach_mount_hud_offset_pos", _prefix);
+	m_hands_offset[0][7] = READ_IF_EXISTS(pSettings, r_fvector3, sect_name, val_name, vZero);
+	strconcat(sizeof(val_name), val_name, "attach_mount_hud_offset_rot", _prefix);
+	m_hands_offset[1][7] = READ_IF_EXISTS(pSettings, r_fvector3, sect_name, val_name, vZero);
+
 	m_fFreelookZOffset = READ_IF_EXISTS(pSettings, r_float, sect_name, "freelook_z_offset_mul", 0.f);
 	m_bLeadGunLeftHand = READ_IF_EXISTS(pSettings, r_bool, sect_name, "lh_lead_gun", false);
 }
@@ -503,6 +582,10 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
 		m_model->CalculateBones_Invalidate();
 	}
 
+	if (m_attach_place_idx == SCOPE_ATTACH_IDX) {
+		return ret;
+	}
+
 	R_ASSERT2(m_parent_hud_item, "parent hud item is NULL");
 	CPhysicItem& parent_object = m_parent_hud_item->object();
 	//R_ASSERT2		(parent_object, "object has no parent actor");
@@ -536,6 +619,7 @@ player_hud::player_hud()
 	m_model_2 = nullptr;
 	m_attached_items[0] = nullptr;
 	m_attached_items[1] = nullptr;
+	m_attached_items[SCOPE_ATTACH_IDX] = nullptr;
 	m_attach_offset.identity();
 	m_attach_offset_2.identity();
 	m_transform.identity();
@@ -731,6 +815,9 @@ bool player_hud::render_item_ui_query()
 	if (m_attached_items[1])
 		res |= m_attached_items[1]->render_item_ui_query();
 
+	if (m_attached_items[SCOPE_ATTACH_IDX])
+		res |= m_attached_items[SCOPE_ATTACH_IDX]->render_item_ui_query();
+
 	return res;
 }
 
@@ -745,6 +832,9 @@ void player_hud::render_item_ui()
 
 	if (m_attached_items[1])
 		m_attached_items[1]->render_item_ui();
+
+	if (m_attached_items[SCOPE_ATTACH_IDX])
+		m_attached_items[SCOPE_ATTACH_IDX]->render_item_ui();
 
 	UIRender->CacheSetCullMode(IUIRender::cmCCW);
 	UI().m_currentPointType = bk;
@@ -767,6 +857,9 @@ void player_hud::render_hud()
 
 	if (m_attached_items[1])
 		m_attached_items[1]->render();
+
+	if (m_attached_items[SCOPE_ATTACH_IDX])
+		m_attached_items[SCOPE_ATTACH_IDX]->render();
 
 	if (script_anim_item_model)
 	{
@@ -927,13 +1020,16 @@ void player_hud::update(const Fmatrix& cam_trans)
 
 	if (m_attached_items[0])
 		m_attached_items[0]->m_parent_hud_item->UpdateHudAdditional(trans);
-		
+	
 	if (m_attached_items[1])
 	{
 		m_attached_items[1]->m_parent_hud_item->UpdateHudAdditional(trans_2);
 		if (wep && wep->IsZoomed())
 			trans_2.mulB_43(wep->m_shoot_shake_mat);
 	}
+
+	if (m_attached_items[SCOPE_ATTACH_IDX])
+		m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item->UpdateHudAdditional(trans);
 	
 	if (m_attached_items[0] && !m_attached_items[1])
 		trans_2 = trans;
@@ -1093,6 +1189,9 @@ void player_hud::update(const Fmatrix& cam_trans)
 	if (m_attached_items[1])
 		m_attached_items[1]->update(true);
 
+	if (m_attached_items[SCOPE_ATTACH_IDX])
+		m_attached_items[SCOPE_ATTACH_IDX]->update(true);
+
 	if (script_anim_item_attached && script_anim_item_model)
 		update_script_item();
 
@@ -1134,16 +1233,21 @@ void player_hud::updateMovementLayerState()
 		if (m_attached_items[0] && m_attached_items[0]->m_parent_hud_item->object().cast_weapon())
 			wep = m_attached_items[0]->m_parent_hud_item->object().cast_weapon();
 
-		if (wep && wep->IsZoomed())
+		if (wep && wep->IsZoomed()) {
 			state.bCrouch ? m_movement_layers[eAimCrouch]->Play() : m_movement_layers[eAimWalk]->Play();
-		else if (state.bCrouch)
+		}
+		else if (state.bCrouch) {
 			m_movement_layers[eCrouch]->Play();
-		else if (state.bSprint)
+		}
+		else if (state.bSprint) {
 			m_movement_layers[eSprint]->Play();
-		else if (!isActorAccelerated(pActor->MovingState(), false))
+		}
+		else if (!isActorAccelerated(pActor->MovingState(), false)) {
 			m_movement_layers[eWalk]->Play();
-		else
+		}
+		else {
 			m_movement_layers[eRun]->Play();
+		}
 	}
 }
 
@@ -1660,6 +1764,11 @@ void player_hud::OnMovementChanged(ACTOR_DEFS::EMoveCommand cmd)
 			if (m_attached_items[1]->m_parent_hud_item->GetState() == CHUDState::eIdle)
 				m_attached_items[1]->m_parent_hud_item->PlayAnimIdle();
 		}
+		if (m_attached_items[SCOPE_ATTACH_IDX])
+		{
+			if (m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item->GetState() == CHUDState::eIdle)
+				m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item->PlayAnimIdle();
+		}
 	}
 	else
 	{
@@ -1668,6 +1777,9 @@ void player_hud::OnMovementChanged(ACTOR_DEFS::EMoveCommand cmd)
 
 		if (m_attached_items[1])
 			m_attached_items[1]->m_parent_hud_item->OnMovementChanged(cmd);
+
+		if (m_attached_items[SCOPE_ATTACH_IDX])
+			m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item->OnMovementChanged(cmd);
 	}
 
 	luabind::functor<void> func;

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -5,6 +5,8 @@
 #include "../Include/xrRender/KinematicsAnimated.h"
 #include "actor_defs.h"
 
+#define SCOPE_ATTACH_IDX 2
+
 class player_hud;
 class CHudItem;
 class CMotionDef;
@@ -200,7 +202,7 @@ struct hud_item_measures
 	Flags8 m_prop_flags;
 
 	Fvector m_item_attach[2]; // pos,rot
-	Fvector m_hands_offset[2][6]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2 --#SM+#--
+	Fvector m_hands_offset[2][8]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2, attach_base, attach_mount --#SM+#--
 	Fvector m_strafe_offset[4][2]; // pos,rot,data1,data2/ normal,aim-GL	 --#SM+#--
 
 	u16 m_fire_bone;
@@ -286,6 +288,14 @@ struct attachable_hud_item
 	Fvector& hands_offset_pos();
 	Fvector& hands_offset_rot();
 
+	Fvector& aim_offset_pos();
+	Fvector& aim_offset_rot();
+
+	Fvector& attach_base_offset_pos();
+	Fvector& attach_base_offset_rot();
+	Fvector& attach_mount_offset_pos();
+	Fvector& attach_mount_offset_rot();
+
 	//props
 	u32 m_upd_firedeps_frame;
 	void tune(Ivector values);
@@ -355,6 +365,7 @@ public:
 	{
 		m_attached_items[0] = NULL;
 		m_attached_items[1] = NULL;
+		m_attached_items[SCOPE_ATTACH_IDX] = NULL;
 	};
 
 	Fmatrix m_transform;
@@ -376,13 +387,13 @@ private:
 
 	shared_str m_sect_name;
 	xr_vector<u16> m_ancors;
-	attachable_hud_item* m_attached_items[2];
+	attachable_hud_item* m_attached_items[3];
 	xr_vector<attachable_hud_item*> m_pool;
 	static void _BCL FingerCallback(CBoneInstance* B);
 public:
 	IKinematicsAnimated* m_model;
 	IKinematicsAnimated* m_model_2;
-	Fvector m_adjust_offset[2][6]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2
+	Fvector m_adjust_offset[2][9]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2, attach_base, attach_mount, aim for attach
 	Fvector m_adjust_obj[2]; // pos,rot; used for the item/weapon itself
 	Fvector m_adjust_ui_offset[2]; // pos,rot; used for custom device ui
 	Fvector m_adjust_firepoint_shell[2][2];


### PR DESCRIPTION
An extension for default attachment system which allows to load scope ogf separately from weapon model. It's made with possible extension by adding new attachment types in mind. The code is disabled until "modular_attachments=true" parameter is set in weapons config