### PR TITLE
Russian translation for UBGL/Alt aim separation feature

### DIFF
--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -162,7 +162,9 @@
 	<string id="ui_mm_modded_exes_qol_crash_save_count">
 		<text>Сейвы во время вылетов Кол-во (crash_save_count)</text>
 	</string>
-
+  <string id="ui_mm_modded_exes_qol_aimmode_remember">
+    <text>Режим прицеливания запомнить (aimmode_remember)</text>
+  </string>
 
 	<!-- Sounds -->
 	<string id="ui_mm_menu_sounds">

--- a/gamedata/scripts/modxml_inject_keybinds.script
+++ b/gamedata/scripts/modxml_inject_keybinds.script
@@ -39,5 +39,28 @@ function RegisterUBGLKeybindSeparationInjector()
 
 			xml_obj:insertFromXMLString(new_node)
 		end
+
+		if xml_file_name == [[text\rus\ui_st_keybinding.xml]] then
+			local string_nodes = xml_obj:query("string[id=kb_func] > text")
+
+			if string_nodes[1] then
+				local string_node = string_nodes[1]
+				local target_text = xml_obj:getText(string_node)
+				if target_text then
+
+					local text_overwrite = "Альтернативное прицеливание"
+					xml_obj:setText(string_node, text_overwrite)
+				end
+			end
+
+			local new_node = 
+			[[
+            <string id="kb_switch_ubgl">
+            <text>Подствольник</text>
+            </string>
+			]]
+
+			xml_obj:insertFromXMLString(new_node)
+		end
     end)
 end


### PR DESCRIPTION
Adds russian translation for the text elements added as part of the UBGL/Alt aim separation feature: https://github.com/themrdemonized/xray-monolith/pull/134