### PR TITLE
Expose wallmark range via options menu

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -156,8 +156,21 @@
 	<string id="ui_mm_modded_exes_visual_particles_allow_silencer_hide_tracer">
 		<text>Allow silencers to hide tracers (allow_silencer_hide_tracer)</text>
 	</string>
-	
 
+	<!-- Wallmarks -->
+	<string id="ui_mm_wallmarks_modded_exes">
+		<text>Wallmarks</text>
+	</string>
+	<string id="ui_mm_menu_wallmarks">
+		<text>Wallmarks</text>
+	</string>
+	<string id="ui_mm_modded_exes_visual_wallmarks_g_wallmark_range_static">
+		<text>Static wallmark range (g_wallmark_range_static)</text>
+	</string>
+	<string id="ui_mm_modded_exes_visual_wallmarks_g_wallmark_range_skeleton">
+		<text>Skeletal wallmark range (g_wallmark_range_skeleton)</text>
+	</string>
+	
 	<!-- HDR10 -->
 	<string id="ui_mm_menu_hdr10">
 		<text>HDR 10</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -156,7 +156,20 @@
 	<string id="ui_mm_modded_exes_visual_particles_allow_silencer_hide_tracer">
 		<text>Позволить глушителям скрывать трассирующие элементы (allow_silencer_hide_tracer)</text>
 	</string>
-	
+
+	<!-- Wallmarks -->
+	<string id="ui_mm_wallmarks_modded_exes">
+		<text>Следы от пуль</text>
+	</string>
+	<string id="ui_mm_menu_wallmarks">
+		<text>Следы от пуль</text>
+	</string>
+	<string id="ui_mm_modded_exes_visual_wallmarks_g_wallmark_range_static">
+		<text>Диапазон статических следов от пуль (g_wallmark_range_static)</text>
+	</string>
+	<string id="ui_mm_modded_exes_visual_wallmarks_g_wallmark_range_skeleton">
+		<text>Диапазон следов от скелетных пуль (g_wallmark_range_skeleton)</text>
+	</string>
 
 	<!-- HDR10 -->
 	<string id="ui_mm_menu_hdr10">

--- a/gamedata/scripts/options_modded_exes_visual.script
+++ b/gamedata/scripts/options_modded_exes_visual.script
@@ -5,6 +5,7 @@ local page_crosshair = options_modded_exes_crosshair.PAGE
 local page_hdr10 = options_modded_exes_hdr10.PAGE
 local page_3d_scopes = options_modded_exes_3d_scopes.PAGE
 local page_particles = options_modded_exes_particles.PAGE
+local page_wallmarks = options_modded_exes_wallmarks.PAGE
 
 -- Import smart constructors
 options_builder.import_into(this)
@@ -16,5 +17,6 @@ GROUP = group {
 	page_crosshair,
 	page_3d_scopes,
 	page_particles,
+	page_wallmarks,
 	page_hdr10,
 }

--- a/gamedata/scripts/options_modded_exes_wallmarks.script
+++ b/gamedata/scripts/options_modded_exes_wallmarks.script
@@ -1,0 +1,19 @@
+--- Wallmarks options tree
+
+-- Import smart constructors
+options_builder.import_into(this)
+
+-- Shader scopes
+PAGE = page {
+	{ id = "wallmarks" },
+	track {
+		id = "g_wallmark_range_static",
+		def = 100,
+		step = 10,
+	},
+	track {
+		id = "g_wallmark_range_skeleton",
+		def = 50,
+		step = 10,
+	},
+}

--- a/src/Layers/xrRender/WallmarksEngine.cpp
+++ b/src/Layers/xrRender/WallmarksEngine.cpp
@@ -10,6 +10,8 @@
 #include "../../xrEngine/GameFont.h"
 #include "SkeletonCustom.h"
 
+float wallmark_range_static = 100.f;
+float wallmark_range_skeleton = 50.f;
 
 namespace WallmarksEngine
 {
@@ -317,7 +319,7 @@ void CWallmarksEngine::AddStaticWallmark(CDB::TRI* pTri, const Fvector* pVerts, 
 	ref_shader hShader, float sz, float ttl, bool ignore_opt, float rotation)
 {
 	// optimization cheat: don't allow wallmarks more than 100 m from viewer/actor
-	if (!ignore_opt && contact_point.distance_to_sqr(Device.vCameraPosition) > _sqr(100.f))
+	if (!ignore_opt && contact_point.distance_to_sqr(Device.vCameraPosition) > _sqr(wallmark_range_static))
 		return;
 
 	// Physics may add wallmarks in parallel with rendering
@@ -331,7 +333,7 @@ void CWallmarksEngine::AddSkeletonWallmark(const Fmatrix* xf, CKinematics* obj, 
 {
 	if (::RImplementation.phase != CRender::PHASE_NORMAL) return;
 	// optimization cheat: don't allow wallmarks more than 50 m from viewer/actor
-	if (!ignore_opt && xf->c.distance_to_sqr(Device.vCameraPosition) > _sqr(50.f)) return;
+	if (!ignore_opt && xf->c.distance_to_sqr(Device.vCameraPosition) > _sqr(wallmark_range_skeleton)) return;
 
 	VERIFY(obj&&xf&&(size>EPS_L));
 	lock.Enter();

--- a/src/engine-vs2022.sln
+++ b/src/engine-vs2022.sln
@@ -138,6 +138,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{8EC4
 		..\gamedata\scripts\options_modded_exes_sound.script = ..\gamedata\scripts\options_modded_exes_sound.script
 		..\gamedata\scripts\options_modded_exes_ui_hud.script = ..\gamedata\scripts\options_modded_exes_ui_hud.script
 		..\gamedata\scripts\options_modded_exes_visual.script = ..\gamedata\scripts\options_modded_exes_visual.script
+		..\gamedata\scripts\options_modded_exes_wallmarks.script = ..\gamedata\scripts\options_modded_exes_wallmarks.script
 		..\gamedata\scripts\scopeRadii.script = ..\gamedata\scripts\scopeRadii.script
 		..\gamedata\scripts\slaxml.script = ..\gamedata\scripts\slaxml.script
 		..\gamedata\scripts\true_first_person_death.script = ..\gamedata\scripts\true_first_person_death.script

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -152,6 +152,9 @@ extern int g_nearwall;
 extern int g_nearwall_trace;
 extern BOOL drawPickupItemNames;
 
+extern float wallmark_range_static;
+extern float wallmark_range_skeleton;
+
 extern string32 crosshair_shader;
 extern string32 crosshair_texture;
 extern float crosshair_near_size;
@@ -2882,4 +2885,8 @@ void CCC_RegisterCommands()
 
 	// Draw pickup item names
 	CMD4(CCC_Integer, "g_draw_pickup_item_names", &drawPickupItemNames, 0, 1);
+
+	// Wallmark distances
+	CMD4(CCC_Float, "g_wallmark_range_static", &wallmark_range_static, 0.f, 1000.f);
+	CMD4(CCC_Float, "g_wallmark_range_skeleton", &wallmark_range_skeleton, 0.f, 1000.f);
 }


### PR DESCRIPTION
Replaces the hardcoded 50m / 100m wallmark ranges with customizable cvars.