### PR TITLE
Fix weapon particle projection in third-person

### DIFF
--- a/src/xrGame/ShootingObject.cpp
+++ b/src/xrGame/ShootingObject.cpp
@@ -242,7 +242,15 @@ void CShootingObject::StartParticles(CParticlesObject*& pParticles, LPCSTR parti
 	pParticles = CParticlesObject::Create(particles_name, (BOOL)auto_remove_flag);
 
 	UpdateParticles(pParticles, pos, vel);
-	pParticles->Play(IsHudModeNow());
+
+	CSpectator* tmp_spectr = smart_cast<CSpectator*>(Level().CurrentControlEntity());
+	bool in_hud_mode = IsHudModeNow();
+	if (in_hud_mode && tmp_spectr &&
+		(tmp_spectr->GetActiveCam() != CSpectator::eacFirstEye))
+	{
+		in_hud_mode = false;
+	}
+	pParticles->Play(in_hud_mode);
 }
 
 void CShootingObject::StopParticles(CParticlesObject*& pParticles)

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -3153,7 +3153,7 @@ bool CWeapon::MovingAnimAllowedNow()
 
 bool CWeapon::IsHudModeNow()
 {
-	return (IsAttachedToHUD() != NULL);
+	return GetHUDmode();
 }
 
 float CWeapon::GetMinScopeZoomFactor() const


### PR DESCRIPTION
Weapon particles were previously being drawn using HUD projection when using the player's third-person camera, visible as a misalignment with the weapon when playing at FOV != 83 and HUD FOV <1.

This was due to `CWeapon::IsHudModeNow()` - inherited from `CShootingObject` - not being aware of it; these changes fix the problem by redirecting it to the third-person aware `CWeapon::GetHUDmode()` - inherited from `CHudItem` - and ensuring all HUD projection -relevant `CShootingObject` call-sites behave consistently.

As a side-effect, it also fixes `CWeaponRPG7::switch2_Fire` incorrectly applying a first-person offset to its launch position and direction while in third-person. According to VS' reference search, this is the only other call site affected by the change.