### PR TITLE
Implement `g_aimpos` to govern bullet direction

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -272,6 +272,9 @@
 	<string id="ui_mm_modded_exes_gameplay_g_firepos_zoom">
 		<text>Enable bullets firing from gun barrel while aiming (g_firepos_zoom)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_g_aimpos">
+		<text>Aim bullets along barrel (g_aimpos)</text>
+	</string>
 	<string id="ui_mm_modded_exes_gameplay_g_firedir_third_person">
 		<text>Use first-person firing direction when in third-person (g_firedir_third_person)</text>
 	</string>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -267,6 +267,9 @@
 	<string id="ui_mm_modded_exes_gameplay_g_firepos_zoom">
 		<text>Пули вылетают из ствола во время прицеливания (g_firepos_zoom)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_g_aimpos">
+		<text>Направьте пули по направлению ствола (g_aimpos)</text>
+	</string>
 	<string id="ui_mm_modded_exes_gameplay_g_firedir_third_person">
 		<text>Используйте направление стрельбы от первого лица в третьем лице (g_firedir_third_person)</text>
 	</string>

--- a/gamedata/scripts/ltx_help_ex.script
+++ b/gamedata/scripts/ltx_help_ex.script
@@ -19,6 +19,7 @@
         silenced_tracers - Option to disable silencers hiding the tracer on a per weapon basis
         fire_point_silencer - Adjust fire point when silencer is attached, defaults to the value of fire_point. Supports both HUD and world models
 		nearwall_zoomed_range - Maximum offset toward camera when aiming down sight close to a wall.
+        aimpos - Disables g_aimpos for this weapon if set to false.
         ai_rpm - Set RPM of weapon for AI (only for SSRS)
         modular_attachments - enable modular attachments (https://github.com/themrdemonized/xray-monolith/pull/135)
         modular_scope_group - section which is used to define available scopes (modular attachments)

--- a/gamedata/scripts/ui_options_modded_exes.script
+++ b/gamedata/scripts/ui_options_modded_exes.script
@@ -717,6 +717,13 @@ function init_opt_base()
 						cmd = "g_firepos_zoom",
 					},
 					{
+						id = "g_aimpos",
+						type = "check",
+						val = 1,
+						def = false,
+						cmd = "g_aimpos",
+					},
+					{
 						id = "g_firedir_third_person",
 						type = "check",
 						val = 1,

--- a/src/xrGame/Actor_Flags.h
+++ b/src/xrGame/Actor_Flags.h
@@ -24,6 +24,7 @@ enum
 	AF_3D_PDA = (1 << 20),
 	AF_FIREPOS_ZOOM = (1 << 21),
 	AF_FIREDIR_THIRD_PERSON = (1 << 22),
+	AF_AIMPOS = (1 << 23),
 };
 
 extern Flags32 psActorFlags;

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -164,9 +164,29 @@ void CHUDManager::OnFrame()
 		pUIGame->OnFrame();
 
 	PP.CameraPick();
-	DoPick(PP);
 
 	g_player_hud->OnFrame();
+
+	// If aim position is not enabled
+	bool aimpos = psActorFlags.test(AF_AIMPOS);
+	if (aimpos)
+	{
+		CHudItem* pItem = smart_cast<CHudItem*>(Actor()->inventory().ActiveItem());
+		if (pItem)
+		{
+			attachable_hud_item* hi = pItem->HudItemData();
+			hud_item_measures measures = hi->m_measures;
+			Fmatrix matrix = hi->m_item_transform;
+			matrix.mulB_43(hi->m_model->LL_GetTransform(measures.m_fire_bone));
+			matrix.mulB_43(Fmatrix().translate(measures.m_fire_point_offset));
+
+			// Use weapon aim direction
+			PP.defs.dir = Fvector().mul(matrix.k, PP.defs.range);
+			PP.defs.dir.normalize();
+		}
+	}
+
+	DoPick(PP);
 }
 
 //--------------------------------------------------------------------

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -167,13 +167,15 @@ void CHUDManager::OnFrame()
 
 	g_player_hud->OnFrame();
 
-	// If aim position is not enabled
+	// If aim position is enabled
 	bool aimpos = psActorFlags.test(AF_AIMPOS);
 	if (aimpos)
 	{
+		// Ensure we have a HUD item
 		CHudItem* pItem = smart_cast<CHudItem*>(Actor()->inventory().ActiveItem());
 		if (pItem)
 		{
+			// Aim along barrel rotation
 			attachable_hud_item* hi = pItem->HudItemData();
 			hud_item_measures measures = hi->m_measures;
 			Fmatrix matrix = hi->m_item_transform;

--- a/src/xrGame/HUDTarget.cpp
+++ b/src/xrGame/HUDTarget.cpp
@@ -73,6 +73,7 @@ CHUDTarget::CHUDTarget()
 
 	Load();
 	m_bShowCrosshair = false;
+	m_bFirstUpdate = true;
 }
 
 CHUDTarget::~CHUDTarget()
@@ -151,7 +152,7 @@ void CHUDTarget::IntegratePosition()
 		target = Fvector().add(pos, Fvector().mul(dir, pp.barrel_dist));
 
 	// Interpolate crosshair position toward target
-	if (psHUD_Flags.is(HUD_CROSSHAIR_DISTANCE_LERP))
+	if (!m_bFirstUpdate && psHUD_Flags.is(HUD_CROSSHAIR_DISTANCE_LERP))
 	{
 		float zFar = g_pGamePersistent->Environment().CurrentEnv->far_plane;
 		float fac = 1 - (target.z / zFar);
@@ -161,6 +162,8 @@ void CHUDTarget::IntegratePosition()
 	}
 	else
 		crosshairPos = target;
+
+	m_bFirstUpdate = false;
 }
 
 void CHUDTarget::IntegrateOpacity()

--- a/src/xrGame/HUDTarget.h
+++ b/src/xrGame/HUDTarget.h
@@ -16,6 +16,7 @@ private:
 	float crosshairOpacity;
 
 	bool m_bShowCrosshair;
+	bool m_bFirstUpdate;
 	CHUDCrosshair HUDCrosshair;
 
 private:

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -897,6 +897,8 @@ void CWeapon::Load(LPCSTR section)
 	//--DSR-- SilencerOverheat_end
 
 	m_nearwall_zoomed_range = READ_IF_EXISTS(pSettings, r_float, section, "nearwall_zoomed_range", 0.04f);
+
+	m_aimpos = READ_IF_EXISTS(pSettings, r_bool, section, "aimpos", true);
 }
 
 // demonized: World model on stalkers adjustments
@@ -3220,11 +3222,29 @@ Fmatrix CWeapon::RayTransform()
 
 	Fmatrix matrix;
 
+	// If we're in first-person...
 	if (GetHUDmode())
 	{
+		// Compose barrel matrix
 		matrix = hi->m_item_transform;
 		matrix.mulB_43(hi->m_model->LL_GetTransform(measures.m_fire_bone));
 		matrix.mulB_43(Fmatrix().translate(measures.m_fire_point_offset));
+
+		// If aim position is not enabled
+		bool aimpos = m_aimpos && psActorFlags.test(AF_AIMPOS);
+		if (!aimpos)
+		{
+			// Aim toward camera look position
+			Fvector pos = matrix.c;
+			auto pick = HUD().GetPick();
+			Fvector target = Fvector().add(pick.defs.start, Fvector().mul(pick.defs.dir, pick.defs.range));
+			Fvector delta = Fvector().sub(target, pos).normalize();
+
+			float h, p;
+			delta.getHP(h, p);
+			matrix.setHPB(h, p, 0);
+			matrix.c = pos;
+		}
 	}
 	else
 	{

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -3240,9 +3240,11 @@ Fmatrix CWeapon::RayTransform()
 			Fvector target = Fvector().add(pick.defs.start, Fvector().mul(pick.defs.dir, pick.defs.range));
 			Fvector delta = Fvector().sub(target, pos).normalize();
 
-			float h, p;
+			float h, p, b;
 			delta.getHP(h, p);
-			matrix.setHPB(h, p, 0);
+			float _h, _p;
+			Device.mInvView.getHPB(_h, _p, b);
+			matrix.setHPB(h, p, b);
 			matrix.c = pos;
 		}
 	}

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -530,6 +530,7 @@ public:
 
 private:
 	float m_nearwall_zoomed_range;
+	float m_aimpos;
 
 public:
 	float GetTargetNearWallOffset();

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2499,6 +2499,7 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask, "g_firepos", &psActorFlags, AF_FIREPOS);
 	CMD3(CCC_Mask, "g_firepos_zoom", &psActorFlags, AF_FIREPOS_ZOOM);
 	CMD3(CCC_Mask, "g_firedir_third_person", &psActorFlags, AF_FIREDIR_THIRD_PERSON);
+	CMD3(CCC_Mask, "g_aimpos", &psActorFlags, AF_AIMPOS);
 	CMD4(CCC_Integer, "g_nearwall", &g_nearwall, 0, 2);
 	CMD4(CCC_Integer, "g_nearwall_trace", &g_nearwall_trace, 0, 1);
 	CMD3(CCC_Mask, "g_crosshair_show_always", &psHUD_Flags, HUD_CROSSHAIR_SHOW_ALWAYS);


### PR DESCRIPTION
Splits the `g_firepos` behaviour out into separate position and direction settings. This allows weapons with broken fire bones to gain partial benefit from the 3D ballistics system (ex. firing around corners) without an asset-level fix by firing toward the camera's horizon target, and recaptures the original from-camera-along-barrel-direction behaviour in `g_firepos 0` + `g_aimpos 1`.

Also available in LTX; setting `aimpos = false` in a weapon section will forcefully disable the behaviour, allowing broken weapons to coexist with well-behaved ones when using the new ballistics.