### PR TITLE
Fix: Incorrect projection in HUD <-> World transforms

### DIFF
--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -314,13 +314,13 @@ public:
 
 	Fvector& hud_to_world(Fvector& v, const Fmatrix& p)
 	{
-		mView.transform(v);
-		p.transform(v);
+		mView.transform_tiny(v);
+		p.transform_tiny(v);
 
 		v.z -= ViewportNear;
 
-		mInvProject.transform(v);
-		mInvView.transform(v);
+		mInvProject.transform_tiny(v);
+		mInvView.transform_tiny(v);
 
 		return v;
 	}
@@ -362,13 +362,13 @@ public:
 
 	Fvector& world_to_hud(Fvector& v, const Fmatrix& p)
 	{
-		mInvView.transform(v);
-		mInvProject.transform(v);
+		mInvView.transform_tiny(v);
+		mInvProject.transform_tiny(v);
 
 		v.z += ViewportNear;
 
-		mProjectHud.transform(v);
-		mView.transform(v);
+		mProjectHud.transform_tiny(v);
+		mView.transform_tiny(v);
 		return v;
 	}
 


### PR DESCRIPTION
Amends incorrect application of the W-divide during HUD <-> World transforms.

Previous implementation was lossy, as `transform` throws away linear Z for 3D vectors after dividing by W, instead replacing it with a value close to 1, and causing the reprojected position to end up correct in X / Y but wrong in depth.

Mea culpa for the mistake 🙏