### PR TITLE
Scripted game_object shader/texture changing

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -385,6 +385,31 @@
         function add_attachment(number, string);
         function get_attachment(number);
         function remove_attachment(number);
+		
+		// Shader/Textures
+		function get_shaders(bool)
+		function set_shader(number, string, string, bool)
+		
+		get_shaders(hud_mode)
+		hud_mode is optional and will default to false
+		returns a table of submesh IDs with subtables containing the shader and texture names of all submeshes of a model, table looks like this for example:
+		{
+		1 = 
+			{
+			texture = "act\act_face_mask_03",
+			shader = "models\model_pn",
+			},
+		2 = 
+			{
+			texture = "act\act_stalker_cskysun_2",
+			shader = "models\model_pn",
+			},
+		},
+		
+		set_shader(id, shader, texture, hud_mode) can assign a new shader/texture to the submesh ID
+		id can be -1 to apply the shader/texture to all submeshes at once
+		shader/texture can be nil if you only want to apply one of them
+		hud_mode is optional and will default to false
     }
 
     class CArtefact : CGameObject {

--- a/src/Include/xrRender/RenderVisual.h
+++ b/src/Include/xrRender/RenderVisual.h
@@ -7,10 +7,16 @@ class IKinematicsAnimated;
 class IParticleCustom;
 struct vis_data;
 
+enum IRenderVisualFlags
+{
+	eIgnoreOptimization = (1 << 0),
+	eNoShadow = (1 << 1),
+};
+
 class IRenderVisual
 {
 public:
-	IRenderVisual() { _ignore_optimization = false; }
+	IRenderVisual() { flags.zero(); }
 
 	virtual ~IRenderVisual()
 	{
@@ -19,15 +25,21 @@ public:
 	virtual vis_data& _BCL getVisData() = 0;
 	virtual u32 getType() = 0;
 
-	bool _ignore_optimization;
+	Flags16 flags;
 
 #ifdef DEBUG
 	virtual shared_str	_BCL	getDebugName() = 0;
 #endif
+	virtual LPCSTR _BCL getDebugShader() { return nullptr; }
+	virtual LPCSTR _BCL getDebugTexture() { return nullptr; }
 
+	virtual xr_vector<IRenderVisual*>* get_children() { return nullptr; };
+
+	virtual void SetShaderTexture(char* shader, LPCSTR texture) {};
 	virtual void MarkAsHot(bool is_hot) {};				//--DSR-- HeatVision
 	virtual void MarkAsGlowing(bool is_glowing) {};		//--DSR-- SilencerOverheat
 
+	virtual IRenderVisual* _BCL dcast_RenderVisual() { return this; }
 	virtual IKinematics* _BCL dcast_PKinematics() { return 0; }
 	virtual IKinematicsAnimated* dcast_PKinematicsAnimated() { return 0; }
 	virtual IParticleCustom* dcast_ParticleCustom() { return 0; }

--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -43,6 +43,7 @@ void dxRender_Visual::Release()
 void dxRender_Visual::Load(const char* N, IReader* data, u32)
 {
 	dbg_name = N;
+	skinning = ::Render->m_skinning;
 
 	// header
 	VERIFY(data);
@@ -67,7 +68,7 @@ void dxRender_Visual::Load(const char* N, IReader* data, u32)
 		string256 fnT, fnS;
 		data->r_stringZ(fnT, sizeof(fnT));
 		data->r_stringZ(fnS, sizeof(fnS));
-		shader.create(fnS, fnT);
+		SetShaderTexture(fnS, fnT);
 	}
 
 	// desc
@@ -116,6 +117,32 @@ void dxRender_Visual::MarkAsGlowing(bool is_glowing)
 }
 //--DSR-- SilencerOverheat_end
 
+void dxRender_Visual::SetShaderTexture(char* s_shader, LPCSTR s_texture)
+{
+	if (s_shader && strlen(s_shader))
+	{
+		char* no_shadow = strstr(s_shader, "$no_shadows");
+
+		if (no_shadow)
+		{
+			flags.set(IRenderVisualFlags::eNoShadow, TRUE);
+			*no_shadow = 0;
+		}
+		else
+			flags.set(IRenderVisualFlags::eNoShadow, FALSE);
+
+		dbg_shader = s_shader;
+	}
+
+	if (s_texture && strlen(s_texture))
+	{
+		dbg_texture = s_texture;
+	}
+
+	::Render->m_skinning = skinning;
+	shader.create(*dbg_shader, *dbg_texture);
+}
+
 #define PCOPY(a)	a = pFrom->a
 
 void dxRender_Visual::Copy(dxRender_Visual* pFrom)
@@ -126,5 +153,9 @@ void dxRender_Visual::Copy(dxRender_Visual* pFrom)
 #ifdef _EDITOR
 	PCOPY(desc);
 #endif
+	PCOPY(flags);
 	PCOPY(dbg_name);
+	PCOPY(dbg_shader);
+	PCOPY(dbg_texture);
+	PCOPY(skinning);
 }

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -49,12 +49,17 @@ public:
     ogf_desc					desc		;
 #endif
 	shared_str					dbg_name	;
+	shared_str					dbg_shader	;
+	shared_str					dbg_texture	;
 	virtual shared_str	_BCL	getDebugName() { return dbg_name; }
+	virtual LPCSTR _BCL			getDebugShader() { return *dbg_shader; }
+	virtual LPCSTR _BCL			getDebugTexture() { return *dbg_texture; }
 public:
 	// Common data for rendering
 	u32 Type; // visual's type
 	vis_data vis; // visibility-data
 	ref_shader shader; // pipe state, shared
+	s32 skinning;
 
 	virtual void Render(float LOD)
 	{
@@ -74,6 +79,8 @@ public:
 	//	virtual	CKinematics*		dcast_PKinematics			()				{ return 0;	}
 	//	virtual	CKinematicsAnimated*dcast_PKinematicsAnimated	()				{ return 0;	}
 	//	virtual IParticleCustom*	dcast_ParticleCustom		()				{ return 0;	}
+
+	virtual void SetShaderTexture(char* shader, LPCSTR texture);
 
 	virtual vis_data& _BCL getVisData() { return vis; }
 	virtual u32 getType() { return Type; }

--- a/src/Layers/xrRender/FHierrarhyVisual.cpp
+++ b/src/Layers/xrRender/FHierrarhyVisual.cpp
@@ -37,7 +37,7 @@ void FHierrarhyVisual::Release()
 	if (!bDontDelete)
 	{
 		for (u32 i = 0; i < children.size(); i++)
-			children[i]->Release();
+			((dxRender_Visual*)children[i])->Release();
 	}
 }
 
@@ -55,7 +55,7 @@ void FHierrarhyVisual::Load(const char* N, IReader* data, u32 dwFlags)
 			THROW;
 #else
 			u32 ID = data->r_u32();
-			children[i] = (dxRender_Visual*)::Render->getVisual(ID);
+			children[i] = ::Render->getVisual(ID);
 #endif
 		}
 		bDontDelete = TRUE;
@@ -75,7 +75,7 @@ void FHierrarhyVisual::Load(const char* N, IReader* data, u32 dwFlags)
 					xr_strcpy(short_name, N);
 					if (strext(short_name)) *strext(short_name) = 0;
 					strconcat(sizeof(name_load), name_load, short_name, ":", itoa(count, num, 10));
-					children.push_back((dxRender_Visual*)::Render->model_CreateChild(name_load, O));
+					children.push_back(::Render->model_CreateChild(name_load, O));
 					O->close();
 					O = OBJ->open_chunk(count);
 				}
@@ -109,7 +109,7 @@ void FHierrarhyVisual::Copy(dxRender_Visual* pSrc)
 	children.reserve(pFrom->children.size());
 	for (u32 i = 0; i < pFrom->children.size(); i++)
 	{
-		dxRender_Visual* p = (dxRender_Visual*)::Render->model_Duplicate(pFrom->children[i]);
+		IRenderVisual* p = ::Render->model_Duplicate(pFrom->children[i]);
 		children.push_back(p);
 	}
 	bDontDelete = FALSE;

--- a/src/Layers/xrRender/FHierrarhyVisual.h
+++ b/src/Layers/xrRender/FHierrarhyVisual.h
@@ -12,7 +12,7 @@
 class FHierrarhyVisual : public dxRender_Visual
 {
 public:
-	xr_vector<dxRender_Visual*> children;
+	xr_vector<IRenderVisual*> children;
 	BOOL bDontDelete;
 public:
 	FHierrarhyVisual();
@@ -25,6 +25,8 @@ public:
 	//--DSR-- HeatVision_start
 	virtual void MarkAsHot(bool is_hot);
 	//--DSR-- HeatVision_end
+
+	virtual xr_vector<IRenderVisual*>* get_children() { return &children; };
 };
 
 #endif //FHierrarhyVisualH

--- a/src/Layers/xrRender/ModelPool.cpp
+++ b/src/Layers/xrRender/ModelPool.cpp
@@ -171,9 +171,6 @@ void CModelPool::Instance_Register(LPCSTR N, dxRender_Visual* V)
 
 void CModelPool::Destroy()
 {
-	// Pool
-	Pool.clear();
-
 	// Registry
 	while (!Registry.empty())
 	{
@@ -239,39 +236,22 @@ dxRender_Visual* CModelPool::Create(const char* name, IReader* data)
 	xr_strcpy(low_name, name);
 	strlwr(low_name);
 	if (strext(low_name)) *strext(low_name) = 0;
-	//	Msg						("-CREATE %s",low_name);
-
-	// 0. Search POOL
-	POOL_IT it = Pool.find(low_name);
-	if (it != Pool.end())
+	
+	// 1. Search for already loaded model (reference, base model)
+	dxRender_Visual* Base = Instance_Find(low_name);
+	if (0 == Base)
 	{
-		// 1. Instance found
-		dxRender_Visual* Model = it->second;
-		Model->Spawn();
-		Pool.erase(it);
-		return Model;
+		// 2. If not found
+		bAllowChildrenDuplicate = FALSE;
+		if (data) Base = Instance_Load(low_name, data, TRUE);
+		else Base = Instance_Load(low_name, TRUE);
+		bAllowChildrenDuplicate = TRUE;
 	}
-	else
-	{
-		// 1. Search for already loaded model (reference, base model)
-		dxRender_Visual* Base = Instance_Find(low_name);
 
-		if (0 == Base)
-		{
-			// 2. If not found
-			bAllowChildrenDuplicate = FALSE;
-			if (data) Base = Instance_Load(low_name, data,TRUE);
-			else Base = Instance_Load(low_name,TRUE);
-			bAllowChildrenDuplicate = TRUE;
-#ifdef _EDITOR
-			if (!Base)		return 0;
-#endif
-		}
-		// 3. If found - return (cloned) reference
-		dxRender_Visual* Model = Instance_Duplicate(Base);
-		Registry.insert(mk_pair(Model, low_name));
-		return Model;
-	}
+	// 3. If found - return (cloned) reference
+	dxRender_Visual* Model = Instance_Duplicate(Base);
+	Registry.insert(mk_pair(Model, low_name));
+	return Model;
 }
 
 dxRender_Visual* CModelPool::CreateChild(LPCSTR name, IReader* data)
@@ -302,25 +282,7 @@ void CModelPool::DeleteInternal(dxRender_Visual* & V, BOOL bDiscard)
 	VERIFY(!g_bRendering);
 	if (!V) return;
 	V->Depart();
-	if (bDiscard || bForceDiscard)
-	{
-		Discard(V, TRUE);
-	}
-	else
-	{
-		//
-		REGISTRY_IT it = Registry.find(V);
-		if (it != Registry.end())
-		{
-			// Registry entry found - move it to pool
-			Pool.insert(mk_pair(it->second, V));
-		}
-		else
-		{
-			// Registry entry not-found - just special type of visual / particles / etc.
-			xr_delete(V);
-		}
-	}
+	Discard(V, bDiscard || bForceDiscard);
 	V = NULL;
 }
 
@@ -329,20 +291,18 @@ void CModelPool::Delete(dxRender_Visual* & V, BOOL bDiscard)
 	if (NULL == V) return;
 	if (g_bRendering)
 	{
-		VERIFY(!bDiscard);
-		ModelsToDelete.push_back(V);
+		ModelsToDelete.insert(mk_pair(V, !!bDiscard));
 	}
 	else
 	{
 		DeleteInternal(V, bDiscard);
 	}
-	V = NULL;
 }
 
 void CModelPool::DeleteQueue()
 {
-	for (u32 it = 0; it < ModelsToDelete.size(); it++)
-		DeleteInternal(ModelsToDelete[it]);
+	for (xr_map<dxRender_Visual*, bool>::iterator it = ModelsToDelete.begin(); it != ModelsToDelete.end(); it++)
+		DeleteInternal((dxRender_Visual*)it->first, it->second);
 	ModelsToDelete.clear();
 }
 
@@ -352,8 +312,6 @@ void CModelPool::Discard(dxRender_Visual* & V, BOOL b_complete)
 	REGISTRY_IT it = Registry.find(V);
 	if (it != Registry.end())
 	{
-		// Pool - OK
-
 		// Base
 		const shared_str& name = it->second;
 		xr_vector<ModelDef>::iterator I = Models.begin();
@@ -387,7 +345,6 @@ void CModelPool::Discard(dxRender_Visual* & V, BOOL b_complete)
 		}
 		// Registry
 		xr_delete(V);
-		//.		xr_free			(name);
 		Registry.erase(it);
 	}
 	else
@@ -418,17 +375,6 @@ void CModelPool::Prefetch_One(LPCSTR N)
 {
 	dxRender_Visual* V = Create(N);
 	Delete(V,FALSE);
-}
-
-void CModelPool::ClearPool(BOOL b_complete)
-{
-	POOL_IT _I = Pool.begin();
-	POOL_IT _E = Pool.end();
-	for (; _I != _E; _I++)
-	{
-		Discard(_I->second, b_complete);
-	}
-	Pool.clear();
 }
 
 dxRender_Visual* CModelPool::CreatePE(PS::CPEDef* source)
@@ -463,7 +409,6 @@ void CModelPool::dump()
 	Msg("--- models: %d, mem usage: %d Kb ", k, sz / 1024);
 	sz = 0;
 	k = 0;
-	int free_cnt = 0;
 	for (REGISTRY_IT it = Registry.begin(); it != Registry.end(); it++)
 	{
 		CKinematics* K = PCKinematics((dxRender_Visual*)it->first);
@@ -472,12 +417,10 @@ void CModelPool::dump()
 		{
 			u32 cur = K->mem_usage(true);
 			sz += cur;
-			bool b_free = (Pool.find(it->second) != Pool.end());
-			if (b_free) ++free_cnt;
-			Msg("#%3d: [%s] [%5d Kb] - %s", k++, (b_free) ? "free" : "used", cur / 1024, it->second.c_str());
+			Msg("#%3d: [%5d Kb] - %s", k++, cur / 1024, it->second.c_str());
 		}
 	}
-	Msg("--- instances: %d, free %d, mem usage: %d Kb ", k, free_cnt, sz / 1024);
+	Msg("--- instances: %d, mem usage: %d Kb ", k, sz / 1024);
 	Log("--- model pool --- end.");
 }
 

--- a/src/Layers/xrRender/ModelPool.h
+++ b/src/Layers/xrRender/ModelPool.h
@@ -18,14 +18,6 @@ class ECORE_API CModelPool
 private:
 	friend class CRender;
 
-	struct str_pred : public std::binary_function<const shared_str&, const shared_str&, bool>
-	{
-		IC bool operator()(const shared_str& x, const shared_str& y) const
-		{
-			return xr_strcmp(x, y) < 0;
-		}
-	};
-
 	struct ModelDef
 	{
 		shared_str name;
@@ -39,15 +31,12 @@ private:
 		}
 	};
 
-	typedef xr_multimap<shared_str, dxRender_Visual*, str_pred> POOL;
-	typedef POOL::iterator POOL_IT;
 	typedef xr_map<dxRender_Visual*, shared_str> REGISTRY;
 	typedef REGISTRY::iterator REGISTRY_IT;
 private:
 	xr_vector<ModelDef> Models; // Reference / Base
-	xr_vector<dxRender_Visual*> ModelsToDelete; // 
+	xr_map<dxRender_Visual*, bool> ModelsToDelete; // 
 	REGISTRY Registry; // Just pairing of pointer / Name
-	POOL Pool; // Unused / Inactive
 	BOOL bLogging;
 	BOOL bForceDiscard;
 	BOOL bAllowChildrenDuplicate;
@@ -76,7 +65,6 @@ public:
 
 	void Prefetch();
 	void Prefetch_One(LPCSTR N);
-	void ClearPool(BOOL b_complete);
 
 	void dump();
 

--- a/src/Layers/xrRender/SkeletonCustom.cpp
+++ b/src/Layers/xrRender/SkeletonCustom.cpp
@@ -585,7 +585,7 @@ void CKinematics::Visibility_Update()
 		if (!_c->has_visible_bones())
 		{
 			// move into invisible list
-			children_invisible.push_back(children[c_it]);
+			children_invisible.push_back((dxRender_Visual*)children[c_it]);
 			swap(children[c_it], children.back());
 			children.pop_back();
 			Update_Visibility = TRUE;

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -814,96 +814,21 @@ IC bool IsValuableToRender(dxRender_Visual* pVisual, bool isStatic, bool sm, Fma
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void CRender::add_leafs_Dynamic(dxRender_Visual* pVisual, bool ignore)
+void CRender::add_leafs_Dynamic(dxRender_Visual* pVisual)
 {
 	if (!pVisual)
 		return;
 
-	if (!ignore && !IsValuableToRender(pVisual, false, phase == 1, *val_pTransform))
+	Flags16& flags = pVisual->flags;
+
+	if (phase != PHASE_NORMAL && !!flags.test(IRenderVisualFlags::eNoShadow))
+		return;
+
+	if (!!!flags.test(IRenderVisualFlags::eIgnoreOptimization) && !IsValuableToRender(pVisual, false, phase == 1, *val_pTransform))
 		return;
 
 	// Visual is 100% visible - simply add it
-	xr_vector<dxRender_Visual*>::iterator I, E; // it may be useful for 'hierrarhy' visual
-
-	switch (pVisual->Type)
-	{
-	case MT_PARTICLE_GROUP:
-		{
-			// Add all children, doesn't perform any tests
-			PS::CParticleGroup* pG = (PS::CParticleGroup*)pVisual;
-			for (PS::CParticleGroup::SItemVecIt i_it = pG->items.begin(); i_it != pG->items.end(); ++i_it)
-			{
-				PS::CParticleGroup::SItem& I = *i_it;
-				if (I._effect) add_leafs_Dynamic(I._effect, ignore);
-				for (xr_vector<dxRender_Visual*>::iterator pit = I._children_related.begin(); pit != I
-				                                                                                     ._children_related.
-				                                                                                     end(); ++pit)
-					add_leafs_Dynamic(*pit, ignore);
-				for (xr_vector<dxRender_Visual*>::iterator pit = I._children_free.begin(); pit != I._children_free.end()
-				     ; ++pit)
-					add_leafs_Dynamic(*pit, ignore);
-			}
-		}
-		return;
-	case MT_HIERRARHY:
-		{
-			// Add all children, doesn't perform any tests
-			FHierrarhyVisual* pV = (FHierrarhyVisual*)pVisual;
-			I = pV->children.begin();
-			E = pV->children.end();
-			for (; I != E; ++I) add_leafs_Dynamic(*I, ignore);
-		}
-		return;
-	case MT_SKELETON_ANIM:
-	case MT_SKELETON_RIGID:
-		{
-			// Add all children, doesn't perform any tests
-			CKinematics* pV = (CKinematics*)pVisual;
-			BOOL _use_lod = FALSE;
-			if (pV->m_lod)
-			{
-				Fvector Tpos;
-				float D;
-				val_pTransform->transform_tiny(Tpos, pV->vis.sphere.P);
-				float ssa = CalcSSA(D, Tpos, pV->vis.sphere.R / 2.f); // assume dynamics never consume full sphere
-				if (ssa < r_ssaLOD_A) _use_lod = TRUE;
-			}
-			if (_use_lod)
-			{
-				add_leafs_Dynamic(pV->m_lod, ignore);
-			}
-			else
-			{
-				pV->CalculateBones(TRUE);
-				pV->CalculateWallmarks(); //. bug?
-				I = pV->children.begin();
-				E = pV->children.end();
-				for (; I != E; ++I) add_leafs_Dynamic(*I, ignore);
-			}
-		}
-		return;
-	default:
-		{
-			// General type of visual
-			// Calculate distance to it's center
-			Fvector Tpos;
-			val_pTransform->transform_tiny(Tpos, pVisual->vis.sphere.P);
-			r_dsgraph_insert_dynamic(pVisual, Tpos);
-		}
-		return;
-	}
-}
-
-void CRender::add_leafs_Static(dxRender_Visual* pVisual)
-{
-	if (!HOM.visible(pVisual->vis))
-		return;
-
-	if (!pVisual->_ignore_optimization && !IsValuableToRender(pVisual, true, phase == 1, *val_pTransform))
-		return;
-
-	// Visual is 100% visible - simply add it
-	xr_vector<dxRender_Visual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
+	xr_vector<IRenderVisual*>::iterator I, E; // it may be useful for 'hierrarhy' visual
 
 	switch (pVisual->Type)
 	{
@@ -931,7 +856,92 @@ void CRender::add_leafs_Static(dxRender_Visual* pVisual)
 			FHierrarhyVisual* pV = (FHierrarhyVisual*)pVisual;
 			I = pV->children.begin();
 			E = pV->children.end();
-			for (; I != E; ++I) add_leafs_Static(*I);
+			for (; I != E; ++I) add_leafs_Dynamic((dxRender_Visual*)*I);
+		}
+		return;
+	case MT_SKELETON_ANIM:
+	case MT_SKELETON_RIGID:
+		{
+			// Add all children, doesn't perform any tests
+			CKinematics* pV = (CKinematics*)pVisual;
+			BOOL _use_lod = FALSE;
+			if (pV->m_lod)
+			{
+				Fvector Tpos;
+				float D;
+				val_pTransform->transform_tiny(Tpos, pV->vis.sphere.P);
+				float ssa = CalcSSA(D, Tpos, pV->vis.sphere.R / 2.f); // assume dynamics never consume full sphere
+				if (ssa < r_ssaLOD_A) _use_lod = TRUE;
+			}
+			if (_use_lod)
+			{
+				add_leafs_Dynamic(pV->m_lod);
+			}
+			else
+			{
+				pV->CalculateBones(TRUE);
+				pV->CalculateWallmarks(); //. bug?
+				I = pV->children.begin();
+				E = pV->children.end();
+				for (; I != E; ++I) add_leafs_Dynamic((dxRender_Visual*)*I);
+			}
+		}
+		return;
+	default:
+		{
+			// General type of visual
+			// Calculate distance to it's center
+			Fvector Tpos;
+			val_pTransform->transform_tiny(Tpos, pVisual->vis.sphere.P);
+			r_dsgraph_insert_dynamic(pVisual, Tpos);
+		}
+		return;
+	}
+}
+
+void CRender::add_leafs_Static(dxRender_Visual* pVisual)
+{
+	if (!HOM.visible(pVisual->vis))
+		return;
+
+	Flags16& flags = pVisual->dcast_RenderVisual()->flags;
+
+	if (phase != PHASE_NORMAL && !!flags.test(IRenderVisualFlags::eNoShadow))
+		return;
+
+	if (!!!flags.test(IRenderVisualFlags::eIgnoreOptimization) && !IsValuableToRender(pVisual, true, phase == 1, *val_pTransform))
+		return;
+
+	// Visual is 100% visible - simply add it
+	xr_vector<IRenderVisual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
+
+	switch (pVisual->Type)
+	{
+	case MT_PARTICLE_GROUP:
+		{
+			// Add all children, doesn't perform any tests
+			PS::CParticleGroup* pG = (PS::CParticleGroup*)pVisual;
+			for (PS::CParticleGroup::SItemVecIt i_it = pG->items.begin(); i_it != pG->items.end(); ++i_it)
+			{
+				PS::CParticleGroup::SItem& I = *i_it;
+				if (I._effect) add_leafs_Dynamic(I._effect);
+				for (xr_vector<dxRender_Visual*>::iterator pit = I._children_related.begin(); pit != I
+				                                                                                     ._children_related.
+				                                                                                     end(); ++pit)
+					add_leafs_Dynamic(*pit);
+				for (xr_vector<dxRender_Visual*>::iterator pit = I._children_free.begin(); pit != I._children_free.end()
+				     ; ++pit)
+					add_leafs_Dynamic(*pit);
+			}
+		}
+		return;
+	case MT_HIERRARHY:
+		{
+			// Add all children, doesn't perform any tests
+			FHierrarhyVisual* pV = (FHierrarhyVisual*)pVisual;
+			I = pV->children.begin();
+			E = pV->children.end();
+			for (; I != E; ++I) add_leafs_Static((dxRender_Visual*)*I);
 		}
 		return;
 	case MT_SKELETON_ANIM:
@@ -942,7 +952,7 @@ void CRender::add_leafs_Static(dxRender_Visual* pVisual)
 			pV->CalculateBones(TRUE);
 			I = pV->children.begin();
 			E = pV->children.end();
-			for (; I != E; ++I) add_leafs_Static(*I);
+			for (; I != E; ++I) add_leafs_Static((dxRender_Visual*)*I);
 		}
 		return;
 	case MT_LOD:
@@ -967,7 +977,7 @@ void CRender::add_leafs_Static(dxRender_Visual* pVisual)
 				// Add all children, doesn't perform any tests
 				I = pV->children.begin();
 				E = pV->children.end();
-				for (; I != E; ++I) add_leafs_Static(*I);
+				for (; I != E; ++I) add_leafs_Static((dxRender_Visual*)*I);
 			}
 		}
 		return;
@@ -992,7 +1002,12 @@ void CRender::add_leafs_Static(dxRender_Visual* pVisual)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 BOOL CRender::add_Dynamic(dxRender_Visual* pVisual, u32 planes)
 {
-	if (!pVisual->_ignore_optimization && !IsValuableToRender(pVisual, false, phase == 1, *val_pTransform))
+	Flags16& flags = pVisual->dcast_RenderVisual()->flags;
+
+	if (phase != PHASE_NORMAL && !!flags.test(IRenderVisualFlags::eNoShadow))
+		return FALSE;
+
+	if (!!!flags.test(IRenderVisualFlags::eIgnoreOptimization) && !IsValuableToRender(pVisual, false, phase == 1, *val_pTransform))
 		return FALSE;
 
 	// Check frustum visibility and calculate distance to visual's center
@@ -1004,7 +1019,7 @@ BOOL CRender::add_Dynamic(dxRender_Visual* pVisual, u32 planes)
 	if (fcvNone == VIS) return FALSE;
 
 	// If we get here visual is visible or partially visible
-	xr_vector<dxRender_Visual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
+	xr_vector<IRenderVisual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
 
 	switch (pVisual->Type)
 	{
@@ -1052,11 +1067,11 @@ BOOL CRender::add_Dynamic(dxRender_Visual* pVisual, u32 planes)
 			E = pV->children.end();
 			if (fcvPartial == VIS)
 			{
-				for (; I != E; ++I) add_Dynamic(*I, planes);
+				for (; I != E; ++I) add_Dynamic((dxRender_Visual*)*I, planes);
 			}
 			else
 			{
-				for (; I != E; ++I) add_leafs_Dynamic(*I);
+				for (; I != E; ++I) add_leafs_Dynamic((dxRender_Visual*)*I);
 			}
 		}
 		break;
@@ -1084,7 +1099,7 @@ BOOL CRender::add_Dynamic(dxRender_Visual* pVisual, u32 planes)
 				pV->CalculateWallmarks(); //. bug?
 				I = pV->children.begin();
 				E = pV->children.end();
-				for (; I != E; ++I) add_leafs_Dynamic(*I);
+				for (; I != E; ++I) add_leafs_Dynamic((dxRender_Visual*)*I);
 			}
 			/*
 			I = pV->children.begin		();
@@ -1109,7 +1124,12 @@ BOOL CRender::add_Dynamic(dxRender_Visual* pVisual, u32 planes)
 
 void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
 {
-	if (!pVisual->_ignore_optimization && !IsValuableToRender(pVisual, true, phase == 1, *val_pTransform))
+	Flags16& flags = pVisual->dcast_RenderVisual()->flags;
+
+	if (phase != PHASE_NORMAL && !!flags.test(IRenderVisualFlags::eNoShadow))
+		return;
+
+	if (!!!flags.test(IRenderVisualFlags::eIgnoreOptimization) && !IsValuableToRender(pVisual, true, phase == 1, *val_pTransform))
 		return;
 
 	// Check frustum visibility and calculate distance to visual's center
@@ -1123,7 +1143,7 @@ void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
 		return;
 
 	// If we get here visual is visible or partially visible
-	xr_vector<dxRender_Visual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
+	xr_vector<IRenderVisual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
 
 	switch (pVisual->Type)
 	{
@@ -1170,16 +1190,16 @@ void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
 			FHierrarhyVisual* pV = (FHierrarhyVisual*)pVisual;
 			if (VIS == fcvPartial)
 			{
-				for (dxRender_Visual* childRenderable : pV->children)
+				for (IRenderVisual* childRenderable : pV->children)
 				{
-					add_Static(childRenderable, planes);
+					add_Static((dxRender_Visual*)childRenderable, planes);
 				}
 			}
 			else
 			{
-				for (dxRender_Visual* childRenderable : pV->children)
+				for (IRenderVisual* childRenderable : pV->children)
 				{
-					add_leafs_Static(childRenderable);
+					add_leafs_Static((dxRender_Visual*)childRenderable);
 				}
 			}
 		}
@@ -1192,16 +1212,16 @@ void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
 			pV->CalculateBones(TRUE);
 			if (VIS == fcvPartial)
 			{
-				for (dxRender_Visual* childRenderable : pV->children)
+				for (IRenderVisual* childRenderable : pV->children)
 				{
-					add_Static(childRenderable, planes);
+					add_Static((dxRender_Visual*)childRenderable, planes);
 				}
 			}
 			else
 			{
-				for (dxRender_Visual* childRenderable : pV->children)
+				for (IRenderVisual* childRenderable : pV->children)
 				{
-					add_leafs_Static(childRenderable);
+					add_leafs_Static((dxRender_Visual*)childRenderable);
 				}
 			}
 		}
@@ -1226,9 +1246,9 @@ void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
 #endif
 			{
 				// Add all children, perform tests
-				for (dxRender_Visual* childRenderable : pV->children)
+				for (IRenderVisual* childRenderable : pV->children)
 				{
-					add_leafs_Static(childRenderable);
+					add_leafs_Static((dxRender_Visual*)childRenderable);
 				}
 			}
 		}

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -944,7 +944,7 @@ void R_dsgraph_structure::r_dsgraph_render_R1_box(IRender_Sector* _S, Fbox& BB, 
 		dxRender_Visual* V = lstVisuals[test];
 
 		// Visual is 100% visible - simply add it
-		xr_vector<dxRender_Visual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
+		xr_vector<IRenderVisual*>::iterator I, E; // it may be usefull for 'hierrarhy' visuals
 
 		switch (V->Type)
 		{
@@ -956,7 +956,7 @@ void R_dsgraph_structure::r_dsgraph_render_R1_box(IRender_Sector* _S, Fbox& BB, 
 				E = pV->children.end();
 				for (; I != E; ++I)
 				{
-					dxRender_Visual* T = *I;
+					dxRender_Visual* T = (dxRender_Visual*)*I;
 					if (BB.intersect(T->vis.box)) lstVisuals.push_back(T);
 				}
 			}
@@ -971,7 +971,7 @@ void R_dsgraph_structure::r_dsgraph_render_R1_box(IRender_Sector* _S, Fbox& BB, 
 				E = pV->children.end();
 				for (; I != E; ++I)
 				{
-					dxRender_Visual* T = *I;
+					dxRender_Visual* T = (dxRender_Visual*)*I;
 					if (BB.intersect(T->vis.box)) lstVisuals.push_back(T);
 				}
 			}
@@ -983,7 +983,7 @@ void R_dsgraph_structure::r_dsgraph_render_R1_box(IRender_Sector* _S, Fbox& BB, 
 				E = pV->children.end();
 				for (; I != E; ++I)
 				{
-					dxRender_Visual* T = *I;
+					dxRender_Visual* T = (dxRender_Visual*)*I;
 					if (BB.intersect(T->vis.box)) lstVisuals.push_back(T);
 				}
 			}

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -184,6 +184,7 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
+IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -231,7 +232,6 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
-void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {
@@ -299,7 +299,7 @@ ENGINE_API extern BOOL g_bRendering;
 void CRender::add_Visual(IRenderVisual* V)
 {
 	VERIFY(g_bRendering);
-	add_leafs_Dynamic((dxRender_Visual*)V, V->_ignore_optimization);
+	add_leafs_Dynamic((dxRender_Visual*)V);
 }
 
 void CRender::add_Geometry(IRenderVisual* V) { add_Static((dxRender_Visual*)V, View->getMask()); }

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -100,7 +100,7 @@ private:
 
 	BOOL add_Dynamic(dxRender_Visual* pVisual, u32 planes); // normal processing
 	void add_Static(dxRender_Visual* pVisual, u32 planes);
-	void add_leafs_Dynamic(dxRender_Visual* pVisual, bool ignore = false); // if detected node's full visibility
+	void add_leafs_Dynamic(dxRender_Visual* pVisual); // if detected node's full visibility
 	void add_leafs_Static(dxRender_Visual* pVisual); // if detected node's full visibility
 
 public:
@@ -198,12 +198,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
+	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
-	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R2/r2.cpp
+++ b/src/Layers/xrRenderPC_R2/r2.cpp
@@ -478,6 +478,7 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
+IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -525,7 +526,6 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCTSTR name) { Models->Prefetch_One(name); }
-void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {
@@ -612,7 +612,7 @@ BOOL CRender::occ_visible(vis_data& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(sPoly& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(Fbox& P) { return HOM.visible(P); }
 
-void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V, V->_ignore_optimization); }
+void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V); }
 void CRender::add_Geometry(IRenderVisual* V) { add_Static((dxRender_Visual*)V, View->getMask()); }
 
 // demonized: add user defined rotation to wallmark

--- a/src/Layers/xrRenderPC_R2/r2.h
+++ b/src/Layers/xrRenderPC_R2/r2.h
@@ -153,7 +153,7 @@ private:
 
 	BOOL add_Dynamic(dxRender_Visual* pVisual, u32 planes); // normal processing
 	void add_Static(dxRender_Visual* pVisual, u32 planes);
-	void add_leafs_Dynamic(dxRender_Visual* pVisual, bool ignore = false); // if detected node's full visibility
+	void add_leafs_Dynamic(dxRender_Visual* pVisual); // if detected node's full visibility
 	void add_leafs_Static(dxRender_Visual* pVisual); // if detected node's full visibility
 
 public:
@@ -296,12 +296,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
+	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
-	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R2/r2_loader.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_loader.cpp
@@ -192,7 +192,6 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
-		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/Layers/xrRenderPC_R3/r3.cpp
+++ b/src/Layers/xrRenderPC_R3/r3.cpp
@@ -620,6 +620,7 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
+IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -667,7 +668,6 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
-void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {
@@ -754,7 +754,7 @@ BOOL CRender::occ_visible(vis_data& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(sPoly& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(Fbox& P) { return HOM.visible(P); }
 
-void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V, V->_ignore_optimization); }
+void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V); }
 void CRender::add_Geometry(IRenderVisual* V) { add_Static((dxRender_Visual*)V, View->getMask()); }
 
 // demonized: add user defined rotation to wallmark

--- a/src/Layers/xrRenderPC_R3/r3.h
+++ b/src/Layers/xrRenderPC_R3/r3.h
@@ -185,7 +185,7 @@ private:
 
 	BOOL add_Dynamic(dxRender_Visual* pVisual, u32 planes); // normal processing
 	void add_Static(dxRender_Visual* pVisual, u32 planes);
-	void add_leafs_Dynamic(dxRender_Visual* pVisual, bool ignore = false); // if detected node's full visibility
+	void add_leafs_Dynamic(dxRender_Visual* pVisual); // if detected node's full visibility
 	void add_leafs_Static(dxRender_Visual* pVisual); // if detected node's full visibility
 
 public:
@@ -343,12 +343,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
+	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
-	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R3/r3_loader.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_loader.cpp
@@ -197,7 +197,6 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
-		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -688,6 +688,7 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
+IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -735,7 +736,6 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
-void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {
@@ -822,7 +822,7 @@ BOOL CRender::occ_visible(vis_data& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(sPoly& P) { return HOM.visible(P); }
 BOOL CRender::occ_visible(Fbox& P) { return HOM.visible(P); }
 
-void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V, V->_ignore_optimization); }
+void CRender::add_Visual(IRenderVisual* V) { add_leafs_Dynamic((dxRender_Visual*)V); }
 void CRender::add_Geometry(IRenderVisual* V) { add_Static((dxRender_Visual*)V, View->getMask()); }
 
 // demonized: add user defined rotation to wallmark

--- a/src/Layers/xrRenderPC_R4/r4.h
+++ b/src/Layers/xrRenderPC_R4/r4.h
@@ -204,7 +204,7 @@ private:
 
 	BOOL add_Dynamic(dxRender_Visual* pVisual, u32 planes); // normal processing
 	void add_Static(dxRender_Visual* pVisual, u32 planes);
-	void add_leafs_Dynamic(dxRender_Visual* pVisual, bool ignore = false); // if detected node's full visibility
+	void add_leafs_Dynamic(dxRender_Visual* pVisual); // if detected node's full visibility
 	void add_leafs_Static(dxRender_Visual* pVisual); // if detected node's full visibility
 
 public:
@@ -363,12 +363,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
+	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
-	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -181,7 +181,6 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
-		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/xrEngine/IGame_Persistent.cpp
+++ b/src/xrEngine/IGame_Persistent.cpp
@@ -257,7 +257,6 @@ void IGame_Persistent::OnGameEnd()
 {
 #ifndef _EDITOR
 	ObjectPool.clear();
-	Render->models_Clear(TRUE);
 #endif
 }
 

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -322,13 +322,13 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0) = 0;
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data) = 0;
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V) = 0;
+	virtual IRenderVisual* model_Instance(LPCSTR name) = 0;
 	//virtual void model_Delete (IRenderVisual* & V, BOOL bDiscard=FALSE) = 0;
 	virtual void model_Delete(IRenderVisual*& V, BOOL bDiscard = FALSE) = 0;
 	// virtual void model_Delete (IRender_DetailModel* & F) = 0;
 	virtual void model_Logging(BOOL bEnable) = 0;
 	virtual void models_Prefetch() = 0;
 	virtual void models_PrefetchOne(LPCSTR name) = 0;
-	virtual void models_Clear(BOOL b_complete) = 0;
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V) = 0;

--- a/src/xrGame/DestroyablePhysicsObject.cpp
+++ b/src/xrGame/DestroyablePhysicsObject.cpp
@@ -31,6 +31,7 @@ void CDestroyablePhysicsObject::OnChangeVisual()
 {
 	if (m_pPhysicsShell)
 	{
+		m_pPhysicsShell->set_Kinematics(nullptr);
 		m_pPhysicsShell->Deactivate();
 		xr_delete(m_pPhysicsShell);
 		VERIFY(0==Visual());

--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -60,6 +60,13 @@ DLL_Pure* CHudItem::_construct()
 
 CHudItem::~CHudItem()
 {
+	DeleteHudItemData();
+}
+
+void CHudItem::DeleteHudItemData()
+{
+	xr_delete(m_attachable);
+	m_attachable = nullptr;
 }
 
 void CHudItem::Load(LPCSTR section)
@@ -801,11 +808,11 @@ bool CHudItem::HudAnimationExist(LPCSTR anim_name)
 		bool is_16x9 = UI().is_widescreen();
 		u16 attach_place_idx = pSettings->r_u16(HudItemData()->m_sect_name, "attach_place_idx");
 		xr_sprintf(anim_name_r, "%s%s", anim_name, ((attach_place_idx == 1) && is_16x9) ? "_16x9" : "");
-		player_hud_motion* anm = HudItemData()->m_hand_motions.find_motion(anim_name_r);
+		player_hud_motion* anm = HudItemData()->m_hand_motions->find_motion(anim_name_r);
 		if (anm)
 			return true;
 
-		anm = HudItemData()->m_hand_motions.find_motion(anim_name);
+		anm = HudItemData()->m_hand_motions->find_motion(anim_name);
 		if (anm)
 			return true;
 	}
@@ -866,28 +873,22 @@ void CHudItem::OnMovementChanged(ACTOR_DEFS::EMoveCommand cmd)
 	}
 }
 
+extern shared_str current_player_hud_sect;
+
 attachable_hud_item* CHudItem::HudItemData()
 {
-	attachable_hud_item* hi = nullptr;
 	if (!g_player_hud)
-		return hi;
+		return nullptr;
 
-	hi = g_player_hud->attached_item(0);
-	if (hi && hi->m_parent_hud_item == this)
-		return hi;
+	if (!m_attachable)
+	{
+		current_player_hud_sect = hud_sect;
+		m_attachable = xr_new<attachable_hud_item>(g_player_hud);
+		m_attachable->m_parent_hud_item = this;
+		m_attachable->load(hud_sect);
+	}
 
-	hi = g_player_hud->attached_item(1);
-	if (hi && hi->m_parent_hud_item == this)
-		return hi;
-
-	hi = g_player_hud->attached_item(SCOPE_ATTACH_IDX);
-	if (hi && hi->m_parent_hud_item == this)
-		return hi;
-
-	hi = g_player_hud->get_hud_item(HudSection());
-	R_ASSERT(hi);
-
-	return hi;
+	return m_attachable;
 }
 
 bool CHudItem::IsAttachedToHUD()

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -93,6 +93,8 @@ protected:
 		bool m_bStopAtEndAnimIsRunning;
 	};
 
+	attachable_hud_item* m_attachable;
+
 	float m_fLR_CameraFactor; // Фактор бокового наклона худа при ходьбе [-1; +1]
 	float m_fLR_MovingFactor; // Фактор бокового наклона худа при движении камеры [-1; +1]
 	float m_fLR_InertiaFactor; // Фактор горизонтальной инерции худа при движении камеры [-1; +1]
@@ -129,6 +131,8 @@ public:
 	BOOL GetHUDmode();
 	void PlayBlendAnm(LPCSTR name, float speed = 1.f, float power = 1.f, bool stop_old = true);
 	IC bool IsPending() const { return !!m_huditem_flags.test(fl_pending); }
+
+	virtual void DeleteHudItemData();
 
 	virtual bool ActivateItem();
 	virtual void DeactivateItem();

--- a/src/xrGame/Level_network.cpp
+++ b/src/xrGame/Level_network.cpp
@@ -87,7 +87,6 @@ void CLevel::remove_objects()
 	stalker_animation_data_storage().clear();
 
 	VERIFY(Render);
-	Render->models_Clear(FALSE);
 
 	Render->clear_static_wallmarks();
 

--- a/src/xrGame/PhysicsShellHolder.cpp
+++ b/src/xrGame/PhysicsShellHolder.cpp
@@ -379,7 +379,12 @@ void CPhysicsShellHolder::OnChangeVisual()
 			char_support->destroy_imotion();
 
 		VERIFY(!character_physics_support() || !character_physics_support()->interactive_motion());
-		if (m_pPhysicsShell)m_pPhysicsShell->Deactivate();
+		if (m_pPhysicsShell)
+		{
+			m_pPhysicsShell->set_Kinematics(nullptr);
+			m_pPhysicsShell->Deactivate();
+		}
+
 		xr_delete(m_pPhysicsShell);
 		VERIFY(0==m_pPhysicsShell);
 	}

--- a/src/xrGame/ai/crow/ai_crow.cpp
+++ b/src/xrGame/ai/crow/ai_crow.cpp
@@ -159,7 +159,17 @@ BOOL CAI_Crow::net_Spawn(CSE_Abstract* DC)
 	m_Anims.m_fly.Load(M, "fly_fwd");
 	m_Anims.m_idle.Load(M, "fly_idle");
 
-	renderable.visual->_ignore_optimization = true;
+	renderable.visual->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+
+	if (children)
+	{
+		for (auto* child : *children)
+		{
+			child->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+		}
+	}
 
 	o_workload_frame = 0;
 	o_workload_rframe = 0;

--- a/src/xrGame/ai/monsters/basemonster/base_monster.cpp
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.cpp
@@ -817,6 +817,12 @@ void CBaseMonster::net_Relcase(CObject* O)
 	m_pPhysics_support->in_NetRelcase(O);
 }
 
+void CBaseMonster::OnChangeVisual()
+{
+	if (renderable.visual && ID() != u16(-1)) control().reinit(); //skip during load
+	inherited::OnChangeVisual();
+}
+
 void CBaseMonster::create_base_controls()
 {
 	m_anim_base = xr_new<CControlAnimationBase>();

--- a/src/xrGame/ai/monsters/basemonster/base_monster.h
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.h
@@ -103,6 +103,8 @@ public:
 	virtual void net_Import(NET_Packet& P);
 	virtual void net_Relcase(CObject* O);
 
+	virtual void OnChangeVisual();
+
 	//save/load server serialization
 	virtual void save(NET_Packet& output_packet) { inherited::save(output_packet); }
 	virtual void load(IReader& input_packet) { inherited::load(input_packet); }

--- a/src/xrGame/ai/stalker/ai_stalker.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker.cpp
@@ -1574,6 +1574,26 @@ void CAI_Stalker::ChangeVisual(shared_str NewVisual)
 
 	cNameVisual_set(NewVisual);
 
+	IKinematicsAnimated* V = smart_cast<IKinematicsAnimated*>(Visual());
+	if (V)
+	{
+		if (!g_Alive())
+		{
+			m_pPhysics_support->in_Die(false);
+		}
+		else
+		{
+			CStepManager::reload(cNameSect_str());
+		}
+
+		CDamageManager::reload(cNameSect_str(), "damage", pSettings);
+		ResetBoneProtections(NULL, NULL);
+		reattach_items();
+		m_pPhysics_support->in_ChangeVisual();
+		animation().reload();
+		movement().reload(cNameSect_str());
+	}
+
 	Visual()->dcast_PKinematics()->CalculateBones_Invalidate();
 	Visual()->dcast_PKinematics()->CalculateBones(TRUE);
 };

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1529,11 +1529,26 @@ void set_nv_lumfactor(float factor)
 
 void remove_hud_model(LPCSTR section)
 {
-	LPCSTR hud_section = READ_IF_EXISTS(pSettings, r_string, section, "hud", nullptr);
-	if (hud_section != nullptr)
-		g_player_hud->remove_from_model_pool(hud_section);
-	else
-		Msg("can't find hud section for [%s]", section);
+	attachable_hud_item* itm0 = g_player_hud->attached_item(0);
+	attachable_hud_item* itm1 = g_player_hud->attached_item(1);
+
+	if (itm0 && itm0->m_parent_hud_item->object().cNameSect().equal(section))
+	{
+		CHudItem* itm = itm0->m_parent_hud_item;
+		g_player_hud->detach_item_idx(0);
+		itm0->m_parent_hud_item->DeleteHudItemData();
+		g_player_hud->attach_item(itm);
+		itm->PlayAnimIdle();
+	}
+	
+	if (itm1 && itm1->m_parent_hud_item->object().cNameSect().equal(section))
+	{
+		CHudItem* itm = itm1->m_parent_hud_item;
+		g_player_hud->detach_item_idx(1);
+		itm1->m_parent_hud_item->DeleteHudItemData();
+		g_player_hud->attach_item(itm);
+		itm->PlayAnimIdle();
+	}
 }
 
 const u32 ActorMovingState()

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -570,6 +570,7 @@ void attachable_hud_item::load(const shared_str& sect_name)
 
 	m_attach_place_idx = pSettings->r_u16(sect_name, "attach_place_idx");
 	m_measures.load(sect_name, m_model);
+	m_hand_motions = m_parent->get_hand_motions(*sect_name);
 }
 
 player_hud_motion* attachable_hud_item::find_motion(const shared_str& anm_name)
@@ -579,12 +580,12 @@ player_hud_motion* attachable_hud_item::find_motion(const shared_str& anm_name)
 	bool is_16x9 = UI().is_widescreen();
 	xr_sprintf(anim_name_r, "%s%s", anm_name.c_str(), ((m_attach_place_idx == 1) && is_16x9) ? "_16x9" : "");
 
-	player_hud_motion* anm = m_hand_motions.find_motion(anim_name_r);
+	player_hud_motion* anm = m_hand_motions->find_motion(anim_name_r);
 
 	if (!anm)
-		anm = m_hand_motions.find_motion(anm_name);
+		anm = m_hand_motions->find_motion(anm_name);
 
-	R_ASSERT2(anm, make_string("model [%s] has no motion alias defined [%s]", m_sect_name.c_str(), anim_name_r).c_str())
+	R_ASSERT2(anm, make_string("model [%s] has no motion alias defined [%s]", m_sect_name.c_str(), anm_name).c_str())
 	;
 	VERIFY2(anm->m_animations.size(),
 	        make_string("model [%s] has no motion defined in motion_alias [%s]", pSettings->r_string(m_sect_name,
@@ -733,7 +734,6 @@ player_hud::~player_hud()
 	::Render->model_Delete(v);
 	m_model_2 = nullptr;
 
-	delete_data(m_pool);
 	delete_data(m_hand_motions);
 	delete_data(m_script_layers);
 	delete_data(m_movement_layers);
@@ -987,8 +987,9 @@ u32 player_hud::motion_length_script(LPCSTR section, LPCSTR anm_name, float spee
 
 u32 player_hud::motion_length(const shared_str& anim_name, const shared_str& hud_name, const CMotionDef*& md)
 {
-	attachable_hud_item* pi = get_hud_item(hud_name);
-	player_hud_motion* pm = pi->m_hand_motions.find_motion(anim_name);
+	player_hud_motion_container* pc = get_hand_motions(*hud_name);
+	if (!pc) return 0;
+	player_hud_motion* pm = pc->find_motion(anim_name);
 	if (!pm || !pm->m_animations.size())
 		return 100; // ms TEMPORARY
 	R_ASSERT2(pm,
@@ -1608,46 +1609,6 @@ u32 player_hud::script_anim_play(u8 hand, LPCSTR section, LPCSTR anm_name, bool 
 	return length;
 }
 
-void player_hud::remove_from_model_pool(LPCSTR sect)
-{
-	xr_vector<attachable_hud_item*>::iterator it = m_pool.begin();
-	xr_vector<attachable_hud_item*>::iterator it_e = m_pool.end();
-	for (; it != it_e; ++it)
-	{
-		attachable_hud_item* itm = *it;
-		if (itm->m_sect_name == sect)
-		{
-			if (m_attached_items[0] && m_attached_items[0] == itm)
-				detach_item_idx(0);
-			else if (m_attached_items[1] && m_attached_items[1] == itm)
-				detach_item_idx(1);
-
-			m_pool.erase(it);
-			break;
-		}
-	}
-}
-
-shared_str current_player_hud_sect;
-attachable_hud_item* player_hud::get_hud_item(const shared_str& sect)
-{
-	current_player_hud_sect = sect;
-	xr_vector<attachable_hud_item*>::iterator it = m_pool.begin();
-	xr_vector<attachable_hud_item*>::iterator it_e = m_pool.end();
-	for (; it != it_e; ++it)
-	{
-		attachable_hud_item* itm = *it;
-		if (itm->m_sect_name == sect)
-			return itm;
-	}
-	attachable_hud_item* res = xr_new<attachable_hud_item>(this);
-	res->load(sect);
-	res->m_hand_motions.load(m_model, sect);
-	m_pool.push_back(res);
-
-	return res;
-}
-
 bool player_hud::allow_activation(CHudItem* item)
 {
 	if (script_anim_part != u8(-1))
@@ -1658,9 +1619,10 @@ bool player_hud::allow_activation(CHudItem* item)
 		return true;
 }
 
+shared_str current_player_hud_sect;
 void player_hud::attach_item(CHudItem* item)
 {
-	attachable_hud_item* pi = get_hud_item(item->HudSection());
+	attachable_hud_item* pi = item->HudItemData();
 	int item_idx = pi->m_attach_place_idx;
 
 	if (m_attached_items[item_idx] != pi)
@@ -1669,7 +1631,6 @@ void player_hud::attach_item(CHudItem* item)
 			m_attached_items[item_idx]->m_parent_hud_item->on_b_hud_detach();
 
 		m_attached_items[item_idx] = pi;
-		pi->m_parent_hud_item = item;
 
 		if (item_idx == 0 && m_attached_items[1])
 			m_attached_items[1]->m_parent_hud_item->CheckCompatibility(item);
@@ -1678,7 +1639,6 @@ void player_hud::attach_item(CHudItem* item)
 
 		updateMovementLayerState();
 	}
-	pi->m_parent_hud_item = item;
 }
 
 //sync anim of other part to selected part (1 = sync to left hand anim; 2 = sync to right hand anim)
@@ -1760,8 +1720,6 @@ void player_hud::detach_item_idx(u16 idx)
 	if (NULL == m_attached_items[idx]) return;
 
 	m_attached_items[idx]->m_parent_hud_item->on_b_hud_detach();
-
-	m_attached_items[idx]->m_parent_hud_item = NULL;
 	m_attached_items[idx] = NULL;
 
 	if (idx == 1)
@@ -1778,7 +1736,7 @@ void player_hud::detach_item_idx(u16 idx)
 		if (m_attached_items[1])
 		{
 			//fix for a rare case where the right hand stays visible on screen after detaching the right hand's attached item
-			player_hud_motion* pm = m_attached_items[1]->m_hand_motions.find_motion("anm_idle");
+			player_hud_motion* pm = m_attached_items[1]->m_hand_motions->find_motion("anm_idle");
 			const motion_descr& M = pm->m_animations[0];
 			m_model->PlayCycle(0, M.mid, false);
 			m_model->PlayCycle(2, M.mid, false);

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -266,7 +266,7 @@ struct attachable_hud_item
 	Fmatrix m_attach_offset;
 	Fmatrix m_item_transform;
 
-	player_hud_motion_container m_hand_motions;
+	player_hud_motion_container* m_hand_motions;
 
 	attachable_hud_item(player_hud* pparent): m_parent(pparent), m_upd_firedeps_frame(u32(-1)), m_parent_hud_item(nullptr),
 	                                          m_model(nullptr), m_attach_place_idx(0) {}
@@ -315,7 +315,7 @@ public:
 	void load(const shared_str& model_name, bool force = false);
 	void load_script(LPCSTR section);
 	void reset_model_script() { script_override_arms = false; load(m_sect_name, true); };
-	void load_default() { load("actor_hud_05"); };
+	void load_default() { load("actor_hud_05", true); };
 	void update(const Fmatrix& trans);
 	void updateMovementLayerState();
 	void StopScriptAnim();
@@ -329,7 +329,6 @@ public:
 	u32 anim_play(u16 part, const MotionID& M, BOOL bMixIn, const CMotionDef*& md, float speed, u16 override_part = u16(-1));
 	u32 script_anim_play(u8 hand, LPCSTR itm_name, LPCSTR anm_name, bool bMixIn = true, float speed = 1.f);
 	const shared_str& section_name() const { return m_sect_name; }
-	void remove_from_model_pool(LPCSTR sect);
 
 	u8 script_anim_part;
 	Fvector script_anim_offset[2];
@@ -352,8 +351,6 @@ public:
 	player_hud_motion_container* get_hand_motions(LPCSTR section);
 
 	void update_script_item();
-
-	attachable_hud_item* get_hud_item(const shared_str& sect);
 
 	void attach_item(CHudItem* item);
 	void re_sync_anim(u8 part);
@@ -392,7 +389,6 @@ private:
 	shared_str m_sect_name;
 	xr_vector<u16> m_ancors;
 	attachable_hud_item* m_attached_items[3];
-	xr_vector<attachable_hud_item*> m_pool;
 	static void _BCL FingerCallback(CBoneInstance* B);
 public:
 	IKinematicsAnimated* m_model;

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -1093,3 +1093,107 @@ CGameObject& CScriptGameObject::object() const
 
 	return (*m_game_object);
 }
+
+//////////////////////////////////////////////////////////////////////////
+// Shader / Textures Magic
+luabind::object CScriptGameObject::GetShaders(bool bHud)
+{
+	IKinematics* k = nullptr;
+
+	if (bHud)
+	{
+		CActor* act = smart_cast<CActor*>(&object());
+		CHudItem* itm = smart_cast<CHudItem*>(&object());
+		if (itm)
+			k = itm->HudItemData()->m_model;
+		else if (act)
+			k = g_player_hud->m_model->dcast_PKinematics();
+	}
+
+	if (!k)
+		k = object().Visual()->dcast_PKinematics();
+
+	luabind::object table = luabind::newtable(ai().script_engine().lua());
+
+	if (!k)
+	{
+		table["error"] = true;
+		return table;
+	}
+
+	IRenderVisual* vis = k->dcast_RenderVisual();
+	xr_vector<IRenderVisual*>* children = vis->get_children();
+
+	if (!children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = vis->getDebugShader();
+		subtable["texture"] = vis->getDebugTexture();
+		table[1] = subtable;
+		return table;
+	}
+
+	int i = 1;
+
+	for (auto* child : *children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShader();
+		subtable["texture"] = child->getDebugTexture();
+		table[i] = subtable;
+		++i;
+	}
+
+	return table;
+}
+
+void set_shader_tex(IRenderVisual* vis, int id, char* shader, LPCSTR texture)
+{
+	xr_vector<IRenderVisual*>* children = vis->get_children();
+
+	if (!children)
+	{
+		vis->SetShaderTexture(shader, texture);
+		return;
+	}
+
+	if (id == -1)
+	{
+		for (auto* child : *children)
+		{
+			child->SetShaderTexture(shader, texture);
+		}
+		return;
+	}
+
+	id--;
+
+	if (id >= 0 && children->size() > id)
+		children->at(id)->SetShaderTexture(shader, texture);
+}
+
+void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, bool bHud)
+{
+	IKinematics* k = nullptr;
+
+	if (bHud)
+	{
+		CActor* act = smart_cast<CActor*>(&object());
+		CHudItem* itm = smart_cast<CHudItem*>(&object());
+		if (itm)
+			k = itm->HudItemData()->m_model;
+		else if (act)
+		{
+			set_shader_tex(g_player_hud->m_model->dcast_RenderVisual(), id, xr_strdup(shader), texture);
+			set_shader_tex(g_player_hud->m_model_2->dcast_RenderVisual(), id, xr_strdup(shader), texture);
+			return;
+		}
+	}
+
+	if (!k)
+		k = object().Visual()->dcast_PKinematics();
+
+	if (!k) return;
+
+	set_shader_tex(k->dcast_RenderVisual(), id, xr_strdup(shader), texture);
+}

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1121,6 +1121,9 @@ public:
 #endif
 	//-Alundaio
 
+	::luabind::object GetShaders(bool bHud = false);
+	void SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, bool bHud = false);
+
 	script_attachment* AddAttachment(u16 slot, LPCSTR model_name);
 	script_attachment* GetAttachment(u16 slot);
 	void RemoveAttachment(u16 slot);

--- a/src/xrGame/script_game_object2.cpp
+++ b/src/xrGame/script_game_object2.cpp
@@ -656,26 +656,6 @@ void CScriptGameObject::set_visual_name(LPCSTR visual, bool bForce)
 	if (stalker)
 	{
 		stalker->ChangeVisual(visual);
-
-		IKinematicsAnimated* V = smart_cast<IKinematicsAnimated*>(stalker->Visual());
-		if (V)
-		{
-			if (!stalker->g_Alive())
-			{
-				stalker->m_pPhysics_support->in_Die(false);
-			}
-			else
-			{
-				stalker->CStepManager::reload(stalker->cNameSect().c_str());
-			}
-
-			stalker->CDamageManager::reload(*stalker->cNameSect(), "damage", pSettings);
-			stalker->ResetBoneProtections(NULL, NULL);
-			stalker->reattach_items();
-			stalker->m_pPhysics_support->in_ChangeVisual();
-			stalker->animation().reload();
-		}
-
 		return;
 	}
 

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -636,6 +636,9 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		.def("add_attachment", &CScriptGameObject::AddAttachment)
 		.def("get_attachment", &CScriptGameObject::GetAttachment)
 		.def("remove_attachment", &CScriptGameObject::RemoveAttachment)
+
+		.def("get_shaders", &CScriptGameObject::GetShaders)
+		.def("set_shader", &CScriptGameObject::SetShaderTexture)
 		;
 	return (instance);
 }

--- a/src/xrGame/stalker_animation_manager.cpp
+++ b/src/xrGame/stalker_animation_manager.cpp
@@ -73,6 +73,7 @@ void CStalkerAnimationManager::reinit()
 void CStalkerAnimationManager::reload()
 {
 	m_visual = object().Visual();
+	R_ASSERT(m_visual);
 
 	m_crouch_state_config = object().SpecificCharacter().crouch_type();
 	VERIFY((m_crouch_state_config == 0) || (m_crouch_state_config == 1) || (m_crouch_state_config == -1));
@@ -84,7 +85,7 @@ void CStalkerAnimationManager::reload()
 	m_skeleton_animated = smart_cast<IKinematicsAnimated*>(m_visual);
 	VERIFY(m_skeleton_animated);
 
-	m_data_storage = stalker_animation_data_storage().object(m_skeleton_animated);
+	m_data_storage = stalker_animation_data_storage().object(smart_cast<IKinematicsAnimated*>(::Render->model_Instance(*object().cNameVisual())));
 	VERIFY(m_data_storage);
 
 	if (!object().g_Alive())


### PR DESCRIPTION
- Scripts can now read and change the shaders/textures of models (and all their submeshes)
- It's now possible to disable shadows for a submesh by appending `$no_shadows` to its shader name (in the ogf or using the scripted way that was added in this commit)

Necessary changes for all of this to work:
- Removed model pool that reassigned unused models to newly spawned objects
- Removed player hud item pool, every item has its own attachable_hud_item now
- Some changes to prevent crashes due to the removed pools
- Added support for flags to meshes and turned ignore_optimization and the newly added no_shadows into flags
- hud_adjust.remove_hud_model now actually works as a result of this!

Thanks to @nltp-ashes and BAN for testing and feedback