### PR TITLE
Actor camera y offset

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -328,7 +328,7 @@
         function get_actor_object_looking_at()
         function get_actor_person_looking_at()
         function get_actor_default_action_for_object()
-
+		function set_actor_box_y_offset(u32 box_num, float offset) --box_num:0 for stand, 1 for crouch, 2 for prone;
         // Stalker NPCs
         function get_enable_anomalies_pathfinding()
         function set_enable_anomalies_pathfinding(bool)

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -340,7 +340,7 @@ void set_box_y_offset(LPCSTR section, CPHMovementControl& mc, u32 box_num, float
 	vBOX_center.y = offset;
 	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_size");
 	vBOX_size = pSettings->r_fvector3(section, buff);
-	vBOX_size.y += (cammera_into_collision_shift / 2.f) + offset;
+	vBOX_size.y = offset;
 	bb.set(vBOX_center, vBOX_center);
 	bb.grow(vBOX_size);
 	mc.SetBox(box_num, bb);

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -337,7 +337,7 @@ void set_box_y_offset(LPCSTR section, CPHMovementControl& mc, u32 box_num, float
 	string64 buff, buff1;
 	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_center");
 	vBOX_center = pSettings->r_fvector3(section, buff);
-	vBOX_center.y = offset
+	vBOX_center.y = offset;
 	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_size");
 	vBOX_size = pSettings->r_fvector3(section, buff);
 	vBOX_size.y += (cammera_into_collision_shift / 2.f) + offset;

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -329,9 +329,25 @@ void set_box(LPCSTR section, CPHMovementControl& mc, u32 box_num)
 	mc.SetBox(box_num, bb);
 }
 
+void set_box_y_offset(LPCSTR section, CPHMovementControl& mc, u32 box_num, float offset)
+{
+	Fbox bb;
+	Fvector vBOX_center, vBOX_size;
+	// m_PhysicMovementControl: BOX
+	string64 buff, buff1;
+	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_center");
+	vBOX_center = pSettings->r_fvector3(section, buff);
+	vBOX_center.y = offset
+	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_size");
+	vBOX_size = pSettings->r_fvector3(section, buff);
+	vBOX_size.y += (cammera_into_collision_shift / 2.f) + offset;
+	bb.set(vBOX_center, vBOX_center);
+	bb.grow(vBOX_size);
+	mc.SetBox(box_num, bb);
+}
+
 void CActor::Load(LPCSTR section)
 {
-	// Msg						("Loading actor: %s",section);
 	inherited::Load(section);
 	material().Load(section);
 	CInventoryOwner::Load(section);
@@ -506,6 +522,11 @@ void CActor::Load(LPCSTR section)
 	m_sInventoryBoxUseAction = "inventory_box_use";
 	//---------------------------------------------------------------------
 	m_sHeadShotParticle = READ_IF_EXISTS(pSettings, r_string, section, "HeadShotParticle", 0);
+}
+
+void CActor::set_actor_box_y_offset(u32 box_num, float offset)
+{
+	set_box_y_offset("actor", *character_physics_support()->movement(), box_num, offset);
 }
 
 void CActor::PHHit(SHit& H)

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -340,7 +340,7 @@ void set_box_y_offset(LPCSTR section, CPHMovementControl& mc, u32 box_num, float
 	vBOX_center.y = offset;
 	strconcat(sizeof(buff), buff, "ph_box", itoa(box_num, buff1, 10), "_size");
 	vBOX_size = pSettings->r_fvector3(section, buff);
-	vBOX_size.y = offset;
+	vBOX_size.y += (cammera_into_collision_shift / 2.f) + offset;
 	bb.set(vBOX_center, vBOX_center);
 	bb.grow(vBOX_size);
 	mc.SetBox(box_num, bb);

--- a/src/xrGame/Actor.h
+++ b/src/xrGame/Actor.h
@@ -185,7 +185,7 @@ public:
 
 	virtual void OnPlayHeadShotParticle(NET_Packet P);
 
-
+	virtual void set_actor_box_y_offset(u32 box_num, float offset);
 	virtual void Die(CObject* who);
 	virtual void Hit(SHit* pHDS);
 	virtual void PHHit(SHit& H);

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1086,6 +1086,7 @@ public:
 	void SetActorRunCoef(float run_coef);
 	float GetActorRunBackCoef() const;
 	void SetActorRunBackCoef(float run_back_coef);
+	void SetActorCamBoxYOffset(u32 box_num, float offset);
 	float GetActorWalkAccel() const;
 	void SetActorWalkAccel(float val);
 	float GetActorWalkBackCoef() const;

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -2565,6 +2565,18 @@ void CScriptGameObject::SetActorRunBackCoef(float run_back_coef)
 	pActor->m_fRunBackFactor = run_back_coef;
 }
 
+void CScriptGameObject::SetActorCamBoxYOffset(u32 box_num, float offset)
+{
+	CActor* pActor = smart_cast<CActor*>(&object());
+	if (!pActor)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+			"CActor : cannot access class member SetActorCamBoxYOffset!");
+		return;
+	}
+	pActor->set_actor_box_y_offset(box_num, offset);
+}
+
 
 float CScriptGameObject::GetActorWalkAccel() const
 {

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -595,6 +595,7 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		// demonized: Additional exports
 		.def("get_actor_walk_accel", &CScriptGameObject::GetActorWalkAccel)
 		.def("set_actor_walk_accel", &CScriptGameObject::SetActorWalkAccel)
+		.def("set_actor_box_y_offset", &CScriptGameObject::SetActorCamBoxYOffset)
 		.def("get_actor_walk_back_coef", &CScriptGameObject::GetActorWalkBackCoef)
 		.def("set_actor_walk_back_coef", &CScriptGameObject::SetActorWalkBackCoef)
 		.def("get_actor_crouch_coef", &CScriptGameObject::GetActorCrouchCoef)


### PR DESCRIPTION
Allows to offset actor camera in y coordinate so player will be able precisely change camera height to aim and shoot through holes in walls normally inaccessible