### PR TITLE
MAS scope spawn fix

### DIFF
--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -985,6 +985,19 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 	
 	iAmmoElapsed = E->a_elapsed;
 	m_flagsAddOnState = E->m_addon_flags.get();
+	
+	if (m_modular_attachments && (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope) != 0 && m_scopes.size() > 1)
+	{
+		m_cur_scope = ::Random.randI(1, m_scopes.size());
+		CWeaponMagazined* wm = smart_cast<CWeaponMagazined*>(this);
+		if (wm)
+		{
+			wm->LoadScopeKoeffs();
+			m_scopeItem = xr_new<CAnonHudItem>();
+			m_scopeItem->Load(m_scopes[m_cur_scope].c_str());
+		}
+	}
+
 	m_ammoType = E->ammo_type;
 	SetState(E->wpn_state);
 	SetNextState(E->wpn_state);

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -169,6 +169,8 @@ protected:
 	virtual bool IsHudModeNow();
 	virtual bool SOParentIsActor() { return ParentIsActor(); }
 	u8 last_idx;
+
+	CAnonHudItem* m_scopeItem = NULL;
 public:
 	void signal_HideComplete();
 	virtual bool Action(u16 cmd, u32 flags);

--- a/src/xrGame/WeaponMagazined.h
+++ b/src/xrGame/WeaponMagazined.h
@@ -37,8 +37,6 @@ protected:
 	// General
 	//кадр момента пересчета UpdateSounds
 	u32 dwUpdateSounds_Frame;
-
-	CAnonHudItem* m_scopeItem = NULL;
 protected:
 	virtual void OnMagazineEmpty();
 


### PR DESCRIPTION
A simple fix which replaces invalid m_cur_scope=0 with some random scope when modular attachments are enabled