### PR TITLE
Implement `g_aimpos_zoom`

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -600,13 +600,16 @@
 	</string>
 	
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_firepos">
-		<text>Enable bullets firing from gun barrel while unaimed (g_firepos)</text>
+		<text>Fire bullets from gun barrel while unaimed (g_firepos)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_firepos_zoom">
-		<text>Enable bullets firing from gun barrel while aiming (g_firepos_zoom)</text>
+		<text>Fire bullets from gun barrel while aiming (g_firepos_zoom)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_aimpos">
-		<text>Aim bullets along barrel (g_aimpos)</text>
+		<text>Aim bullets along gun barrel while unaimed (g_aimpos)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_aimpos_zoom">
+		<text>Aim bullets along gun barrel while aiming (g_aimpos_zoom)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_firedir_third_person">
 		<text>Use first-person firing direction when in third-person (g_firedir_third_person)</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -587,6 +587,9 @@
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_aimpos">
 		<text>Направьте пули по направлению ствола (g_aimpos)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_aimpos_zoom">
+		<text>Направляйте пули вдоль ствола оружия во время прицеливания (g_aimpos_zoom)</text>
+	</string>
 	<string id="ui_mm_modded_exes_gameplay_3d_ballistics_g_firedir_third_person">
 		<text>Используйте направление стрельбы от первого лица в третьем лице (g_firedir_third_person)</text>
 	</string>

--- a/gamedata/scripts/options_modded_exes_3d_ballistics.script
+++ b/gamedata/scripts/options_modded_exes_3d_ballistics.script
@@ -9,6 +9,7 @@ PAGE = page {
 	check { id = "g_firepos" },
 	check { id = "g_firepos_zoom" },
 	check { id = "g_aimpos" },
+	check { id = "g_aimpos_zoom" },
 	check { id = "g_firedir_third_person" },
 	list_enum {
 		id = "g_nearwall",

--- a/src/xrGame/Actor_Flags.h
+++ b/src/xrGame/Actor_Flags.h
@@ -25,6 +25,7 @@ enum
 	AF_FIREPOS_ZOOM = (1 << 21),
 	AF_FIREDIR_THIRD_PERSON = (1 << 22),
 	AF_AIMPOS = (1 << 23),
+	AF_AIMPOS_ZOOM = (1 << 24),
 };
 
 extern Flags32 psActorFlags;

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -363,7 +363,20 @@ bool CHUDManager::FireposActive()
 
 bool CHUDManager::AimposActive()
 {
-	return psActorFlags.test(AF_AIMPOS);
+	// If we have an actor...
+	CActor* pActor = smart_cast<CActor*>(Level().CurrentEntity());
+	if (!pActor)
+		return psActorFlags.test(AF_AIMPOS);
+
+	// And a weapon...
+	CWeapon* pWeapon = smart_cast<CWeapon*>(pActor->inventory().ActiveItem());
+	if (!pWeapon)
+		return psActorFlags.test(AF_AIMPOS);
+
+	// Firepos is active if a setting matches its respective zoom state
+	float zFac = pWeapon->GetZRotatingFactor();
+	return (psActorFlags.test(AF_AIMPOS) && zFac < 1.f)
+		|| (psActorFlags.test(AF_AIMPOS_ZOOM) && zFac >= 1.f);
 }
 
 ICF static BOOL pick_trace_callback(collide::rq_result& result, LPVOID params)

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -3244,7 +3244,7 @@ Fmatrix CWeapon::RayTransform()
 		matrix.mulB_43(Fmatrix().translate(measures.m_fire_point_offset));
 
 		// If aim position is not enabled
-		bool aimpos = m_aimpos && psActorFlags.test(AF_AIMPOS);
+		bool aimpos = m_aimpos && HUD().AimposActive();
 		if (!aimpos)
 		{
 			// Aim toward camera look position

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -3297,8 +3297,8 @@ Fmatrix CWeapon::RayTransform()
 
 void CWeapon::g_fireParams(SPickParam& pp)
 {
-	// Block base implmentation if firepos is enabled
-	if (HUD().FireposActive())
+	// Block base implementation if aimpos is enabled
+	if (HUD().AimposActive())
 	{
 		return;
 	}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2550,7 +2550,7 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask, "g_firepos_zoom", &psActorFlags, AF_FIREPOS_ZOOM);
 	CMD3(CCC_Mask, "g_firedir_third_person", &psActorFlags, AF_FIREDIR_THIRD_PERSON);
 	CMD3(CCC_Mask, "g_aimpos", &psActorFlags, AF_AIMPOS);
-
+	CMD3(CCC_Mask, "g_aimpos_zoom", &psActorFlags, AF_AIMPOS_ZOOM);
 	CMD4(CCC_Integer, "g_nearwall", &g_nearwall, 0, 2);
 	CMD4(CCC_Integer, "g_nearwall_trace", &g_nearwall_trace, 0, 1);
 


### PR DESCRIPTION
Equivalent to `g_firepos_zoom` but for aim direction; potentially good for users of 2D scopes who don't want to deal with zeroing behaviour.