### PR TITLE
MAS random scope spawn fix

### DIFF
--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -986,7 +986,7 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 	iAmmoElapsed = E->a_elapsed;
 	m_flagsAddOnState = E->m_addon_flags.get();
 	
-	if (m_modular_attachments && (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope) != 0 && m_scopes.size() > 1)
+	if (m_modular_attachments && m_cur_scope == 0 && (m_flagsAddOnState & CSE_ALifeItemWeapon::eWeaponAddonScope) != 0 && m_scopes.size() > 1)
 	{
 		m_cur_scope = ::Random.randI(1, m_scopes.size());
 		CWeaponMagazined* wm = smart_cast<CWeaponMagazined*>(this);


### PR DESCRIPTION
Another small fix, now of a stupid bug placed by me 1 commit before. Turned out net_Spawn is actually called on every weapon when loading a game so there should be a check for its parameters