### PR TITLE
Crosshair: Far size option

### DIFF
--- a/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/scripts/ui_options_modded_exes.script
@@ -55,6 +55,16 @@ function init_opt_base()
 						cmd = "g_crosshair_near_size",
 					},
 					{
+						id = "g_crosshair_far_size",
+						type = "track",
+						val = 2,
+						def = 1,
+						min = 1,
+						max = 16,
+						step = 0.1,
+						cmd = "g_crosshair_far_size",
+					},
+					{
 						id = "g_crosshair_distance_lerp_rate",
 						type = "track",
 						val = 2,

--- a/src/xrGame/HUDCrosshair.cpp
+++ b/src/xrGame/HUDCrosshair.cpp
@@ -12,6 +12,7 @@
 string32 crosshair_shader = "hud\\cursor";
 string32 crosshair_texture = "ui\\cursor";
 float crosshair_near_size = 1.f;
+float crosshair_far_size = 1.f;
 
 CHUDCrosshair::CHUDCrosshair()
 {
@@ -122,7 +123,7 @@ void CHUDCrosshair::RenderShaderCrosshair()
 	float zNear = Device.ViewportNear;
 	float zFar = g_pGamePersistent->Environment().CurrentEnv->far_plane;
 	float t = (pos_.z - zNear - 1) / (zFar - zNear);
-	float size = lerp(crosshair_near_size, zFar, t);
+	float size = lerp(crosshair_near_size, crosshair_far_size * zFar, t);
 
 	// Transform and push vertices
 	for (int i = 0; i < 4; i++)
@@ -179,7 +180,7 @@ void CHUDCrosshair::RenderWireCrosshair()
 	float zNear = Device.ViewportNear;
 	float zFar = g_pGamePersistent->Environment().CurrentEnv->far_plane;
 	float t = (pos_.z - zNear - 1) / (zFar - zNear);
-	float size = lerp(crosshair_near_size, zFar, t);
+	float size = lerp(crosshair_near_size, crosshair_far_size * zFar, t);
 
 	// Project into NDC with W-divide
 	Device.mProject.transform(pos);

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -154,6 +154,7 @@ extern int g_nearwall_trace;
 extern string32 crosshair_shader;
 extern string32 crosshair_texture;
 extern float crosshair_near_size;
+extern float crosshair_far_size;
 extern float crosshair_occluded_opacity;
 extern float crosshair_occlusion_fade_rate;
 extern float crosshair_distance_lerp_rate;
@@ -2498,6 +2499,7 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "g_nearwall", &g_nearwall, 0, 2);
 	CMD4(CCC_Integer, "g_nearwall_trace", &g_nearwall_trace, 0, 1);
 	CMD4(CCC_Float, "g_crosshair_near_size", &crosshair_near_size, 1.f, 16.f);
+	CMD4(CCC_Float, "g_crosshair_far_size", &crosshair_far_size, 1.f, 16.f);
 	CMD4(CCC_Float, "g_crosshair_distance_lerp_rate", &crosshair_distance_lerp_rate, 1.f, 100.f);
 	CMD4(CCC_Float, "g_crosshair_occluded_opacity", &crosshair_occluded_opacity, 0.f, 1.f);
 	CMD4(CCC_Float, "g_crosshair_occlusion_fade_rate", &crosshair_occlusion_fade_rate, 1.f, 100.f);

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -1846,10 +1846,6 @@ void player_hud::OnFrame()
 	if (m_attached_items[1])
 		m_attached_items[1]->m_parent_hud_item->OnFrame();
 
-	if (m_attached_items[SCOPE_ATTACH_IDX])
-		m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item->OnFrame();
-
-
 	// If near-wall is in position mode...
 	if (g_nearwall == NW_POS)
 	{
@@ -1882,6 +1878,12 @@ void player_hud::OnFrame()
 			}
 			m_transform_2.translate_add(nearwall_1);
 			m_attached_items[1]->m_item_transform.translate_add(nearwall_1);
+		}
+
+		if (m_attached_items[SCOPE_ATTACH_IDX])
+		{
+			CHudItem* parent = m_attached_items[SCOPE_ATTACH_IDX]->m_parent_hud_item;
+			m_attached_items[SCOPE_ATTACH_IDX]->m_item_transform.translate_add(nearwall_0);
 		}
 	}
 }


### PR DESCRIPTION
Mumuskeh pointed out the absence of non-LTX far plane scaling for the crosshair, so I've added `g_crosshair_far_size` to control its size at the far plane.