### PR TITLE
Indoor Gunsound Framework

### DIFF
--- a/src/xrGame/Actor_Flags.h
+++ b/src/xrGame/Actor_Flags.h
@@ -23,7 +23,6 @@ enum
 	AF_AIM_TOGGLE = (1 << 19),
 	AF_3D_PDA = (1 << 20),
 	AF_FIREPOS_ZOOM =(1 << 21),
-	AF_GUNSND_INDOOR =(1 << 22)
 };
 
 extern Flags32 psActorFlags;

--- a/src/xrGame/Actor_Flags.h
+++ b/src/xrGame/Actor_Flags.h
@@ -23,6 +23,7 @@ enum
 	AF_AIM_TOGGLE = (1 << 19),
 	AF_3D_PDA = (1 << 20),
 	AF_FIREPOS_ZOOM =(1 << 21),
+	AF_GUNSND_INDOOR =(1 << 22)
 };
 
 extern Flags32 psActorFlags;

--- a/src/xrGame/HudSound.cpp
+++ b/src/xrGame/HudSound.cpp
@@ -126,11 +126,11 @@ void HUD_SOUND_ITEM::PlaySound(HUD_SOUND_ITEM& hud_snd,
 		                                          flags & sm_2D
 			                                          ? &Fvector().set(0, 0, 0)
 			                                          : &Fvector().set(position.x, position.y, position.z),
-		                                          0, 0, 0);
+		                                          volume_mult, 0, 0);
 	}
 
 	//hud_snd.m_activeSnd->snd.set_volume		(hud_snd.m_activeSnd->volume * b_hud_mode?psHUDSoundVolume:1.0f);
-	hud_snd.m_activeSnd->snd.set_volume(hud_snd.m_activeSnd->volume * (b_hud_mode ? psHUDSoundVolume : 1.0f)*volume_mult);
+	hud_snd.m_activeSnd->snd.set_volume(hud_snd.m_activeSnd->volume * (b_hud_mode ? psHUDSoundVolume : 1.0f) * volume_mult);
 }
 
 void HUD_SOUND_ITEM::StopSound(HUD_SOUND_ITEM& hud_snd)

--- a/src/xrGame/HudSound.cpp
+++ b/src/xrGame/HudSound.cpp
@@ -85,7 +85,8 @@ void HUD_SOUND_ITEM::PlaySound(HUD_SOUND_ITEM& hud_snd,
                                const CObject* parent,
                                bool b_hud_mode,
                                bool looped,
-                               u8 index)
+                               u8 index
+							   float volume_mult = 1.f)
 {
 	if (hud_snd.sounds.empty()) return;
 
@@ -129,7 +130,7 @@ void HUD_SOUND_ITEM::PlaySound(HUD_SOUND_ITEM& hud_snd,
 	}
 
 	//hud_snd.m_activeSnd->snd.set_volume		(hud_snd.m_activeSnd->volume * b_hud_mode?psHUDSoundVolume:1.0f);
-	hud_snd.m_activeSnd->snd.set_volume(hud_snd.m_activeSnd->volume * (b_hud_mode ? psHUDSoundVolume : 1.0f));
+	hud_snd.m_activeSnd->snd.set_volume(hud_snd.m_activeSnd->volume * (b_hud_mode ? psHUDSoundVolume : 1.0f)*volume_mult);
 }
 
 void HUD_SOUND_ITEM::StopSound(HUD_SOUND_ITEM& hud_snd)
@@ -173,7 +174,8 @@ void HUD_SOUND_COLLECTION::PlaySound(LPCSTR alias,
                                      const CObject* parent,
                                      bool hud_mode,
                                      bool looped,
-                                     u8 index)
+                                     u8 index
+									 float volume_mult = 1.f)
 {
 	xr_vector<HUD_SOUND_ITEM>::iterator it = m_sound_items.begin();
 	xr_vector<HUD_SOUND_ITEM>::iterator it_e = m_sound_items.end();
@@ -185,7 +187,7 @@ void HUD_SOUND_COLLECTION::PlaySound(LPCSTR alias,
 
 	HUD_SOUND_ITEM* snd_item = FindSoundItem(alias, false);
 	if (snd_item)
-		HUD_SOUND_ITEM::PlaySound(*snd_item, position, parent, hud_mode, looped, index);
+		HUD_SOUND_ITEM::PlaySound(*snd_item, position, parent, hud_mode, looped, index, volume_mult);
 }
 
 void HUD_SOUND_COLLECTION::StopSound(LPCSTR alias)
@@ -278,7 +280,7 @@ void HUD_SOUND_COLLECTION_LAYERED::SetPosition(LPCSTR alias, const Fvector& pos)
 }
 
 void HUD_SOUND_COLLECTION_LAYERED::PlaySound(LPCSTR alias, const Fvector& position, const CObject* parent,
-                                             bool hud_mode, bool looped, u8 index)
+                                             bool hud_mode, bool looped, u8 index, float volume_mult = 1.f)
 {
 	xr_vector<HUD_SOUND_COLLECTION>::iterator it = m_sound_items.begin();
 	xr_vector<HUD_SOUND_COLLECTION>::iterator it_e = m_sound_items.end();
@@ -286,7 +288,7 @@ void HUD_SOUND_COLLECTION_LAYERED::PlaySound(LPCSTR alias, const Fvector& positi
 	for (; it != it_e; ++it)
 	{
 		if (it->m_alias == alias)
-			it->PlaySound(alias, position, parent, hud_mode, looped, index);
+			it->PlaySound(alias, position, parent, hud_mode, looped, index, volume_mult);
 	}
 }
 

--- a/src/xrGame/HudSound.cpp
+++ b/src/xrGame/HudSound.cpp
@@ -126,7 +126,7 @@ void HUD_SOUND_ITEM::PlaySound(HUD_SOUND_ITEM& hud_snd,
 		                                          flags & sm_2D
 			                                          ? &Fvector().set(0, 0, 0)
 			                                          : &Fvector().set(position.x, position.y, position.z),
-		                                          volume_mult, 0, 0);
+		                                          &volume_mult, 0, 0);
 	}
 
 	//hud_snd.m_activeSnd->snd.set_volume		(hud_snd.m_activeSnd->volume * b_hud_mode?psHUDSoundVolume:1.0f);

--- a/src/xrGame/HudSound.cpp
+++ b/src/xrGame/HudSound.cpp
@@ -85,8 +85,8 @@ void HUD_SOUND_ITEM::PlaySound(HUD_SOUND_ITEM& hud_snd,
                                const CObject* parent,
                                bool b_hud_mode,
                                bool looped,
-                               u8 index
-							   float volume_mult = 1.f)
+                               u8 index,
+							   float volume_mult)
 {
 	if (hud_snd.sounds.empty()) return;
 
@@ -174,8 +174,8 @@ void HUD_SOUND_COLLECTION::PlaySound(LPCSTR alias,
                                      const CObject* parent,
                                      bool hud_mode,
                                      bool looped,
-                                     u8 index
-									 float volume_mult = 1.f)
+                                     u8 index,
+									 float volume_mult)
 {
 	xr_vector<HUD_SOUND_ITEM>::iterator it = m_sound_items.begin();
 	xr_vector<HUD_SOUND_ITEM>::iterator it_e = m_sound_items.end();
@@ -280,7 +280,7 @@ void HUD_SOUND_COLLECTION_LAYERED::SetPosition(LPCSTR alias, const Fvector& pos)
 }
 
 void HUD_SOUND_COLLECTION_LAYERED::PlaySound(LPCSTR alias, const Fvector& position, const CObject* parent,
-                                             bool hud_mode, bool looped, u8 index, float volume_mult = 1.f)
+                                             bool hud_mode, bool looped, u8 index, float volume_mult)
 {
 	xr_vector<HUD_SOUND_COLLECTION>::iterator it = m_sound_items.begin();
 	xr_vector<HUD_SOUND_COLLECTION>::iterator it_e = m_sound_items.end();

--- a/src/xrGame/HudSound.h
+++ b/src/xrGame/HudSound.h
@@ -24,7 +24,8 @@ struct HUD_SOUND_ITEM
 	                      const CObject* parent,
 	                      bool hud_mode,
 	                      bool looped = false,
-	                      u8 index = u8(-1));
+	                      u8 index = u8(-1),
+						  float volume_mult = 1.f);
 
 	static void StopSound(HUD_SOUND_ITEM& snd);
 
@@ -47,8 +48,8 @@ struct HUD_SOUND_ITEM
 	struct SSnd
 	{
 		ref_sound snd;
-		float delay; //задержка перед проигрыванием
-		float volume; //громкость
+		float delay; //пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
+		float volume; //пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 	};
 
 	shared_str m_alias;
@@ -71,7 +72,7 @@ public:
 
 	HUD_SOUND_ITEM* FindSoundItem(LPCSTR alias, bool b_assert); //AVO: made public to check if sound is loaded
 	void PlaySound(LPCSTR alias, const Fvector& position, const CObject* parent, bool hud_mode, bool looped = false,
-	               u8 index = u8(-1));
+	               u8 index = u8(-1), float volume_mult = 1.f);
 
 	void StopSound(LPCSTR alias);
 
@@ -89,7 +90,7 @@ public:
 	~HUD_SOUND_COLLECTION_LAYERED();
 	HUD_SOUND_ITEM* FindSoundItem(LPCSTR alias, bool b_assert);
 	void PlaySound(LPCSTR alias, const Fvector& position, const CObject* parent, bool hud_mode, bool looped = false,
-	               u8 index = u8(-1));
+	               u8 index = u8(-1), float volume_mult = 1.f);
 	void StopSound(LPCSTR alias);
 	void StopAllSounds();
 	void LoadSound(LPCSTR section, LPCSTR line, LPCSTR alias, bool exclusive = false, int type = sg_SourceType);

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -29,6 +29,7 @@
 
 extern ENGINE_API bool g_dedicated_server;
 ENGINE_API extern float psHUD_FOV_def;
+float g_gunsnd_indoor = 0.f
 
 CUIXml* pWpnScopeXml = NULL;
 
@@ -860,19 +861,40 @@ void CWeaponMagazined::PlaySoundShot()
 			strconcat(sizeof(sndNameMisfire), sndNameMisfire, m_sSndShotCurrent.c_str(), "MisfireActor");
 			if (m_sounds.FindSoundItem(sndNameMisfire, false))
 			{
+				m_sounds.set_volume
 				m_sounds.PlaySound(sndNameMisfire, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
 				return;
 			}
 		}
 		// INDOOR
-		if (psActorFlags.test(AF_GUNSND_INDOOR))
+		if (g_gunsnd_indoor>0.f)
 		{
 			string128 sndNameIndoor;
 			strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
 			if (m_sounds.FindSoundItem(sndNameIndoor, false))
 			{
+				m_sounds.set_volume(g_gunsnd_indoor)
 				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
-				return;
+				if (1-g_gunsnd_indoor>0.f) 
+				{
+					string128 sndNameFirst;
+					m_sounds.set_volume(1-g_gunsnd_indoor)
+					strconcat(sizeof(sndNameFirst), sndNameFirst, m_sSndShotCurrent.c_str(), "ActorFirst");
+					if (m_iShotNum == 1 && m_sounds.FindSoundItem(sndNameFirst, false))
+					{
+						m_sounds.PlaySound(sndNameFirst, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+						return;
+					}
+			
+					string128 sndName;
+					strconcat(sizeof(sndName), sndName, m_sSndShotCurrent.c_str(), "Actor");
+					if (m_sounds.FindSoundItem(sndName, false))
+					{
+						m_sounds.PlaySound(sndName, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+						return;
+					}
+					return;
+				}
 			}
 		}
 

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -29,7 +29,8 @@
 
 extern ENGINE_API bool g_dedicated_server;
 ENGINE_API extern float psHUD_FOV_def;
-float g_gunsnd_indoor = 0.f
+
+float g_gunsnd_indoor = 0.f;
 
 CUIXml* pWpnScopeXml = NULL;
 
@@ -861,7 +862,6 @@ void CWeaponMagazined::PlaySoundShot()
 			strconcat(sizeof(sndNameMisfire), sndNameMisfire, m_sSndShotCurrent.c_str(), "MisfireActor");
 			if (m_sounds.FindSoundItem(sndNameMisfire, false))
 			{
-				m_sounds.set_volume
 				m_sounds.PlaySound(sndNameMisfire, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
 				return;
 			}
@@ -873,16 +873,14 @@ void CWeaponMagazined::PlaySoundShot()
 			strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
 			if (m_sounds.FindSoundItem(sndNameIndoor, false))
 			{
-				m_sounds.set_volume(g_gunsnd_indoor)
-				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
-				if (1-g_gunsnd_indoor>0.f) 
+				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, g_gunsnd_indoor);
+				if (1.f-g_gunsnd_indoor>0.f) 
 				{
 					string128 sndNameFirst;
-					m_sounds.set_volume(1-g_gunsnd_indoor)
 					strconcat(sizeof(sndNameFirst), sndNameFirst, m_sSndShotCurrent.c_str(), "ActorFirst");
 					if (m_iShotNum == 1 && m_sounds.FindSoundItem(sndNameFirst, false))
 					{
-						m_sounds.PlaySound(sndNameFirst, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+						m_sounds.PlaySound(sndNameFirst, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.f-g_gunsnd_indoor);
 						return;
 					}
 			
@@ -895,6 +893,7 @@ void CWeaponMagazined::PlaySoundShot()
 					}
 					return;
 				}
+				return;
 			}
 		}
 

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -31,6 +31,7 @@ extern ENGINE_API bool g_dedicated_server;
 ENGINE_API extern float psHUD_FOV_def;
 
 float g_gunsnd_indoor = 0.f;
+float g_gunsnd_indoor_volume = 1.f;
 
 CUIXml* pWpnScopeXml = NULL;
 
@@ -877,7 +878,7 @@ void CWeaponMagazined::PlaySoundShot()
 			strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
 			if (m_sounds.FindSoundItem(sndNameIndoor, false))
 			{
-				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, g_gunsnd_indoor);
+				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, g_gunsnd_indoor*g_gunsnd_indoor_volume);
 				if (1.f-g_gunsnd_indoor>0.f) 
 				{
 					string128 sndNameFirst;
@@ -935,7 +936,7 @@ void CWeaponMagazined::PlaySoundShot()
 		strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
 		if (m_sounds.FindSoundItem(sndNameIndoor, false))
 		{
-			m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.f);
+			m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.f*g_gunsnd_indoor_volume);
 			return;
 		}
 	}

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -107,10 +107,12 @@ void CWeaponMagazined::Load(LPCSTR section)
 	if (WeaponSoundExist(section, "snd_shoot_actor"))
 		m_sounds.LoadSound(section, "snd_shoot_actor", "sndShotActor", false, m_eSoundShot);
 	//-Alundaio
-
 	// Cyclic fire sounds
 	if (WeaponSoundExist(section, "snd_shoot_actor_first"))
 		m_sounds.LoadSound(section, "snd_shoot_actor_first", "sndShotActorFirst", false, m_eSoundShot);
+
+	if (WeaponSoundExist(section, "snd_shoot_indoor"))
+		m_sounds.LoadSound(section, "snd_shoot_indoor", "sndShootIndoor", false, m_eSoundShot);
 
 	//misfire shot
 	if (WeaponSoundExist(section, "snd_shot_misfire"))
@@ -873,6 +875,7 @@ void CWeaponMagazined::PlaySoundShot()
 		strconcat(sizeof(sndName), sndName, m_sSndShotCurrent.c_str(), "Actor");
 		if (m_sounds.FindSoundItem(sndName, false))
 		{
+			printf(sndName)
 			m_sounds.PlaySound(sndName, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
 			return;
 		}

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -114,9 +114,6 @@ void CWeaponMagazined::Load(LPCSTR section)
 	if (WeaponSoundExist(section, "snd_shoot_actor_first"))
 		m_sounds.LoadSound(section, "snd_shoot_actor_first", "sndShotActorFirst", false, m_eSoundShot);
 
-	if (WeaponSoundExist(section, "snd_shoot_indoor"))
-		m_sounds.LoadSound(section, "snd_shoot_indoor", "sndShootIndoor", false, m_eSoundShot);
-
 	//misfire shot
 	if (WeaponSoundExist(section, "snd_shot_misfire"))
 		m_sounds.LoadSound(section, "snd_shot_misfire", "sndShotMisfire", false, m_eSoundShot);
@@ -891,7 +888,6 @@ void CWeaponMagazined::PlaySoundShot()
 		strconcat(sizeof(sndName), sndName, m_sSndShotCurrent.c_str(), "Actor");
 		if (m_sounds.FindSoundItem(sndName, false))
 		{
-			printf(sndName)
 			m_sounds.PlaySound(sndName, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
 			return;
 		}

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -865,7 +865,7 @@ void CWeaponMagazined::PlaySoundShot()
 			}
 		}
 		// INDOOR
-		if psActorFlags.test(AF_GUNSND_INDOOR)
+		if (psActorFlags.test(AF_GUNSND_INDOOR))
 		{
 			string128 sndNameIndoor;
 			strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -170,6 +170,10 @@ void CWeaponMagazined::Load(LPCSTR section)
 		if (WeaponSoundExist(section, "snd_silncer_shoot_actor_first"))
 			m_sounds.LoadSound(section, "snd_silncer_shoot_actor_first", "sndSilencerShotActorFirst", false, m_eSoundShot);
 
+		// Indoor
+		if (WeaponSoundExist(section, "snd_silncer_shoot_indoor"))
+			m_sounds.LoadSound(section, "snd_silncer_shoot_indoor", "sndSilencerShotIndoor", false, m_eSoundShot);
+
 		//misfire shot
 		if (WeaponSoundExist(section, "snd_silncer_shot_misfire"))
 			m_sounds.LoadSound(section, "snd_silncer_shot_misfire", "sndSilencerShotMisfire", false, m_eSoundShot);
@@ -914,6 +918,7 @@ void CWeaponMagazined::PlaySoundShot()
 		}
 	}
 
+
 	if (bMisfire)
 	{
 		string128 sndNameMisfire;
@@ -921,6 +926,17 @@ void CWeaponMagazined::PlaySoundShot()
 		if (m_sounds.FindSoundItem(sndNameMisfire, false))
 		{
 			m_sounds.PlaySound(sndNameMisfire, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+			return;
+		}
+	}
+
+	if (g_gunsnd_indoor>0.f)
+	{
+		string128 sndNameIndoor;
+		strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
+		if (m_sounds.FindSoundItem(sndNameIndoor, false))
+		{
+			m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.0f);
 			return;
 		}
 	}

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -864,7 +864,7 @@ void CWeaponMagazined::PlaySoundShot()
 				return;
 			}
 		}
-
+		// INDOOR
 		if psActorFlags.test(AF_GUNSND_INDOOR)
 		{
 			string128 sndNameIndoor;

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -892,10 +892,9 @@ void CWeaponMagazined::PlaySoundShot()
 					strconcat(sizeof(sndName), sndName, m_sSndShotCurrent.c_str(), "Actor");
 					if (m_sounds.FindSoundItem(sndName, false))
 					{
-						m_sounds.PlaySound(sndName, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+						m_sounds.PlaySound(sndName, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1,  1.f-g_gunsnd_indoor);
 						return;
 					}
-					return;
 				}
 				return;
 			}
@@ -930,13 +929,13 @@ void CWeaponMagazined::PlaySoundShot()
 		}
 	}
 
-	if (g_gunsnd_indoor>0.f)
+	if (g_gunsnd_indoor==1.f)
 	{
 		string128 sndNameIndoor;
 		strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
 		if (m_sounds.FindSoundItem(sndNameIndoor, false))
 		{
-			m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.0f);
+			m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1, 1.f);
 			return;
 		}
 	}

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -106,8 +106,10 @@ void CWeaponMagazined::Load(LPCSTR section)
 	m_sounds.LoadSound(section, "snd_shoot", "sndShot", false, m_eSoundShot);
 	if (WeaponSoundExist(section, "snd_shoot_actor"))
 		m_sounds.LoadSound(section, "snd_shoot_actor", "sndShotActor", false, m_eSoundShot);
+	// Indoor
+	if (WeaponSoundExist(section, "snd_shoot_indoor"))
+		m_sounds.LoadSound(section, "snd_shoot_indoor", "sndShotIndoor", false, m_eSoundShot);
 	//-Alundaio
-
 	// Cyclic fire sounds
 	if (WeaponSoundExist(section, "snd_shoot_actor_first"))
 		m_sounds.LoadSound(section, "snd_shoot_actor_first", "sndShotActorFirst", false, m_eSoundShot);
@@ -721,6 +723,8 @@ void CWeaponMagazined::UpdateSounds()
 		m_sounds.SetPosition("sndShotMisfireActor", P);
 	if (m_sounds.FindSoundItem("sndShotActorFirst", false))
 		m_sounds.SetPosition("sndShotActorFirst", P);
+	if (m_sounds.FindSoundItem("sndShotIndoor", false))
+		m_sounds.SetPosition("sndShotIndoor", P);
 }
 
 // demonized: check if cycle_down is enabled and shot num below max possible burst. Adds support for arbitrary burst shot at rpm_mode_2 with cycling down to rpm after maxBurstAmount
@@ -857,6 +861,17 @@ void CWeaponMagazined::PlaySoundShot()
 			if (m_sounds.FindSoundItem(sndNameMisfire, false))
 			{
 				m_sounds.PlaySound(sndNameMisfire, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
+				return;
+			}
+		}
+
+		if psActorFlags.test(AF_GUNSND_INDOOR)
+		{
+			string128 sndNameIndoor;
+			strconcat(sizeof(sndNameIndoor), sndNameIndoor, m_sSndShotCurrent.c_str(), "Indoor");
+			if (m_sounds.FindSoundItem(sndNameIndoor, false))
+			{
+				m_sounds.PlaySound(sndNameIndoor, get_LastFP(), H_Root(), !!GetHUDmode(), false, (u8)-1);
 				return;
 			}
 		}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -147,6 +147,7 @@ extern BOOL g_aimmode_remember;
 extern BOOL g_freelook_while_reloading;
 extern BOOL useSeparateUBGLKeybind;
 extern float g_gunsnd_indoor;
+extern float g_gunsnd_indoor_volume;
 
 ENGINE_API extern float g_console_sensitive;
 
@@ -2849,4 +2850,5 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "freelook_while_reloading", &g_freelook_while_reloading, 0, 1);
 	// Indoor weapon sounds
 	CMD3(CCC_Float, "g_gunsnd_indoor", &g_gunsnd_indoor, 0.0f, 1.0f);
+	CMD3(CCC_Float, "g_gunsnd_indoor_volume", &g_gunsnd_indoor_volume, 0.0f, 5.0f);
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -146,6 +146,7 @@ extern BOOL useNewZoomDeltaAlgorithm;
 extern BOOL g_aimmode_remember;
 extern BOOL g_freelook_while_reloading;
 extern BOOL useSeparateUBGLKeybind;
+extern float g_gunsnd_indoor;
 
 ENGINE_API extern float g_console_sensitive;
 
@@ -2475,7 +2476,6 @@ void CCC_RegisterCommands()
 		CMD3(CCC_Mask, "log_missing_ini", &FS.m_Flags, FS.flPrintLTX);
 		CMD3(CCC_Mask, "g_firepos", &psActorFlags, AF_FIREPOS);
 		CMD3(CCC_Mask, "g_firepos_zoom", &psActorFlags, AF_FIREPOS_ZOOM);
-		CMD3(CCC_Mask, "g_gunsnd_indoor", &psActorFlags, AF_GUNSND_INDOOR);
 		CMD4(CCC_Float, "g_end_modif", &g_end_modif, 0.f, 10.f);
 	}
 #endif // MASTER_GOLD
@@ -2838,6 +2838,7 @@ void CCC_RegisterCommands()
 
     CMD4(CCC_Float, "zoom_step_count", &n_zoom_step_count, 1.0f, 10.0f);
 
+
 	// UBGL/Aim mode switch separation
 	// When switching to UBGL the weapon will remember what mode you switched from and will put you back in that mode. 
 	// For example: You were aiming down with a canted sight when you switched to UBGL. When you switch back it will put you back into Canted sight aim and not the scope.
@@ -2846,4 +2847,6 @@ void CCC_RegisterCommands()
 
 	// Allows freelook during reload animations
 	CMD4(CCC_Integer, "freelook_while_reloading", &g_freelook_while_reloading, 0, 1);
+	// Indoor weapon sounds
+	CMD3(CCC_Float, "g_gunsnd_indoor", &g_gunsnd_indoor, 0.f, 1.f);
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2848,5 +2848,5 @@ void CCC_RegisterCommands()
 	// Allows freelook during reload animations
 	CMD4(CCC_Integer, "freelook_while_reloading", &g_freelook_while_reloading, 0, 1);
 	// Indoor weapon sounds
-	CMD3(CCC_Float, "g_gunsnd_indoor", &g_gunsnd_indoor, 0.f, 1.f);
+	CMD3(CCC_Float, "g_gunsnd_indoor", &g_gunsnd_indoor, 0.0f, 1.0f);
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2475,6 +2475,7 @@ void CCC_RegisterCommands()
 		CMD3(CCC_Mask, "log_missing_ini", &FS.m_Flags, FS.flPrintLTX);
 		CMD3(CCC_Mask, "g_firepos", &psActorFlags, AF_FIREPOS);
 		CMD3(CCC_Mask, "g_firepos_zoom", &psActorFlags, AF_FIREPOS_ZOOM);
+		CMD3(CCC_Mask, "g_gunsnd_indoor", &psActorFlags, AF_GUNSND_INDOOR);
 		CMD4(CCC_Float, "g_end_modif", &g_end_modif, 0.f, 10.f);
 	}
 #endif // MASTER_GOLD


### PR DESCRIPTION
- Make it possible to add custom gun sound for indoor, using `g_gunsnd_indoor` command to use it in game.
- To add custom sound, do `snd_shoot_indoor` and `snd_shoot_silncer_indoor` in the weapon stat.
- The command is a float from 0 to 1 to change volume of indoor and outdoor sound, for example 0.7 mean the indoor have 0.7 volume and the outdoor have 0.3 volume. 1 mean all indoor sounds, 0 mean all outdoors sounds. (0 is the default).
- Add a new parameter for HUD_SOUND_ITEM, HUD_SOUND_COLLECTION, HUD_SOUND_COLLECTION_LAYERED :PlaySound function called volume_mult allow changing the volume of sounds played, default value = 1. Require to make the command above possible.
- g_gunsnd_indoor_volume to change indoor gunsound’s volume.
More info on the mod can be found on its mod thread in Anomaly discord