### PR TITLE
[ReShade] Fix crash in fullscreen mode

### DIFF
--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -953,6 +953,10 @@ DXGI_RATIONAL CHW::selectRefresh(u32 dwWidth, u32 dwHeight, DXGI_FORMAT fmt)
     return res;
 }
 
+extern bool use_reshade;
+extern bool init_reshade();
+extern void unregister_reshade();
+
 void CHW::OnAppActivate()
 {
 #if defined(USE_DX11)
@@ -995,6 +999,9 @@ void CHW::OnAppActivate()
 
         UpdateViews();
 #endif
+
+		if (use_reshade)
+            init_reshade();
     }
 }
 
@@ -1008,6 +1015,9 @@ void CHW::OnAppDeactivate()
 
 	if (m_pSwapChain && !is_windowed)
 	{
+		if (use_reshade)
+            unregister_reshade();
+		
         m_pSwapChain->SetFullscreenState(FALSE, NULL);
 
 #ifdef USE_DX11


### PR DESCRIPTION
Game no longer crashes when tabbing out and back into the game in fullscreen mode with ReShade installed