### PR TITLE
Fix headlamp position

### DIFF
--- a/src/xrGame/Torch.cpp
+++ b/src/xrGame/Torch.cpp
@@ -213,8 +213,6 @@ void CTorch::LoadLightParams()
 
 		if (!pSettings->section_exist(light_definition.c_str()))
 			light_definition = *m_light_section;
-
-		light_render->set_hud_mode(true); // Enable HUD flag to player headlamp
 	}
 
 	IKinematics* K = smart_cast<IKinematics*>(Visual());


### PR DESCRIPTION
For whatever reason hud_mode was enabled for the actor's headlamp.
Now that hud_mode actually works, the position is wrong with it enabled.