### PR TITLE
Expose CUIProgressBar's m_UIProgressItem to LUA

### DIFF
--- a/src/xrGame/ui/UIProgressBar.h
+++ b/src/xrGame/ui/UIProgressBar.h
@@ -61,6 +61,8 @@ public:
 	void SetProgressPos(float _Pos);
 	float GetProgressPos() { return m_ProgressPos.y; }
 
+    CUIStatic& GetProgressStatic() { return m_UIProgressItem; }
+
 	void ShowBackground(bool status) { m_bBackgroundPresent = status; }
 	bool IsShownBackground() { return m_bBackgroundPresent; }
 

--- a/src/xrGame/ui/UIProgressBar_script.cpp
+++ b/src/xrGame/ui/UIProgressBar_script.cpp
@@ -24,5 +24,8 @@ void CUIProgressBar::script_register(lua_State* L)
 		.def("SetMinColor", &CUIProgressBar::SetMinColor)
 		.def("SetMiddleColor", &CUIProgressBar::SetMinColor)
 		.def("SetMaxColor", &CUIProgressBar::SetMinColor)
+
+		// NLTP_ASHES
+		.def("GetProgressStatic", &CUIProgressBar::GetProgressStatic)
 	];
 }


### PR DESCRIPTION
As simple as what the title says.

The engine class `CUIProgressBar` contains a `CUIStatic` that displays the progress bar's texture.

This `CUIStatic` wasn't exposed to LUA before which makes scaling it dynamically at runtime impossible.

The changes I made simply expose that inner `CUIStatic` to LUA so modders can apply transforms to it.