### PR TITLE
Fix crosshair readout jitter

### DIFF
--- a/src/xrGame/HUDTarget.cpp
+++ b/src/xrGame/HUDTarget.cpp
@@ -197,9 +197,12 @@ void CHUDTarget::Render()
 
 	float result_dist = GetUIDist();
 
-	Fvector4 pt;
-	Device.mFullTransform.transform(pt, mat_aim.c);
-	pt.y = -pt.y;
+	Fvector4 pt = Fvector4();
+	if (HUD().FireposActive())
+	{
+		Device.mFullTransform.transform(pt, mat_aim.c);
+		pt.y = -pt.y;
+	}
 
 	// Crosshair color
 	u32 color_readout = C_DEFAULT;


### PR DESCRIPTION
Special-cases dynamic readout positioning to only occur when firepos mode is active.

Not as elegant as I'd like; the core of the issue is down to a subtle jitter in both the camera transform and trace distance results, presumably due to nondeterministic collision resolution or some other factor which varies frame-to-frame.

These error factors are usually imperceptibly small, but the readout text renderer (and line renderer, to a lesser extent) clamp to pixel positions, which compounds to create an awkward center-screen case whose final position vacillates between -0.0000 and 0.0000, thus creating a 1px wiggling effect in both axes.

I tried to address it by caching the related quantities and using `Fvector::similar` and similar epsilon checks, but it ended up messy and introduced more error than it eliminated. I think the only way to solve this for good is going to be eliminating the error at its source, but that's a bigger job than this fix.

To wit, this change effectively gates the issue behind `g_firepos 1`, falling back to 2D positioning in the vanilla case. This means the crosshair won't smoothly animate to and from the barrel target when changing modes (i.e. when toggling ADS with `g_firepos 1` and `g_firepos_zoom 0` or vice-versa,) but is otherwise stable at center-screen.

Probably worth putting this info into an issue tracker entry, since it'd be good basis for a fix later down the line.