### PR TITLE
Lucy game object shader texture changing

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -389,6 +389,8 @@
 		// Shader/Textures
 		function get_shaders(bool)
 		function set_shader(number, string, string, bool)
+		function get_default_shaders(bool)
+		function reset_shader(number, bool)
 		
 		get_shaders(hud_mode)
 		hud_mode is optional and will default to false
@@ -406,10 +408,16 @@
 			},
 		},
 		
+		get_default_shaders(hud_mode)
+		returns similar table as get_shaders but containing the default shader and texture names, even after they were changed by set_shader
+		
 		set_shader(id, shader, texture, hud_mode) can assign a new shader/texture to the submesh ID
 		id can be -1 to apply the shader/texture to all submeshes at once
 		shader/texture can be nil if you only want to apply one of them
 		hud_mode is optional and will default to false
+		
+		reset_shader(id, hud_mode)
+		same as set_shader but resets to the default shader/texture values, so you don't need to store them in a table to reset them later
     }
 
     class CArtefact : CGameObject {

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -659,6 +659,10 @@
         function set_ui_position();
         function set_ui_rotation(vector);
         function set_ui_rotation(number, number, number);
+		function get_shaders()
+		function get_default_shaders()
+		function set_shader(number, string, string)
+		function reset_shader(number)
     }
     
     flags:

--- a/src/Include/xrRender/RenderVisual.h
+++ b/src/Include/xrRender/RenderVisual.h
@@ -32,10 +32,14 @@ public:
 #endif
 	virtual LPCSTR _BCL getDebugShader() { return nullptr; }
 	virtual LPCSTR _BCL getDebugTexture() { return nullptr; }
+	
+	virtual LPCSTR _BCL getDebugShaderDef() { return nullptr; }
+	virtual LPCSTR _BCL getDebugTextureDef() { return nullptr; }
 
 	virtual xr_vector<IRenderVisual*>* get_children() { return nullptr; };
 
-	virtual void SetShaderTexture(char* shader, LPCSTR texture) {};
+	virtual void SetShaderTexture(LPCSTR shader, LPCSTR texture) {};
+	virtual void ResetShaderTexture() {};
 	virtual void MarkAsHot(bool is_hot) {};				//--DSR-- HeatVision
 	virtual void MarkAsGlowing(bool is_glowing) {};		//--DSR-- SilencerOverheat
 

--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -147,6 +147,12 @@ void dxRender_Visual::SetShaderTexture(LPCSTR s_shader, LPCSTR s_texture)
 	shader.create(*dbg_shader, *dbg_texture);
 }
 
+void dxRender_Visual::ResetShaderTexture()
+{
+	if (!dbg_shader.equal(dbg_shader_def) || !dbg_texture.equal(dbg_texture_def))
+		SetShaderTexture(*dbg_shader_def, *dbg_texture_def);
+}
+
 #define PCOPY(a)	a = pFrom->a
 
 void dxRender_Visual::Copy(dxRender_Visual* pFrom)
@@ -160,6 +166,8 @@ void dxRender_Visual::Copy(dxRender_Visual* pFrom)
 	PCOPY(flags);
 	PCOPY(dbg_name);
 	PCOPY(dbg_shader);
+	PCOPY(dbg_shader_def);
 	PCOPY(dbg_texture);
+	PCOPY(dbg_texture_def);
 	PCOPY(skinning);
 }

--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -68,7 +68,9 @@ void dxRender_Visual::Load(const char* N, IReader* data, u32)
 		string256 fnT, fnS;
 		data->r_stringZ(fnT, sizeof(fnT));
 		data->r_stringZ(fnS, sizeof(fnS));
-		SetShaderTexture(fnS, fnT);
+		dbg_shader_def = fnS;
+		dbg_texture_def = fnT;
+		ResetShaderTexture();
 	}
 
 	// desc
@@ -117,11 +119,12 @@ void dxRender_Visual::MarkAsGlowing(bool is_glowing)
 }
 //--DSR-- SilencerOverheat_end
 
-void dxRender_Visual::SetShaderTexture(char* s_shader, LPCSTR s_texture)
+void dxRender_Visual::SetShaderTexture(LPCSTR s_shader, LPCSTR s_texture)
 {
 	if (s_shader && strlen(s_shader))
 	{
-		char* no_shadow = strstr(s_shader, "$no_shadows");
+		char* shader = xr_strdup(s_shader);
+		char* no_shadow = strstr(shader, "$no_shadows");
 
 		if (no_shadow)
 		{
@@ -131,7 +134,8 @@ void dxRender_Visual::SetShaderTexture(char* s_shader, LPCSTR s_texture)
 		else
 			flags.set(IRenderVisualFlags::eNoShadow, FALSE);
 
-		dbg_shader = s_shader;
+		dbg_shader = shader;
+		xr_delete(shader);
 	}
 
 	if (s_texture && strlen(s_texture))

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -85,7 +85,7 @@ public:
 	//	virtual IParticleCustom*	dcast_ParticleCustom		()				{ return 0;	}
 
 	virtual void SetShaderTexture(LPCSTR shader, LPCSTR texture);
-	virtual void ResetShaderTexture() { SetShaderTexture(*dbg_shader_def, *dbg_texture_def); }
+	virtual void ResetShaderTexture();
 
 	virtual vis_data& _BCL getVisData() { return vis; }
 	virtual u32 getType() { return Type; }

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -51,9 +51,13 @@ public:
 	shared_str					dbg_name	;
 	shared_str					dbg_shader	;
 	shared_str					dbg_texture	;
+	shared_str					dbg_shader_def	;
+	shared_str					dbg_texture_def	;
 	virtual shared_str	_BCL	getDebugName() { return dbg_name; }
 	virtual LPCSTR _BCL			getDebugShader() { return *dbg_shader; }
 	virtual LPCSTR _BCL			getDebugTexture() { return *dbg_texture; }
+	virtual LPCSTR _BCL			getDebugShaderDef() { return *dbg_shader_def; }
+	virtual LPCSTR _BCL			getDebugTextureDef() { return *dbg_texture_def; }
 public:
 	// Common data for rendering
 	u32 Type; // visual's type
@@ -80,7 +84,8 @@ public:
 	//	virtual	CKinematicsAnimated*dcast_PKinematicsAnimated	()				{ return 0;	}
 	//	virtual IParticleCustom*	dcast_ParticleCustom		()				{ return 0;	}
 
-	virtual void SetShaderTexture(char* shader, LPCSTR texture);
+	virtual void SetShaderTexture(LPCSTR shader, LPCSTR texture);
+	virtual void ResetShaderTexture() { SetShaderTexture(*dbg_shader_def, *dbg_texture_def); }
 
 	virtual vis_data& _BCL getVisData() { return vis; }
 	virtual u32 getType() { return Type; }

--- a/src/Layers/xrRender/ModelPool.cpp
+++ b/src/Layers/xrRender/ModelPool.cpp
@@ -312,8 +312,13 @@ void CModelPool::DeleteInternal(dxRender_Visual* & V, BOOL bDiscard)
 		if (it != Registry.end())
 		{
 			// Registry entry found - move it to pool and reset changed shader/texture if necessary
-			if (!V->dbg_shader.equal(V->dbg_shader_def) || !V->dbg_texture.equal(V->dbg_texture_def))
+			xr_vector<IRenderVisual*>* children = V->get_children();
+			if (children)
+				for (auto* child : *children)
+					child->ResetShaderTexture();
+			else
 				V->ResetShaderTexture();
+
 			Pool.insert(mk_pair(it->second, V));
 		}
 		else

--- a/src/Layers/xrRender/ModelPool.cpp
+++ b/src/Layers/xrRender/ModelPool.cpp
@@ -171,6 +171,9 @@ void CModelPool::Instance_Register(LPCSTR N, dxRender_Visual* V)
 
 void CModelPool::Destroy()
 {
+	// Pool
+	Pool.clear();
+
 	// Registry
 	while (!Registry.empty())
 	{
@@ -237,21 +240,37 @@ dxRender_Visual* CModelPool::Create(const char* name, IReader* data)
 	strlwr(low_name);
 	if (strext(low_name)) *strext(low_name) = 0;
 	
-	// 1. Search for already loaded model (reference, base model)
-	dxRender_Visual* Base = Instance_Find(low_name);
-	if (0 == Base)
+	// 0. Search POOL
+	POOL_IT it = Pool.find(low_name);
+	if (it != Pool.end())
 	{
-		// 2. If not found
-		bAllowChildrenDuplicate = FALSE;
-		if (data) Base = Instance_Load(low_name, data, TRUE);
-		else Base = Instance_Load(low_name, TRUE);
-		bAllowChildrenDuplicate = TRUE;
+		// 1. Instance found
+		dxRender_Visual* Model = it->second;
+		Model->Spawn();
+		Pool.erase(it);
+		return Model;
 	}
+	else
+	{
+		// 1. Search for already loaded model (reference, base model)
+		dxRender_Visual* Base = Instance_Find(low_name);
 
-	// 3. If found - return (cloned) reference
-	dxRender_Visual* Model = Instance_Duplicate(Base);
-	Registry.insert(mk_pair(Model, low_name));
-	return Model;
+		if (0 == Base)
+		{
+			// 2. If not found
+			bAllowChildrenDuplicate = FALSE;
+			if (data) Base = Instance_Load(low_name, data, TRUE);
+			else Base = Instance_Load(low_name, TRUE);
+			bAllowChildrenDuplicate = TRUE;
+#ifdef _EDITOR
+			if (!Base)		return 0;
+#endif
+		}
+		// 3. If found - return (cloned) reference
+		dxRender_Visual* Model = Instance_Duplicate(Base);
+		Registry.insert(mk_pair(Model, low_name));
+		return Model;
+	}
 }
 
 dxRender_Visual* CModelPool::CreateChild(LPCSTR name, IReader* data)
@@ -282,7 +301,27 @@ void CModelPool::DeleteInternal(dxRender_Visual* & V, BOOL bDiscard)
 	VERIFY(!g_bRendering);
 	if (!V) return;
 	V->Depart();
-	Discard(V, bDiscard || bForceDiscard);
+	if (bDiscard || bForceDiscard)
+	{
+		Discard(V, TRUE);
+	}
+	else
+	{
+		//
+		REGISTRY_IT it = Registry.find(V);
+		if (it != Registry.end())
+		{
+			// Registry entry found - move it to pool and reset changed shader/texture if necessary
+			if (!V->dbg_shader.equal(V->dbg_shader_def) || !V->dbg_texture.equal(V->dbg_texture_def))
+				V->ResetShaderTexture();
+			Pool.insert(mk_pair(it->second, V));
+		}
+		else
+		{
+			// Registry entry not-found - just special type of visual / particles / etc.
+			xr_delete(V);
+		}
+	}
 	V = NULL;
 }
 
@@ -291,18 +330,20 @@ void CModelPool::Delete(dxRender_Visual* & V, BOOL bDiscard)
 	if (NULL == V) return;
 	if (g_bRendering)
 	{
-		ModelsToDelete.insert(mk_pair(V, !!bDiscard));
+		VERIFY(!bDiscard);
+		ModelsToDelete.push_back(V);
 	}
 	else
 	{
 		DeleteInternal(V, bDiscard);
 	}
+	V = NULL;
 }
 
 void CModelPool::DeleteQueue()
 {
-	for (xr_map<dxRender_Visual*, bool>::iterator it = ModelsToDelete.begin(); it != ModelsToDelete.end(); it++)
-		DeleteInternal((dxRender_Visual*)it->first, it->second);
+	for (u32 it = 0; it < ModelsToDelete.size(); it++)
+		DeleteInternal(ModelsToDelete[it]);
 	ModelsToDelete.clear();
 }
 
@@ -391,6 +432,17 @@ dxRender_Visual* CModelPool::CreatePG(PS::CPGDef* source)
 	return V;
 }
 
+void CModelPool::ClearPool(BOOL b_complete)
+{
+	POOL_IT _I = Pool.begin();
+	POOL_IT _E = Pool.end();
+	for (; _I != _E; _I++)
+	{
+		Discard(_I->second, b_complete);
+	}
+	Pool.clear();
+}
+
 void CModelPool::dump()
 {
 	Log("--- model pool --- begin:");
@@ -409,6 +461,7 @@ void CModelPool::dump()
 	Msg("--- models: %d, mem usage: %d Kb ", k, sz / 1024);
 	sz = 0;
 	k = 0;
+	int free_cnt = 0;
 	for (REGISTRY_IT it = Registry.begin(); it != Registry.end(); it++)
 	{
 		CKinematics* K = PCKinematics((dxRender_Visual*)it->first);
@@ -417,10 +470,12 @@ void CModelPool::dump()
 		{
 			u32 cur = K->mem_usage(true);
 			sz += cur;
-			Msg("#%3d: [%5d Kb] - %s", k++, cur / 1024, it->second.c_str());
+			bool b_free = (Pool.find(it->second) != Pool.end());
+			if (b_free) ++free_cnt;
+			Msg("#%3d: [%s] [%5d Kb] - %s", k++, (b_free) ? "free" : "used", cur / 1024, it->second.c_str());
 		}
 	}
-	Msg("--- instances: %d, mem usage: %d Kb ", k, sz / 1024);
+	Msg("--- instances: %d, free %d, mem usage: %d Kb ", k, free_cnt, sz / 1024);
 	Log("--- model pool --- end.");
 }
 

--- a/src/Layers/xrRender/ModelPool.h
+++ b/src/Layers/xrRender/ModelPool.h
@@ -18,6 +18,14 @@ class ECORE_API CModelPool
 private:
 	friend class CRender;
 
+	struct str_pred : public std::binary_function<const shared_str&, const shared_str&, bool>
+	{
+		IC bool operator()(const shared_str& x, const shared_str& y) const
+		{
+			return xr_strcmp(x, y) < 0;
+		}
+	};
+
 	struct ModelDef
 	{
 		shared_str name;
@@ -31,12 +39,15 @@ private:
 		}
 	};
 
+	typedef xr_multimap<shared_str, dxRender_Visual*, str_pred> POOL;
+	typedef POOL::iterator POOL_IT;
 	typedef xr_map<dxRender_Visual*, shared_str> REGISTRY;
 	typedef REGISTRY::iterator REGISTRY_IT;
 private:
 	xr_vector<ModelDef> Models; // Reference / Base
-	xr_map<dxRender_Visual*, bool> ModelsToDelete; // 
+	xr_vector<dxRender_Visual*> ModelsToDelete; // 
 	REGISTRY Registry; // Just pairing of pointer / Name
+	POOL Pool; // Unused / Inactive
 	BOOL bLogging;
 	BOOL bForceDiscard;
 	BOOL bAllowChildrenDuplicate;
@@ -65,6 +76,7 @@ public:
 
 	void Prefetch();
 	void Prefetch_One(LPCSTR N);
+	void ClearPool(BOOL b_complete);
 
 	void dump();
 

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -184,7 +184,6 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
-IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -232,6 +231,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
+void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -198,12 +198,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
-	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
+	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R2/r2.cpp
+++ b/src/Layers/xrRenderPC_R2/r2.cpp
@@ -478,7 +478,6 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
-IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -526,6 +525,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCTSTR name) { Models->Prefetch_One(name); }
+void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R2/r2.h
+++ b/src/Layers/xrRenderPC_R2/r2.h
@@ -296,12 +296,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
-	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
+	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R2/r2_loader.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_loader.cpp
@@ -192,6 +192,7 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
+		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/Layers/xrRenderPC_R3/r3.cpp
+++ b/src/Layers/xrRenderPC_R3/r3.cpp
@@ -620,7 +620,6 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
-IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -668,6 +667,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
+void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R3/r3.h
+++ b/src/Layers/xrRenderPC_R3/r3.h
@@ -343,12 +343,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
-	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
+	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R3/r3_loader.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_loader.cpp
@@ -197,6 +197,7 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
+		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -688,7 +688,6 @@ void CRender::ros_destroy(IRender_ObjectSpecific* & p) { xr_delete(p); }
 IRenderVisual* CRender::model_Create(LPCSTR name, IReader* data) { return Models->Create(name, data); }
 IRenderVisual* CRender::model_CreateChild(LPCSTR name, IReader* data) { return Models->CreateChild(name, data); }
 IRenderVisual* CRender::model_Duplicate(IRenderVisual* V) { return Models->Instance_Duplicate((dxRender_Visual*)V); }
-IRenderVisual* CRender::model_Instance(LPCSTR name) { return Models->Instance_Find(name); }
 
 void CRender::model_Delete(IRenderVisual* & V, BOOL bDiscard)
 {
@@ -736,6 +735,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name) { Models->Prefetch_One(name); }
+void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R4/r4.h
+++ b/src/Layers/xrRenderPC_R4/r4.h
@@ -363,12 +363,12 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0);
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data);
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V);
-	virtual IRenderVisual* model_Instance(LPCSTR name);
 	virtual void model_Delete(IRenderVisual* & V, BOOL bDiscard);
 	virtual void model_Delete(IRender_DetailModel* & F);
 	virtual void model_Logging(BOOL bEnable) { Models->Logging(bEnable); }
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name);
+	virtual void models_Clear(BOOL b_complete);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -181,6 +181,7 @@ void CRender::level_Unload()
 
 	if (psDeviceFlags2.test(rsClearModels))
 	{
+		Models->ClearPool(true);
 		Visuals.clear_and_free();
 		dxRenderDeviceRender::Instance().Resources->Dump(false);
 		//static int unload_counter = 0;

--- a/src/xrEngine/IGame_Persistent.cpp
+++ b/src/xrEngine/IGame_Persistent.cpp
@@ -257,6 +257,7 @@ void IGame_Persistent::OnGameEnd()
 {
 #ifndef _EDITOR
 	ObjectPool.clear();
+	Render->models_Clear(TRUE);
 #endif
 }
 

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -322,13 +322,13 @@ public:
 	virtual IRenderVisual* model_Create(LPCSTR name, IReader* data = 0) = 0;
 	virtual IRenderVisual* model_CreateChild(LPCSTR name, IReader* data) = 0;
 	virtual IRenderVisual* model_Duplicate(IRenderVisual* V) = 0;
-	virtual IRenderVisual* model_Instance(LPCSTR name) = 0;
 	//virtual void model_Delete (IRenderVisual* & V, BOOL bDiscard=FALSE) = 0;
 	virtual void model_Delete(IRenderVisual*& V, BOOL bDiscard = FALSE) = 0;
 	// virtual void model_Delete (IRender_DetailModel* & F) = 0;
 	virtual void model_Logging(BOOL bEnable) = 0;
 	virtual void models_Prefetch() = 0;
 	virtual void models_PrefetchOne(LPCSTR name) = 0;
+	virtual void models_Clear(BOOL b_complete) = 0;
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V) = 0;

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -2236,8 +2236,7 @@ void CActor::OnItemDrop(CInventoryItem* inventory_item, bool just_before_destroy
 	CCustomOutfit* outfit = smart_cast<CCustomOutfit*>(inventory_item);
 	if (outfit && inventory_item->m_ItemCurrPlace.type == eItemPlaceSlot)
 	{
-		if (!(just_before_destroy && psDeviceFlags.test(rsDisableObjectsAsCrows)))
-			outfit->ApplySkinModel(this, false, false);
+		outfit->ApplySkinModel(this, false, false);
 	}
 
 	CWeapon* weapon = smart_cast<CWeapon*>(inventory_item);

--- a/src/xrGame/CharacterPhysicsSupport.cpp
+++ b/src/xrGame/CharacterPhysicsSupport.cpp
@@ -1294,15 +1294,9 @@ void CCharacterPhysicsSupport::in_ChangeVisual()
 
 	if (m_pPhysicsShell)
 	{
-		if (!m_EntityAlife.renderable.visual)
-			m_pPhysicsShell->set_Kinematics(nullptr);
-
 		VERIFY(m_eType!=etStalker);
 		if (m_physics_skeleton)
 		{
-			if (!m_EntityAlife.renderable.visual)
-				m_physics_skeleton->set_Kinematics(nullptr);
-
 			m_EntityAlife.processing_deactivate();
 			m_physics_skeleton->Deactivate();
 			xr_delete(m_physics_skeleton);

--- a/src/xrGame/DestroyablePhysicsObject.cpp
+++ b/src/xrGame/DestroyablePhysicsObject.cpp
@@ -31,7 +31,6 @@ void CDestroyablePhysicsObject::OnChangeVisual()
 {
 	if (m_pPhysicsShell)
 	{
-		m_pPhysicsShell->set_Kinematics(nullptr);
 		m_pPhysicsShell->Deactivate();
 		xr_delete(m_pPhysicsShell);
 		VERIFY(0==Visual());

--- a/src/xrGame/Level_network.cpp
+++ b/src/xrGame/Level_network.cpp
@@ -87,6 +87,7 @@ void CLevel::remove_objects()
 	stalker_animation_data_storage().clear();
 
 	VERIFY(Render);
+	Render->models_Clear(FALSE);
 
 	Render->clear_static_wallmarks();
 

--- a/src/xrGame/PhysicsShellHolder.cpp
+++ b/src/xrGame/PhysicsShellHolder.cpp
@@ -82,7 +82,7 @@ void CPhysicsShellHolder::net_Destroy()
 		char_support->destroy_imotion();
 	inherited::net_Destroy();
 	b_sheduled = false;
-	if (!renderable.visual && m_pPhysicsShell) m_pPhysicsShell->set_Kinematics(nullptr);
+	
 	deactivate_physics_shell();
 	xr_delete(m_pPhysicsShell);
 }
@@ -379,11 +379,7 @@ void CPhysicsShellHolder::OnChangeVisual()
 			char_support->destroy_imotion();
 
 		VERIFY(!character_physics_support() || !character_physics_support()->interactive_motion());
-		if (m_pPhysicsShell)
-		{
-			m_pPhysicsShell->set_Kinematics(nullptr);
-			m_pPhysicsShell->Deactivate();
-		}
+		if (m_pPhysicsShell)m_pPhysicsShell->Deactivate();
 
 		xr_delete(m_pPhysicsShell);
 		VERIFY(0==m_pPhysicsShell);

--- a/src/xrGame/ai/monsters/basemonster/base_monster.cpp
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.cpp
@@ -817,12 +817,6 @@ void CBaseMonster::net_Relcase(CObject* O)
 	m_pPhysics_support->in_NetRelcase(O);
 }
 
-void CBaseMonster::OnChangeVisual()
-{
-	if (renderable.visual && ID() != u16(-1)) control().reinit(); //skip during load
-	inherited::OnChangeVisual();
-}
-
 void CBaseMonster::create_base_controls()
 {
 	m_anim_base = xr_new<CControlAnimationBase>();

--- a/src/xrGame/ai/monsters/basemonster/base_monster.h
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.h
@@ -103,8 +103,6 @@ public:
 	virtual void net_Import(NET_Packet& P);
 	virtual void net_Relcase(CObject* O);
 
-	virtual void OnChangeVisual();
-
 	//save/load server serialization
 	virtual void save(NET_Packet& output_packet) { inherited::save(output_packet); }
 	virtual void load(IReader& input_packet) { inherited::load(input_packet); }

--- a/src/xrGame/script_attachment_manager.cpp
+++ b/src/xrGame/script_attachment_manager.cpp
@@ -625,3 +625,125 @@ Fvector script_attachment::GetCenter()
 
 	return { 0,0,0 };
 }
+
+luabind::object script_attachment::GetShaders()
+{
+	luabind::object table = luabind::newtable(ai().script_engine().lua());
+
+	if (!m_model)
+	{
+		table["error"] = true;
+		return table;
+	}
+
+	xr_vector<IRenderVisual*>* children = m_model->get_children();
+
+	if (!children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = m_model->getDebugShader();
+		subtable["texture"] = m_model->getDebugTexture();
+		table[1] = subtable;
+		return table;
+	}
+
+	int i = 1;
+
+	for (auto* child : *children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShader();
+		subtable["texture"] = child->getDebugTexture();
+		table[i] = subtable;
+		++i;
+	}
+
+	return table;
+}
+
+luabind::object script_attachment::GetDefaultShaders()
+{
+	luabind::object table = luabind::newtable(ai().script_engine().lua());
+
+	if (!m_model)
+	{
+		table["error"] = true;
+		return table;
+	}
+
+	xr_vector<IRenderVisual*>* children = m_model->get_children();
+
+	if (!children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = m_model->getDebugShaderDef();
+		subtable["texture"] = m_model->getDebugTextureDef();
+		table[1] = subtable;
+		return table;
+	}
+
+	int i = 1;
+
+	for (auto* child : *children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShaderDef();
+		subtable["texture"] = child->getDebugTextureDef();
+		table[i] = subtable;
+		++i;
+	}
+
+	return table;
+}
+
+void script_attachment::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture)
+{
+	if (!m_model) return;
+	xr_vector<IRenderVisual*>* children = m_model->get_children();
+
+	if (!children)
+	{
+		m_model->SetShaderTexture(shader, texture);
+		return;
+	}
+
+	if (id == -1)
+	{
+		for (auto* child : *children)
+		{
+			child->SetShaderTexture(shader, texture);
+		}
+		return;
+	}
+
+	id--;
+
+	if (id >= 0 && children->size() > id)
+		children->at(id)->SetShaderTexture(shader, texture);
+}
+
+void script_attachment::ResetShaderTexture(int id)
+{
+	if (!m_model) return;
+	xr_vector<IRenderVisual*>* children = m_model->get_children();
+
+	if (!children)
+	{
+		m_model->ResetShaderTexture();
+		return;
+	}
+
+	if (id == -1)
+	{
+		for (auto* child : *children)
+		{
+			child->ResetShaderTexture();
+		}
+		return;
+	}
+
+	id--;
+
+	if (id >= 0 && children->size() > id)
+		children->at(id)->ResetShaderTexture();
+}

--- a/src/xrGame/script_attachment_manager.h
+++ b/src/xrGame/script_attachment_manager.h
@@ -13,16 +13,16 @@ enum script_attachment_flags
 struct script_attachment_bone_cb
 {
 	u16 m_bone_id, m_attachment_bone_id;
-	luabind::functor<Fmatrix>* m_func;
+	::luabind::functor<Fmatrix>* m_func;
 	script_attachment* m_attachment;
 	Fmatrix m_mat;
 	bool m_overwrite;
 
-	script_attachment_bone_cb(const luabind::functor<Fmatrix>& func, script_attachment* att, u16 id, bool overwrite)
+	script_attachment_bone_cb(const ::luabind::functor<Fmatrix>& func, script_attachment* att, u16 id, bool overwrite)
 	{
 		m_attachment = att;
 		m_attachment_bone_id = id;
-		m_func = xr_new<luabind::functor<Fmatrix>>(func);
+		m_func = xr_new<::luabind::functor<Fmatrix>>(func);
 		m_mat = Fidentity;
 		m_bone_id = BI_NONE;
 		m_overwrite = overwrite;
@@ -111,7 +111,7 @@ public:
 	void SetParent(script_attachment* att);
 	void SetParent(CGameObject* obj);
 	void SetParent(CScriptGameObject* obj);
-	luabind::object GetParent();
+	::luabind::object GetParent();
 
 	void SetParentBone(u16 bone_id) { m_parent_bone = bone_id; }
 	u16 GetParentBone() { return m_parent_bone; }
@@ -149,12 +149,17 @@ public:
 
 	static void _BCL ScriptAttachmentBoneCallback(CBoneInstance* B);
 	void SetBoneCallback(u16 bone_id, u16 parent_bone, bool overwrite = false);
-	void SetBoneCallback(u16 bone_id, const luabind::functor<Fmatrix>& func, bool overwrite = false);
+	void SetBoneCallback(u16 bone_id, const ::luabind::functor<Fmatrix>& func, bool overwrite = false);
 	void RemoveBoneCallback(u16 bone_id);
 
 	Fmatrix GetBoneMatrix(u16 bone_id);
 	Fmatrix GetTransform() { return m_transform; };
 	Fvector GetCenter();
+
+	::luabind::object GetShaders();
+	::luabind::object GetDefaultShaders();
+	void SetShaderTexture(int id, LPCSTR shader, LPCSTR texture);
+	void ResetShaderTexture(int id);
 
 	DECLARE_SCRIPT_REGISTER_FUNCTION
 };

--- a/src/xrGame/script_attachment_script.cpp
+++ b/src/xrGame/script_attachment_script.cpp
@@ -2,7 +2,7 @@
 #include "pch_script.h"
 #include "script_attachment_manager.h"
 
-using namespace luabind;
+using namespace ::luabind;
 
 #pragma optimize("s",on)
 void script_attachment::script_register(lua_State* L)
@@ -57,6 +57,10 @@ void script_attachment::script_register(lua_State* L)
 		.def("get_transform", &script_attachment::GetTransform)
 		.def("get_center", &script_attachment::GetCenter)
 		.def("bone_callback", (void (script_attachment::*)(u16,u16,bool)) &script_attachment::SetBoneCallback)
-		.def("bone_callback", (void (script_attachment::*)(u16, const luabind::functor<Fmatrix>&,bool)) &script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(u16, const ::luabind::functor<Fmatrix>&,bool)) &script_attachment::SetBoneCallback)
+		.def("get_shaders", &script_attachment::GetShaders)
+		.def("get_default_shaders", &script_attachment::GetDefaultShaders)
+		.def("set_shader", &script_attachment::SetShaderTexture)
+		.def("reset_shader", &script_attachment::ResetShaderTexture)
 	];
 }

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -1147,6 +1147,57 @@ luabind::object CScriptGameObject::GetShaders(bool bHud)
 	return table;
 }
 
+luabind::object CScriptGameObject::GetDefaultShaders(bool bHud)
+{
+	IKinematics* k = nullptr;
+
+	if (bHud)
+	{
+		CActor* act = smart_cast<CActor*>(&object());
+		CHudItem* itm = smart_cast<CHudItem*>(&object());
+		if (itm)
+			k = itm->HudItemData()->m_model;
+		else if (act)
+			k = g_player_hud->m_model->dcast_PKinematics();
+	}
+
+	if (!k)
+		k = object().Visual()->dcast_PKinematics();
+
+	luabind::object table = luabind::newtable(ai().script_engine().lua());
+
+	if (!k)
+	{
+		table["error"] = true;
+		return table;
+	}
+
+	IRenderVisual* vis = k->dcast_RenderVisual();
+	xr_vector<IRenderVisual*>* children = vis->get_children();
+
+	if (!children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = vis->getDebugShaderDef();
+		subtable["texture"] = vis->getDebugTextureDef();
+		table[1] = subtable;
+		return table;
+	}
+
+	int i = 1;
+
+	for (auto* child : *children)
+	{
+		luabind::object subtable = luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShaderDef();
+		subtable["texture"] = child->getDebugTextureDef();
+		table[i] = subtable;
+		++i;
+	}
+
+	return table;
+}
+
 void set_shader_tex(IRenderVisual* vis, int id, LPCSTR shader, LPCSTR texture)
 {
 	xr_vector<IRenderVisual*>* children = vis->get_children();
@@ -1170,6 +1221,31 @@ void set_shader_tex(IRenderVisual* vis, int id, LPCSTR shader, LPCSTR texture)
 
 	if (id >= 0 && children->size() > id)
 		children->at(id)->SetShaderTexture(shader, texture);
+}
+
+void reset_shader_tex(IRenderVisual* vis, int id)
+{
+	xr_vector<IRenderVisual*>* children = vis->get_children();
+
+	if (!children)
+	{
+		vis->ResetShaderTexture();
+		return;
+	}
+
+	if (id == -1)
+	{
+		for (auto* child : *children)
+		{
+			child->ResetShaderTexture();
+		}
+		return;
+	}
+
+	id--;
+
+	if (id >= 0 && children->size() > id)
+		children->at(id)->ResetShaderTexture();
 }
 
 void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, bool bHud)
@@ -1196,4 +1272,30 @@ void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, 
 	if (!k) return;
 
 	set_shader_tex(k->dcast_RenderVisual(), id, shader, texture);
+}
+
+void CScriptGameObject::ResetShaderTexture(int id, bool bHud)
+{
+	IKinematics* k = nullptr;
+
+	if (bHud)
+	{
+		CActor* act = smart_cast<CActor*>(&object());
+		CHudItem* itm = smart_cast<CHudItem*>(&object());
+		if (itm)
+			k = itm->HudItemData()->m_model;
+		else if (act)
+		{
+			reset_shader_tex(g_player_hud->m_model->dcast_RenderVisual(), id);
+			reset_shader_tex(g_player_hud->m_model_2->dcast_RenderVisual(), id);
+			return;
+		}
+	}
+
+	if (!k)
+		k = object().Visual()->dcast_PKinematics();
+
+	if (!k) return;
+
+	reset_shader_tex(k->dcast_RenderVisual(), id);
 }

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -1147,7 +1147,7 @@ luabind::object CScriptGameObject::GetShaders(bool bHud)
 	return table;
 }
 
-void set_shader_tex(IRenderVisual* vis, int id, char* shader, LPCSTR texture)
+void set_shader_tex(IRenderVisual* vis, int id, LPCSTR shader, LPCSTR texture)
 {
 	xr_vector<IRenderVisual*>* children = vis->get_children();
 
@@ -1184,8 +1184,8 @@ void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, 
 			k = itm->HudItemData()->m_model;
 		else if (act)
 		{
-			set_shader_tex(g_player_hud->m_model->dcast_RenderVisual(), id, xr_strdup(shader), texture);
-			set_shader_tex(g_player_hud->m_model_2->dcast_RenderVisual(), id, xr_strdup(shader), texture);
+			set_shader_tex(g_player_hud->m_model->dcast_RenderVisual(), id, shader, texture);
+			set_shader_tex(g_player_hud->m_model_2->dcast_RenderVisual(), id, shader, texture);
 			return;
 		}
 	}
@@ -1195,5 +1195,5 @@ void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, 
 
 	if (!k) return;
 
-	set_shader_tex(k->dcast_RenderVisual(), id, xr_strdup(shader), texture);
+	set_shader_tex(k->dcast_RenderVisual(), id, shader, texture);
 }

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1122,7 +1122,9 @@ public:
 	//-Alundaio
 
 	::luabind::object GetShaders(bool bHud = false);
+	::luabind::object GetDefaultShaders(bool bHud = false);
 	void SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, bool bHud = false);
+	void ResetShaderTexture(int id, bool bHud = false);
 
 	script_attachment* AddAttachment(u16 slot, LPCSTR model_name);
 	script_attachment* GetAttachment(u16 slot);

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -638,7 +638,9 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		.def("remove_attachment", &CScriptGameObject::RemoveAttachment)
 
 		.def("get_shaders", &CScriptGameObject::GetShaders)
+		.def("get_default_shaders", &CScriptGameObject::GetDefaultShaders)
 		.def("set_shader", &CScriptGameObject::SetShaderTexture)
+		.def("reset_shader", &CScriptGameObject::ResetShaderTexture)
 		;
 	return (instance);
 }

--- a/src/xrGame/stalker_animation_manager.cpp
+++ b/src/xrGame/stalker_animation_manager.cpp
@@ -73,7 +73,6 @@ void CStalkerAnimationManager::reinit()
 void CStalkerAnimationManager::reload()
 {
 	m_visual = object().Visual();
-	R_ASSERT(m_visual);
 
 	m_crouch_state_config = object().SpecificCharacter().crouch_type();
 	VERIFY((m_crouch_state_config == 0) || (m_crouch_state_config == 1) || (m_crouch_state_config == -1));
@@ -85,7 +84,7 @@ void CStalkerAnimationManager::reload()
 	m_skeleton_animated = smart_cast<IKinematicsAnimated*>(m_visual);
 	VERIFY(m_skeleton_animated);
 
-	m_data_storage = stalker_animation_data_storage().object(smart_cast<IKinematicsAnimated*>(::Render->model_Instance(*object().cNameVisual())));
+	m_data_storage = stalker_animation_data_storage().object(m_skeleton_animated);
 	VERIFY(m_data_storage);
 
 	if (!object().g_Alive())


### PR DESCRIPTION
- Removal of Model Pool caused a lot of unpredictable crashes, so now it's back but with a small change to work in line with the set_shader lua methods :)
- Added `get_default_shaders` and `reset_shader` to easily revert a model to its vanilla shaders without the need to store default values in a table
- Added support for getting/setting/resetting Script Attachment model shaders/textures