### PR TITLE
Fix animated HUD FOV

### DIFF
--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -265,18 +265,6 @@ void CHudItem::SendHiddenItem()
 	}
 }
 
-float CHudItem::GetNearWallOffset()
-{
-	if (g_nearwall_trace == NT_CAM)
-	{
-		return m_nearwall_factor * GetNearWallRange() * GetBaseHudFov();
-	}
-	else if (g_nearwall_trace == NT_ITEM)
-	{
-		return m_nearwall_factor * GetBaseHudFov();
-	}
-}
-
 void CHudItem::UpdateHudAdditional(Fmatrix& trans)
 {
 	CActor* pActor = smart_cast<CActor*>(object().H_Parent());
@@ -499,12 +487,38 @@ float CHudItem::GetNearWallRange()
 	return m_nearwall_dist_max - m_nearwall_dist_min;
 }
 
+static float lerp(float a, float b, float t)
+{
+	clamp(t, 0.f, 1.f);
+	return a * (1 - t) + b * t;
+}
+
+float CHudItem::GetTargetHudFov()
+{
+	float target_fov = GetBaseHudFov();
+	if (g_nearwall == NW_FOV)
+		target_fov -= m_nearwall_target_hud_fov * m_nearwall_factor;
+	return target_fov;
+}
+
+float CHudItem::GetTargetNearWallOffset()
+{
+	if (g_nearwall_trace == NT_CAM)
+	{
+		return m_nearwall_factor * GetNearWallRange() * GetBaseHudFov();
+	}
+	else if (g_nearwall_trace == NT_ITEM)
+	{
+		return m_nearwall_factor * GetBaseHudFov();
+	}
+
+	return 0.f;
+}
+
 void CHudItem::UpdateCL()
 {
 	if (g_nearwall && ParentIsActor() && Level().CurrentViewEntity() == object().H_Parent())
 	{
-		float fac;
-
 		// If firepos is active
 		if (g_nearwall_trace == NT_CAM)
 		{
@@ -513,20 +527,24 @@ void CHudItem::UpdateCL()
 
 			float dist = rq.range;
 			clamp(dist, m_nearwall_dist_min, m_nearwall_dist_max);
-			fac = 1 - ((dist - m_nearwall_dist_min) / GetNearWallRange());
+			m_nearwall_factor = 1 - ((dist - m_nearwall_dist_min) / GetNearWallRange());
 		}
 		else if (g_nearwall_trace == NT_ITEM)
 		{
 			// Take the item's trace range and invert it, as negative ranges encode penetration distance
 			collide::rq_result& rq = GetRQ();
-			fac = -rq.range;
-			clamp(fac, 0.f, fac);
+			m_nearwall_factor = -rq.range;
+			clamp(m_nearwall_factor, 0.f, m_nearwall_factor);
 ;		}
-
-		float t = m_nearwall_speed_mod * Device.fTimeDelta;
-		clamp(t, 0.f, 1.f);
-		m_nearwall_factor = m_nearwall_factor * (1 - t) + fac * t;
 	}
+
+	float t = m_nearwall_speed_mod * Device.fTimeDelta;
+	
+	float target_fov = GetTargetHudFov();
+	m_hud_fov = lerp(m_hud_fov, target_fov, t);
+
+	float target_ofs = GetTargetNearWallOffset();
+	m_nearwall_ofs = lerp(m_nearwall_ofs, target_ofs, t);
 
 	if (m_current_motion_def)
 	{
@@ -1116,10 +1134,12 @@ float CHudItem::GetBaseHudFov()
 
 float CHudItem::GetHudFov()
 {
-	float fov = GetBaseHudFov();
-	if (g_nearwall == NW_FOV)
-		fov -= m_nearwall_target_hud_fov * m_nearwall_factor;
-	return fov;
+	return m_hud_fov;
+}
+
+float CHudItem::GetNearWallOffset()
+{
+	return m_nearwall_ofs;
 }
 
 CAnonHudItem::CAnonHudItem() { }

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -202,9 +202,11 @@ public:
 	bool IsAttachedToHUD();
 	virtual bool ParentIsActor();
 	virtual float GetNearWallRange();
-	virtual float GetNearWallOffset();
 	virtual float GetBaseHudFov();
-	virtual float GetHudFov();
+	virtual float GetTargetHudFov();
+	virtual float GetTargetNearWallOffset();
+	float GetNearWallOffset();
+	float GetHudFov();
 	virtual void on_outfit_changed();
 	virtual void on_a_hud_attach();
 	virtual void on_b_hud_detach();
@@ -276,6 +278,8 @@ public:
 	float m_nearwall_target_hud_fov;
 	float m_nearwall_speed_mod;
 	float m_base_fov;
+	float m_hud_fov;
+	float m_nearwall_ofs;
 
 	virtual CHudItem* cast_hud_item() { return this; }
 	virtual bool PlayAnimCrouchIdleMoving(); //AVO: new crouch idle animation

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -509,9 +509,9 @@ inline float smoothstep(float x)
 	return x * x * (3 - 2 * x);
 }
 
-float CWeapon::GetHudFov()
+float CWeapon::GetTargetHudFov()
 {
-	float base = inherited::GetHudFov();
+	float base = inherited::GetTargetHudFov();
 
 	float x = smoothstep(m_zoom_params.m_fZoomRotationFactor);
 	float factor = hud_fov_aim_factor > 0 ? hud_fov_aim_factor : 1;
@@ -533,9 +533,9 @@ static float lerp(float a, float b, float t)
 	return a * (1 - t) + b * t;
 }
 
-float CWeapon::GetNearWallOffset()
+float CWeapon::GetTargetNearWallOffset()
 {
-	float ofs = CHudItem::GetNearWallOffset();
+	float ofs = inherited::GetTargetNearWallOffset();
 	float ofs_ads = ofs;
 	clamp(ofs_ads, ofs_ads, m_nearwall_zoomed_range);
 	Log("ofs", ofs);

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -532,8 +532,8 @@ private:
 	float m_nearwall_zoomed_range;
 
 public:
-	float GetNearWallOffset();
-	float GetHudFov();
+	float GetTargetNearWallOffset();
+	float GetTargetHudFov();
 
 public:
 	Fmatrix RayTransform();


### PR DESCRIPTION
The nearwall changes inadvertently replaced HUD FOV interpolation with an interpolation on the near-wall factor, failing to cover the case where HUD FOV changes outside of nearwall.

I've removed the animation from the base factor, reinstated it on HUD FOV, added a new animated value for the positional offset, and restructured the interface as appropriate. It now exposes the animated values via dumb non-virtual getters, and their target values via virtuals, allowing `CWeapon` to modify as needed without needing to know about any interpolation.