### PR TITLE
Fix inconsistent .def syntax in script_render_device_script.cpp

### DIFF
--- a/src/xrGame/script_render_device_script.cpp
+++ b/src/xrGame/script_render_device_script.cpp
@@ -64,7 +64,7 @@ void CScriptRenderDevice::script_register(lua_State* L)
 		.def_readonly("precache_frame", &CRenderDevice::dwPrecacheFrame)
 		.def_readonly("frame", &CRenderDevice::dwFrame)
 		.def("is_paused", &is_device_paused)
-		.def("pause", &set_device_paused),
-		def("app_ready", &is_app_ready)
+		.def("pause", &set_device_paused)
+		.def("app_ready", &is_app_ready)
 	];
 }


### PR DESCRIPTION
A tiny bit of fix errata that fell out when I shook the 3D shooting branch.

Appears to be a (benign?) syntax error, though VS can't confirm as it lives inside a macro.

Disregard if this is intentional, and simply me not understanding luabind well enough yet.