### PR TITLE
HUD <-> World Transforms

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -281,6 +281,8 @@
         function setXYZi(float x, float y, float z)
         function setXYZi(Fvector)
         Fvector getHPB()
+        function hud_to_world()
+        function world_to_hud()
     }
 
     class particle_object {
@@ -529,7 +531,7 @@
         function GetZoomRotateTime()
         function SetZoomRotateTime(float)
     }
-
+	
     enum rq_target { (sum them up to target multiple types)
         rqtNone     = 0,
         rqtObject   = 1,

--- a/src/Layers/xrRenderPC_R1/LightPPA.cpp
+++ b/src/Layers/xrRenderPC_R1/LightPPA.cpp
@@ -323,8 +323,8 @@ IC void hud_light_apply(xr_map<light*, std::pair<Fvector, Fvector>>& saved_pos, 
 
 		saved_pos.emplace(L, mk_pair(L->position, L->direction));
 
-		Fvector::hud_to_world(L->position);
-		Fvector::hud_to_world_dir(L->direction);
+		Device.hud_to_world(L->position);
+		Device.hud_to_world_dir(L->direction);
 	}
 }
 

--- a/src/Layers/xrRenderPC_R2/r2_R_lights.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_R_lights.cpp
@@ -16,8 +16,8 @@ IC void hud_light_apply(xr_map<light*, std::pair<Fvector, Fvector>>& saved_pos, 
 
 		saved_pos.emplace(L, mk_pair(L->position, L->direction));
 
-		Fvector::hud_to_world(L->position);
-		Fvector::hud_to_world_dir(L->direction);
+		Device.hud_to_world(L->position);
+		Device.hud_to_world_dir(L->direction);
 	}
 }
 

--- a/src/Layers/xrRenderPC_R3/r2_R_lights.cpp
+++ b/src/Layers/xrRenderPC_R3/r2_R_lights.cpp
@@ -16,8 +16,8 @@ IC void hud_light_apply(xr_map<light*, std::pair<Fvector, Fvector>>& saved_pos, 
 
 		saved_pos.emplace(L, mk_pair(L->position, L->direction));
 
-		Fvector::hud_to_world(L->position);
-		Fvector::hud_to_world_dir(L->direction);
+		Device.hud_to_world(L->position);
+		Device.hud_to_world_dir(L->direction);
 	}
 }
 

--- a/src/Layers/xrRenderPC_R4/r2_R_lights.cpp
+++ b/src/Layers/xrRenderPC_R4/r2_R_lights.cpp
@@ -34,8 +34,8 @@ IC void hud_light_apply(xr_map<light*, std::pair<Fvector, Fvector>>& saved_pos, 
 
 		saved_pos.emplace(L, mk_pair(L->position, L->direction));
 
-		Fvector::hud_to_world(L->position);
-		Fvector::hud_to_world_dir(L->direction);
+		Device.hud_to_world(L->position);
+		Device.hud_to_world_dir(L->direction);
 	}
 }
 

--- a/src/xrCore/_matrix.h
+++ b/src/xrCore/_matrix.h
@@ -916,11 +916,18 @@ public:
 		xyz.mul(-1.f);
 	}
 
-	IC static void hud_to_world(Self& xform)
+	IC SelfRef hud_to_world()
 	{
-		Fvector::hud_to_world(xform.c);
-		Fvector::hud_to_world_dir(xform.k);
-		Fvector::generate_orthonormal_basis_normalized(xform.k, xform.j, xform.i);
+		SelfRef tmp = *this;
+		Device.hud_to_world(tmp);
+		return *this;
+	}
+
+	IC SelfRef world_to_hud()
+	{
+		SelfRef tmp = *this;
+		Device.world_to_hud(tmp);
+		return *this;
 	}
 };
 

--- a/src/xrCore/_vector3d.h
+++ b/src/xrCore/_vector3d.h
@@ -693,83 +693,31 @@ public:
 		}
 	}
 
-	IC static void hud_to_world(Self& pos)
-	{
-		Device.mView.transform_tiny(pos);
-		Device.mProjectHud.transform_tiny(pos);
-
-		Device.mInvProject.transform_tiny(pos);
-		Device.mInvView.transform_tiny(pos);
-	}
-
-	IC static void world_to_hud(Self& pos)
-	{
-		Device.mInvView.transform_tiny(pos);
-		Device.mInvProject.transform_tiny(pos);
-
-		Device.mProjectHud.transform_tiny(pos);
-		Device.mView.transform_tiny(pos);
-	}
-
-	IC static void hud_to_world_dir(Self& dir)
-	{
-		Device.mView.transform_dir(dir);
-		Device.mProjectHud.transform_dir(dir);
-
-		Device.mInvProject.transform_dir(dir);
-		Device.mInvView.transform_dir(dir);
-	}
-
-	IC static void world_to_hud_dir(Self& dir)
-	{
-		Device.mInvView.transform_dir(dir);
-		Device.mInvProject.transform_dir(dir);
-
-		Device.mProjectHud.transform_dir(dir);
-		Device.mView.transform_dir(dir);
-	}
-
-	IC SelfRef hud_to_world_self()
+	IC SelfRef hud_to_world()
 	{
 		SelfRef tmp = *this;
-		Device.mView.transform_tiny(tmp);
-		Device.mProjectHud.transform_tiny(tmp);
-
-		Device.mInvProject.transform_tiny(tmp);
-		Device.mInvView.transform_tiny(tmp);
+		Device.hud_to_world(tmp);
 		return *this;
 	}
 
-	IC SelfRef world_to_hud_self()
+	IC SelfRef world_to_hud()
 	{
 		SelfRef tmp = *this;
-		Device.mInvView.transform_tiny(tmp);
-		Device.mInvProject.transform_tiny(tmp);
-
-		Device.mProjectHud.transform_tiny(tmp);
-		Device.mView.transform_tiny(tmp);
+		Device.world_to_hud(tmp);
 		return *this;
 	}
 
-	IC SelfRef hud_to_world_dir_self()
+	IC SelfRef hud_to_world_dir()
 	{
 		SelfRef tmp = *this;
-		Device.mView.transform_dir(tmp);
-		Device.mProjectHud.transform_dir(tmp);
-
-		Device.mInvProject.transform_dir(tmp);
-		Device.mInvView.transform_dir(tmp);
+		Device.hud_to_world_dir(tmp);
 		return *this;
 	}
 
-	IC SelfRef world_to_hud_dir_self()
+	IC SelfRef world_to_hud_dir()
 	{
 		SelfRef tmp = *this;
-		Device.mInvView.transform_dir(tmp);
-		Device.mInvProject.transform_dir(tmp);
-
-		Device.mProjectHud.transform_dir(tmp);
-		Device.mView.transform_dir(tmp);
+		Device.world_to_hud_dir(tmp);
 		return *this;
 	}
 };

--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -312,6 +312,101 @@ public:
 		return (Timer.time_factor());
 	}
 
+	Fvector& hud_to_world(Fvector& v, const Fmatrix& p)
+	{
+		mView.transform(v);
+		p.transform(v);
+
+		v.z -= ViewportNear;
+
+		mInvProject.transform(v);
+		mInvView.transform(v);
+
+		return v;
+	}
+
+	Fvector& hud_to_world(Fvector& v)
+	{
+		return hud_to_world(v, mProjectHud);
+	}
+
+	Fvector& hud_to_world_dir(Fvector& v, const Fmatrix& p)
+	{
+		mView.transform_dir(v);
+		p.transform_dir(v);
+
+		mInvProject.transform_dir(v);
+		mInvView.transform_dir(v);
+
+		return v;
+	}
+
+	Fvector& hud_to_world_dir(Fvector& v)
+	{
+		return hud_to_world_dir(v, mProjectHud);
+	}
+
+	Fmatrix& hud_to_world(Fmatrix& m, const Fmatrix& p)
+	{
+		hud_to_world(m.c, p);
+		hud_to_world_dir(m.i, p).normalize();
+		hud_to_world_dir(m.j, p).normalize();
+		hud_to_world_dir(m.k, p).normalize();
+		return m;
+	}
+
+	Fmatrix& hud_to_world(Fmatrix& m)
+	{
+		return hud_to_world(m, mProjectHud);
+	}
+
+	Fvector& world_to_hud(Fvector& v, const Fmatrix& p)
+	{
+		mInvView.transform(v);
+		mInvProject.transform(v);
+
+		v.z += ViewportNear;
+
+		mProjectHud.transform(v);
+		mView.transform(v);
+		return v;
+	}
+
+	Fvector& world_to_hud(Fvector& v)
+	{
+		return world_to_hud(v, mProjectHud);
+	}
+
+	Fvector& world_to_hud_dir(Fvector& v, const Fmatrix& p)
+	{
+		mInvView.transform_dir(v);
+		mInvProject.transform_dir(v);
+
+		p.transform_dir(v);
+		mView.transform_dir(v);
+
+		return v;
+	}
+
+	Fvector& world_to_hud_dir(Fvector& v)
+	{
+		return world_to_hud_dir(v, mProjectHud);
+	}
+
+	Fmatrix& world_to_hud(Fmatrix& m, const Fmatrix& p)
+	{
+		world_to_hud(m.c, p);
+		world_to_hud_dir(m.i, p).normalize();
+		world_to_hud_dir(m.j, p).normalize();
+		world_to_hud_dir(m.k, p).normalize();
+		return m;
+	}
+
+	Fmatrix& world_to_hud(Fmatrix& m)
+	{
+		return world_to_hud(m, mProjectHud);
+	}
+
 	// Multi-threading
 	xrCriticalSection mt_csEnter;
 	xrCriticalSection mt_csLeave;

--- a/src/xrServerEntities/script_fmatrix_script.cpp
+++ b/src/xrServerEntities/script_fmatrix_script.cpp
@@ -74,5 +74,7 @@ void CScriptFmatrix::script_register(lua_State* L)
 			.def("setXYZi", (Fmatrix & (Fmatrix::*)(float, float, float))(&Fmatrix::setXYZi), return_reference_to(_1))
 			.def("setXYZi", (Fmatrix & (Fmatrix::*)(const Fvector&))(&Fmatrix::setXYZi), return_reference_to(_1))
 			.def("getHPB", &get_matrix_hpb)
+			.def("hud_to_world", &Fmatrix::hud_to_world, return_reference_to(_1))
+			.def("world_to_hud", &Fmatrix::world_to_hud, return_reference_to(_1))
 		];
 }

--- a/src/xrServerEntities/script_fvector_script.cpp
+++ b/src/xrServerEntities/script_fvector_script.cpp
@@ -99,10 +99,10 @@ void CScriptFvector::script_register(lua_State* L)
 		.def("reflect", &Fvector::reflect, return_reference_to(_1))
 		.def("slide", &Fvector::slide, return_reference_to(_1))
 		.def("generate_orthonormal_basis",	&Fvector::generate_orthonormal_basis)
-		.def("hud_to_world", &Fvector::hud_to_world_self, return_reference_to(_1))
-		.def("world_to_hud", &Fvector::world_to_hud_self, return_reference_to(_1))
-		.def("hud_to_world_dir", &Fvector::hud_to_world_dir_self, return_reference_to(_1))
-		.def("world_to_hud_dir", &Fvector::world_to_hud_dir_self, return_reference_to(_1)),
+		.def("hud_to_world", &Fvector::hud_to_world, return_reference_to(_1))
+		.def("world_to_hud", &Fvector::world_to_hud, return_reference_to(_1))
+		.def("hud_to_world_dir", &Fvector::hud_to_world_dir, return_reference_to(_1))
+		.def("world_to_hud_dir", &Fvector::world_to_hud_dir, return_reference_to(_1)),
 
 		class_<Fvector2>("vector2")
 		.def_readwrite("x", &Fvector2::x)


### PR DESCRIPTION
Following up to my Discord ping: I made CRenderDevice authoritative over HUD <-> World transformations, applied some necessary corrections to the logic, and redirected existing implementations. Also exposed the matrix versions to Lua.

I opted not to add any extra Lua methods to CScriptRenderDevice for now, since the existing vector / matrix -based API is fine, and multiple entrypoints will just add maintenance burden down the road.

Extra details are available in the commit messages where relevant - any questions, just let me know.