### PR TITLE
Reduce code duplication in bone_position / bone_direction

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -357,6 +357,11 @@
         string bone_name(u16 id)
         string bone_name(u16 id, bool bHud)
 
+        Fmatrix bone_transform(u16 id)
+        Fmatrix bone_transform(u16 id, bool bHud)
+        Fmatrix bone_transform(string)
+        Fmatrix bone_transform(string, bool bHud)
+
         Fvector bone_position(u16 id)
         Fvector bone_position(u16 id, bool bHud)
         Fvector bone_position(string)
@@ -366,11 +371,6 @@
         Fvector bone_direction(u16 id, bool bHud)
         Fvector bone_direction(string)
         Fvector bone_direction(string, bool bHud)
-
-        Fmatrix bone_transform(u16 id)
-        Fmatrix bone_transform(u16 id, bool bHud)
-        Fmatrix bone_transform(string)
-        Fmatrix bone_transform(string, bool bHud)
 
         u16 bone_parent(u16 id)
         u16 bone_parent(u16 id, bool bHud)

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -396,92 +396,6 @@ u16 CScriptGameObject::bone_id(LPCSTR bone_name, bool bHud)
 	return bone_id;
 }
 
-Fvector CScriptGameObject::bone_position(u16 bone_id, bool bHud)
-{
-	//if (bone_id == BI_NONE) return Fvector().set(0, 0, 0);
-
-	IKinematics* k = nullptr;
-	Fmatrix* xform = nullptr;
-
-	if (bHud)
-	{
-		CActor* act = smart_cast<CActor*>(&object());
-		CHudItem* itm = smart_cast<CHudItem*>(&object());
-		if (itm)
-		{
-			k = itm->HudItemData()->m_model;
-			xform = &itm->HudItemData()->m_item_transform;
-		}
-		else if (act)
-		{
-			k = (bone_id > 20) ? g_player_hud->m_model->dcast_PKinematics() : g_player_hud->m_model_2->dcast_PKinematics();
-			xform = (bone_id > 20) ? &g_player_hud->m_transform : &g_player_hud->m_transform_2;
-		}
-	} else {
-		k = object().Visual()->dcast_PKinematics();
-		xform = &object().XFORM();
-	}
-
-	if (!k) return Fvector().set(0, 0, 0);
-
-	// demonized: backwards compatibility with scripts, get root bone if bone_id is BI_NONE
-	if (bone_id == BI_NONE) {
-		if (strstr(Core.Params, "-dbg") && print_bone_warnings) {
-			Msg("![bone_position] Incorrect bone_id provided for %s (%d), fallback to root bone", object().cNameSect_str(), object().ID());
-			ai().script_engine().print_stack();
-		}
-		bone_id = k->LL_GetBoneRoot();
-	}
-
-	Fmatrix matrix;
-	matrix.mul_43(*xform, k->LL_GetTransform(bone_id));
-	return (matrix.c);
-}
-
-Fvector CScriptGameObject::bone_direction(u16 bone_id, bool bHud)
-{
-	//if (bone_id == BI_NONE) return Fvector().set(0, 0, 0);
-
-	IKinematics* k = nullptr;
-	Fmatrix* xform = nullptr;
-
-	if (bHud)
-	{
-		CActor* act = smart_cast<CActor*>(&object());
-		CHudItem* itm = smart_cast<CHudItem*>(&object());
-		if (itm)
-		{
-			k = itm->HudItemData()->m_model;
-			xform = &itm->HudItemData()->m_item_transform;
-		}
-		else if (act)
-		{
-			k = (bone_id > 20) ? g_player_hud->m_model->dcast_PKinematics() : g_player_hud->m_model_2->dcast_PKinematics();
-			xform = (bone_id > 20) ? &g_player_hud->m_transform : &g_player_hud->m_transform_2;
-		}
-	} else {
-		k = object().Visual()->dcast_PKinematics();
-		xform = &object().XFORM();
-	}
-
-	if (!k) return Fvector().set(0, 0, 0);
-
-	// demonized: backwards compatibility with scripts, get root bone if bone_id is BI_NONE
-	if (bone_id == BI_NONE) {
-		if (strstr(Core.Params, "-dbg") && print_bone_warnings) {
-			Msg("![bone_direction] Incorrect bone_id provided for %s (%d), fallback to root bone", object().cNameSect_str(), object().ID());
-			ai().script_engine().print_stack();
-		}
-		bone_id = k->LL_GetBoneRoot();
-	}
-
-	Fmatrix matrix;
-	Fvector res;
-	matrix.mul_43(*xform, k->LL_GetTransform(bone_id));
-	matrix.getHPB(res);
-	return (res);
-}
-
 Fmatrix CScriptGameObject::bone_transform(u16 bone_id, bool bHud)
 {
 	//if (bone_id == BI_NONE) return Fvector().set(0, 0, 0);
@@ -521,6 +435,19 @@ Fmatrix CScriptGameObject::bone_transform(u16 bone_id, bool bHud)
 	Fmatrix matrix;
 	matrix.mul_43(*xform, k->LL_GetTransform(bone_id));
 	return matrix;
+}
+
+Fvector CScriptGameObject::bone_position(u16 bone_id, bool bHud)
+{
+	return bone_transform(bone_id, bHud).c;
+}
+
+Fvector CScriptGameObject::bone_direction(u16 bone_id, bool bHud)
+{
+	Fmatrix matrix = bone_transform(bone_id, bHud);
+	Fvector res;
+	matrix.getHPB(res);
+	return res;
 }
 
 u16 CScriptGameObject::bone_parent(u16 bone_id, bool bHud)

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1005,6 +1005,11 @@ public:
 	void set_bone_visible(LPCSTR bone_name, bool bVisibility, bool bRecursive, bool bHud) { set_bone_visible(bone_id(bone_name, bHud), bVisibility, bRecursive, bHud); }
 	void set_bone_visible(LPCSTR bone_name, bool bVisibility, bool bRecursive) { set_bone_visible(bone_id(bone_name), bVisibility, bRecursive, false); }
 
+	Fmatrix bone_transform(u16 bone_id, bool bHud);
+	Fmatrix bone_transform(u16 bone_id) { return bone_transform(bone_id, false); }
+	Fmatrix bone_transform(LPCSTR bone_name, bool bHud) { return bone_transform(bone_id(bone_name, bHud), bHud); }
+	Fmatrix bone_transform(LPCSTR bone_name) { return bone_transform(bone_id(bone_name), false); }
+
 	Fvector bone_position(u16 bone_id, bool bHud);
 	Fvector bone_position(u16 bone_id) { return bone_position(bone_id, false); }
 	Fvector bone_position(LPCSTR bone_name, bool bHud) { return bone_position(bone_id(bone_name, bHud), bHud); }
@@ -1014,11 +1019,6 @@ public:
 	Fvector bone_direction(u16 bone_id) { return bone_direction(bone_id, false); }
 	Fvector bone_direction(LPCSTR bone_name, bool bHud) { return bone_direction(bone_id(bone_name, bHud), bHud); }
 	Fvector bone_direction(LPCSTR bone_name) { return bone_direction(bone_id(bone_name), false); }
-
-	Fmatrix bone_transform(u16 bone_id, bool bHud);
-	Fmatrix bone_transform(u16 bone_id) { return bone_transform(bone_id, false); }
-	Fmatrix bone_transform(LPCSTR bone_name, bool bHud) { return bone_transform(bone_id(bone_name, bHud), bHud); }
-	Fmatrix bone_transform(LPCSTR bone_name) { return bone_transform(bone_id(bone_name), false); }
 
 	u16 bone_parent(u16 bone_id, bool bHud);
 	u16 bone_parent(u16 bone_id) { return bone_parent(bone_id, false); }


### PR DESCRIPTION
Both functions' bodies were identical to `bone_transform`, save for picking out the respective component/s, so can be trivially amended to call it instead.

Also reordered `bone_transform` to be declared / defined first, as a syntactic hint that it's logically upstream of `bone_position` / `bone_direction`.