### PR TITLE
Remove hardcoded hud_mode for Flashlight class

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ How to compile exes:
 6. For successful compilation, **the latest build tools with MFC and ATL libraries is required**
 
 ## Changelog
+**2025.03.17**
+* Fix of (https://github.com/themrdemonized/xray-monolith/issues/146)
+
+**2025.03.16**
+* Lucy: Fix headlamp position (https://github.com/themrdemonized/xray-monolith/pull/145)
+
 **2025.03.15**
 * `obj:list_bones(bHud = false)` to return a table of all bones of an object in `[bone_id] = bone_name` form. If `bHud` is true, then use hud model
 * damoldavskiy: Repaired MAS for Script Attachments (https://github.com/themrdemonized/xray-monolith/pull/144)

--- a/gamedata/configs/mod_system_flashlight_definition.ltx
+++ b/gamedata/configs/mod_system_flashlight_definition.ltx
@@ -1,0 +1,2 @@
+![flashlight_definition]
+hud_mode = true

--- a/src/xrGame/Flashlight.cpp
+++ b/src/xrGame/Flashlight.cpp
@@ -60,13 +60,13 @@ BOOL CFlashlight::net_Spawn(CSE_Abstract* DC)
 	float range = pSettings->r_float(m_light_section, (b_r2) ? "range_r2" : "range");
 	light_render->set_color(clr);
 	light_render->set_range(range);
-	light_render->set_hud_mode(true);
+	light_render->set_hud_mode(READ_IF_EXISTS(pSettings, r_bool, m_light_section, "hud_mode", false));
 
 	Fcolor clr_o = pSettings->r_fcolor(m_light_section, (b_r2) ? "omni_color_r2" : "omni_color");
 	float range_o = pSettings->r_float(m_light_section, (b_r2) ? "omni_range_r2" : "omni_range");
 	light_omni->set_color(clr_o);
 	light_omni->set_range(range_o);
-	light_omni->set_hud_mode(true);
+	light_omni->set_hud_mode(READ_IF_EXISTS(pSettings, r_bool, m_light_section, "hud_mode", false));
 
 	light_render->set_cone(deg2rad(pSettings->r_float(m_light_section, "spot_angle")));
 	light_render->set_texture(READ_IF_EXISTS(pSettings, r_string, m_light_section, "spot_texture", (0)));

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -429,7 +429,7 @@ BOOL useSeparateUBGLKeybind = TRUE;
 void CWeapon::SwitchZoomType()
 {
 	if (!useSeparateUBGLKeybind) {
-		if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode || (IsScopeAttached() && READ_IF_EXISTS(pSettings, r_bool, GetScopeName(), "use_alt_aim_hud", false))))
+		if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode || (m_modular_attachments && IsScopeAttached() && READ_IF_EXISTS(pSettings, r_bool, GetScopeName(), "use_alt_aim_hud", false))))
 		{
 			SetZoomType(1);
 			m_zoom_params.m_bUseDynamicZoom = m_zoom_params.m_bUseDynamicZoom_Alt || READ_IF_EXISTS(pSettings, r_bool, cNameSect(), "scope_dynamic_zoom_alt", false);
@@ -450,7 +450,7 @@ void CWeapon::SwitchZoomType()
 			ToggleGrenadeLauncher();
 		}
 
-		if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode || (IsScopeAttached() && READ_IF_EXISTS(pSettings, r_bool, GetScopeName(), "use_alt_aim_hud", false))))
+		if (m_zoomtype == 0 && (m_altAimPos || g_player_hud->m_adjust_mode || (m_modular_attachments && IsScopeAttached() && READ_IF_EXISTS(pSettings, r_bool, GetScopeName(), "use_alt_aim_hud", false))))
 		{
 			SetZoomTypeAndParams(1);
 		} else if (m_zoomtype == 1)


### PR DESCRIPTION
`hud_mode` is no longer hardcoded to be enabled in the Flashlight class.
Instead it's turned off by default and can be turned on by adding `hud_mode = true` to your flashlight definition section.

Optionally include the config file to keep hud_mode for the flashlight item