### PR TITLE
Add support for distortion on HUD geometry

### DIFF
--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -56,7 +56,8 @@ void R_dsgraph_structure::r_dsgraph_insert_dynamic(dxRender_Visual* pVisual, Fve
 	ShaderElement* sh_d = &*pVisual->shader->E[4];
 	if (RImplementation.o.distortion && sh_d && sh_d->flags.bDistort && pmask[sh_d->flags.iPriority / 2])
 	{
-		mapSorted_Node* N = mapDistort.insertInAnyWay(distSQ);
+		mapSorted_T& test = RI.val_bHUD ? mapHUDDistort : mapDistort;
+		mapSorted_Node* N = test.insertInAnyWay(distSQ);
 		N->val.ssa = SSA;
 		N->val.pObject = RI.val_pObject;
 		N->val.pVisual = pVisual;

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -833,6 +833,20 @@ void R_dsgraph_structure::r_dsgraph_render_distort()
 	// Sorted (back to front)
 	mapDistort.traverseRL(sorted_L1);
 	mapDistort.clear();
+
+	// Change projection
+	Fmatrix FTold = Device.mFullTransform;
+	Device.mFullTransform = Device.mFullTransformHud;
+	RCache.set_xform_project(Device.mProjectHud);
+
+	rmNear();
+	mapHUDDistort.traverseLR(sorted_L1);
+	mapHUDDistort.clear();
+	rmNormal();
+
+	// Restore projection
+	Device.mFullTransform = FTold;
+	RCache.set_xform_project(Device.mProject);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -61,6 +61,7 @@ public:
 	R_dsgraph::mapSorted_T										mapHUDEmissive;
 	R_dsgraph::mapSorted_T										mapCamAttachedEmissive;
 #endif
+	R_dsgraph::mapSorted_T										mapHUDDistort;
 
 	// Runtime structures 
 	xr_vector<R_dsgraph::mapNormalVS::TNode*,render_alloc<R_dsgraph::mapNormalVS::TNode*>> nrmVS;
@@ -184,6 +185,7 @@ public:
 		mapLOD.destroy();
 		mapDistort.destroy();
 		mapHUDSorted.destroy();
+		mapHUDDistort.destroy();
 		mapCamAttachedSorted.destroy();
 		mapLandscape.destroy();
 		HUDMask.destroy();

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
@@ -317,8 +317,16 @@ void CRenderTarget::End()
 	BOOL bDistort = RImplementation.o.distortion;
 	BOOL bCMap = NeedColorMapping();
 	bool _menu_pp = g_pGamePersistent ? g_pGamePersistent->OnRenderPPUI_query() : false;
-	if ((0 == RImplementation.mapDistort.size()) && !_menu_pp) bDistort = FALSE;
-	if (bDistort) phase_distortion();
+	u32 count = RImplementation.mapDistort.size() + RImplementation.mapHUDDistort.size();
+
+	if ((0 == count) && !_menu_pp)
+	{
+		bDistort = FALSE;
+	}
+	if (bDistort)
+	{
+		phase_distortion();
+	}
 
 	// combination/postprocess
 	RCache.set_RT(HW.pBaseRT);
@@ -403,9 +411,14 @@ void CRenderTarget::phase_distortion()
 	CHK_DX(HW.pDevice->Clear ( 0L, NULL, D3DCLEAR_TARGET, color_rgba(127,127,127,127), 1.0f, 0L));
 
 	if (g_pGameLevel && g_pGamePersistent && !g_pGamePersistent->OnRenderPPUI_query())
+	{
 		RImplementation.r_dsgraph_render_distort();
+	}
 	else
+	{
 		RImplementation.mapDistort.clear();
+		RImplementation.mapHUDDistort.clear();
+	}
 
 	if (g_pGamePersistent) g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
 }

--- a/src/Layers/xrRenderPC_R2/r2_R_render.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_R_render.cpp
@@ -490,12 +490,12 @@ void CRender::Render()
 
 	// Postprocess
 	Target->phase_combine();
-	VERIFY(0==mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 }
 
 void CRender::render_forward()
 {
-	VERIFY(0==mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 	RImplementation.o.distortion = RImplementation.o.distortion_enabled; // enable distorion
 
 	//******* Main render - second order geometry (the one, that doesn't support deffering)

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
@@ -235,7 +235,11 @@ void CRenderTarget::phase_combine()
 	// Distortion filter
 	BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
 	{
-		if ((0 == RImplementation.mapDistort.size()) && !_menu_pp) bDistort = FALSE;
+		u32 count = RImplementation.mapDistort.size() + RImplementation.mapHUDDistort.size();
+		if ((0 == count) && !_menu_pp)
+		{
+			bDistort = FALSE;
+		}
 		if (bDistort)
 		{
 			u_setrt(rt_Generic_1, 0, 0, HW.pBaseZB); // Now RT is a distortion mask

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -224,7 +224,7 @@ void CRender::Render()
 {
 	PIX_EVENT(CRender_Render);
 
-	VERIFY(0==mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 
 	rmNormal();
 
@@ -636,12 +636,12 @@ void CRender::Render()
 	if (Details)
 		Details->details_clear();
 
-	VERIFY(0==mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 }
 
 void CRender::render_forward()
 {
-	VERIFY(0==mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 	RImplementation.o.distortion = RImplementation.o.distortion_enabled; // enable distorion
 
 	//******* Main render - second order geometry (the one, that doesn't support deffering)
@@ -665,7 +665,7 @@ void CRender::render_forward()
 // Redotix99: for 3D Shader Based Scopes
 void CRender::render_Reticle()
 {
-	VERIFY(0 == mapDistort.size());
+	VERIFY(0 == mapDistort.size() + mapHUDDistort.size());
 	RImplementation.o.distortion = RImplementation.o.distortion_enabled;
 
 	r_dsgraph_render_ScopeSorted();

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -449,8 +449,11 @@ void CRenderTarget::phase_combine()
 	// Distortion filter
 	BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
 	{
-		if ((0 == RImplementation.mapDistort.size()) && !_menu_pp)
+		u32 count = RImplementation.mapDistort.size() + RImplementation.mapHUDDistort.size();
+		if ((count < 1 && !_menu_pp))
+		{
 			bDistort = FALSE;
+		}
 		if (bDistort)
 		{
 			PIX_EVENT(render_distort_objects);

--- a/src/xrGame/ai/monsters/control_animation_base_update.cpp
+++ b/src/xrGame/ai/monsters/control_animation_base_update.cpp
@@ -115,13 +115,10 @@ void CControlAnimationBase::update()
 	if (m_state_attack) return;
 
 	// Установка Yaw
-	if (m_object->control().path_builder().is_moving_on_path() && m_object->path().enabled()) m_object
-	                                                                                          ->dir().
-	                                                                                          use_path_direction(
-		                                                                                          ((spec_params &
-				                                                                                          ASP_MOVE_BKWD)
-			                                                                                          ==
-			                                                                                          ASP_MOVE_BKWD));
+	if (m_object->control().path_builder().is_moving_on_path() && m_object->path().enabled())
+	{
+		m_object->dir().use_path_direction(((spec_params & ASP_MOVE_BKWD) == ASP_MOVE_BKWD));
+	}
 
 	SelectAnimation();
 	SelectVelocities();

--- a/src/xrGame/ai/monsters/dog/dog.cpp
+++ b/src/xrGame/ai/monsters/dog/dog.cpp
@@ -216,9 +216,8 @@ void CAI_Dog::reinit()
 
 	com_man().add_rotation_jump_data("1", "2", "3", "4", PI_DIV_2);
 	com_man().add_rotation_jump_data("5", "6", "7", "8", deg(179));
-	//com_man().add_melee_jump_data("5","jump_right_0");
-	//com_man().add_rotation_jump_data("stand_jump_left_0","stand_jump_left_0",
-	//	                             "stand_jump_right_0","stand_jump_right_0", deg(179));
+	//com_man().add_melee_jump_data("5", "jump_right_0");
+	//com_man().add_rotation_jump_data("stand_jump_left_0", "stand_jump_left_0", "stand_jump_right_0" ,"stand_jump_right_0", deg(179));
 	//com_man().add_melee_jump_data("stand_jump_left_0", "stand_jump_right_0");
 
 	b_anim_end = false;


### PR DESCRIPTION
This PR adds support for distortion shaders on HUD geometry.

Most of the code is *inspired* (an exact copy) of [code](https://github.com/ixray-team/ixray-1.6-stcop/commit/801e6f0cfe890b5356cbf42a8ad8164fa8044efe) made by [Drombeys](https://github.com/Drombeys) for the IX-Ray engine. So credits goes to them for the work, I simply ported it to Anomaly's engine.