### PR TITLE
Fix logspam in CWeapon::GetNearWallOffset

### DIFF
--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -538,8 +538,6 @@ float CWeapon::GetNearWallOffset()
 	float ofs = CHudItem::GetNearWallOffset();
 	float ofs_ads = ofs;
 	clamp(ofs_ads, ofs_ads, m_nearwall_zoomed_range);
-	Log("ofs", ofs);
-	Log("ofs_ads", ofs_ads);
 	return lerp(ofs, ofs_ads, GetZRotatingFactor());
 }
 


### PR DESCRIPTION
Removes `ofs` and `ofs_ads` messages leftover from testing near-wall changes.