### PR TITLE
 Add 'Always Show Crosshair' option

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -26,6 +26,9 @@
 	<string id="ui_mm_hud_modded_exes">
 		<text>HUD</text>
 	</string>
+	<string id="ui_mm_modded_exes_misc_g_crosshair_show_always">
+		<text>Always show crosshair (g_crosshair_show_always)</text>
+	</string>
 	<string id="ui_mm_modded_exes_misc_g_use_shader_crosshair">
 		<text>Use shader crosshair (g_use_shader_crosshair)</text>
 	</string>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -26,6 +26,9 @@
 	<string id="ui_mm_hud_modded_exes">
 		<text>HUD</text>
 	</string>
+	<string id="ui_mm_modded_exes_misc_g_crosshair_show_always">
+		<text>Всегда показывать перекрестие (g_crosshair_show_always)</text>
+	</string>
 	<string id="ui_mm_modded_exes_misc_g_use_shader_crosshair">
 		<text>Использовать шейдерное перекрестие (g_use_shader_crosshair)</text>
 	</string>

--- a/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/scripts/ui_options_modded_exes.script
@@ -38,6 +38,13 @@ function init_opt_base()
 						size = { 512, 50 },
 					},
 					{
+						id = "g_crosshair_show_always",
+						type = "check",
+						val = 1,
+						def = false,
+						cmd = "g_crosshair_show_always",
+					},
+					{
 						id = "g_use_shader_crosshair",
 						type = "check",
 						val = 1,

--- a/src/xrEngine/CustomHUD.h
+++ b/src/xrEngine/CustomHUD.h
@@ -14,6 +14,7 @@ ENGINE_API extern Flags32 psHUD_Flags;
 #define HUD_WEAPON_RT2 (1<<11)
 #define HUD_DRAW_RT2 (1<<12)
 #define HUD_SHADER_CROSSHAIR (1<<13)
+#define HUD_CROSSHAIR_SHOW_ALWAYS (1<<14)
 
 class ENGINE_API IRender_Visual;
 class CUI;

--- a/src/xrGame/HUDTarget.cpp
+++ b/src/xrGame/HUDTarget.cpp
@@ -166,8 +166,10 @@ void CHUDTarget::IntegrateOpacity()
 
 void CHUDTarget::Render()
 {
-	BOOL b_do_rendering = (psHUD_Flags.is(HUD_CROSSHAIR | HUD_CROSSHAIR_RT | HUD_CROSSHAIR_RT2));
+	IntegratePosition();
+	IntegrateOpacity();
 
+	BOOL b_do_rendering = (psHUD_Flags.is(HUD_CROSSHAIR | HUD_CROSSHAIR_RT | HUD_CROSSHAIR_RT2));
 	if (!b_do_rendering)
 		return;
 
@@ -177,9 +179,6 @@ void CHUDTarget::Render()
 	if (0 == O) return;
 	CEntity* E = smart_cast<CEntity*>(O);
 	if (0 == E) return;
-
-	IntegratePosition();
-	IntegrateOpacity();
 
 	const SPickParam& pp = Actor()->GetPick();
 

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -2997,6 +2997,9 @@ float CWeapon::Weight() const
 
 bool CWeapon::show_crosshair()
 {
+	if (psHUD_Flags.is(HUD_CROSSHAIR_SHOW_ALWAYS))
+		return true;
+
 	return !IsPending() && (!IsZoomed() || !ZoomHideCrosshair());
 }
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2497,6 +2497,7 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask, "g_firedir_third_person", &psActorFlags, AF_FIREDIR_THIRD_PERSON);
 	CMD4(CCC_Integer, "g_nearwall", &g_nearwall, 0, 2);
 	CMD4(CCC_Integer, "g_nearwall_trace", &g_nearwall_trace, 0, 1);
+	CMD3(CCC_Mask, "g_crosshair_show_always", &psHUD_Flags, HUD_CROSSHAIR_SHOW_ALWAYS);
 	CMD4(CCC_Float, "g_crosshair_near_size", &crosshair_near_size, 1.f, 16.f);
 	CMD4(CCC_Float, "g_crosshair_distance_lerp_rate", &crosshair_distance_lerp_rate, 1.f, 100.f);
 	CMD4(CCC_Float, "g_crosshair_occluded_opacity", &crosshair_occluded_opacity, 0.f, 1.f);


### PR DESCRIPTION
When enabled, overrides `CWeapon::show_crosshair` to prevent the crosshair from being hidden during weapon-switch, reload, and ADS.

Looks cooler / more consistent with the 3D reticle. Also useful for visualizing reposition behavior and calibrating it around the new 3D ballistics.

Now runs distance / opacity interpolation unconditionally as well, since the previous only-when-rendering approach caused noticeable catch-up when unhiding the crosshair.