### PR TITLE
Procedural move animations

### DIFF
--- a/src/xrEngine/defines.h
+++ b/src/xrEngine/defines.h
@@ -65,6 +65,7 @@ enum
 	rsOptShadowGeom = (1 << 9),
 	rsAimSway = (1 << 10),
 	rsAlwaysActive = (1 << 11),
+	rsBlendMoveAnims = (1 << 12),
 };
 
 // game path definition

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -1286,6 +1286,9 @@ bool CWeapon::NeedBlendAnm()
 	if (IsZoomed() && psDeviceFlags2.test(rsAimSway))
 		return true;
 
+	if (psDeviceFlags2.test(rsBlendMoveAnims))
+		return true;
+	
 	return inherited::NeedBlendAnm();
 }
 
@@ -3117,7 +3120,7 @@ void CWeapon::render_hud_mode()
 
 bool CWeapon::MovingAnimAllowedNow()
 {
-	return !IsZoomed();
+	return !IsZoomed() && !psDeviceFlags2.test(rsBlendMoveAnims);
 }
 
 bool CWeapon::IsHudModeNow()

--- a/src/xrGame/WeaponBinoculars.cpp
+++ b/src/xrGame/WeaponBinoculars.cpp
@@ -34,6 +34,16 @@ void CWeaponBinoculars::Load(LPCSTR section)
 	m_bVision = !!pSettings->r_bool(section, "vision_present");
 }
 
+bool CWeaponBinoculars::NeedBlendAnm()
+{
+	return false;
+}
+
+bool CWeaponBinoculars::MovingAnimAllowedNow()
+{
+	return true;
+}
+
 Fmatrix CWeaponBinoculars::RayTransform()
 {
 	Fmatrix matrix = CHudItem::RayTransform();

--- a/src/xrGame/WeaponBinoculars.h
+++ b/src/xrGame/WeaponBinoculars.h
@@ -19,6 +19,9 @@ public:
 
 	void Load(LPCSTR section);
 
+	virtual bool NeedBlendAnm();
+	virtual bool MovingAnimAllowedNow();
+
 	virtual Fmatrix RayTransform();
 
 	virtual void OnZoomIn();

--- a/src/xrGame/WeaponKnife.cpp
+++ b/src/xrGame/WeaponKnife.cpp
@@ -75,6 +75,16 @@ void CWeaponKnife::Load(LPCSTR section)
 	knife_material_idx = GMLib.GetMaterialIdx(KNIFE_MATERIAL_NAME);
 }
 
+bool CWeaponKnife::NeedBlendAnm()
+{
+	return false;
+}
+
+bool CWeaponKnife::MovingAnimAllowedNow()
+{
+	return true;
+}
+
 Fmatrix CWeaponKnife::RayTransform()
 {
 	Fmatrix matrix = CHudItem::RayTransform();

--- a/src/xrGame/WeaponKnife.h
+++ b/src/xrGame/WeaponKnife.h
@@ -56,6 +56,9 @@ public:
 
 	void Load(LPCSTR section);
 
+	virtual bool NeedBlendAnm();
+	virtual bool MovingAnimAllowedNow();
+
 	virtual Fmatrix RayTransform();
 	virtual void g_fireParams(SPickParam& pp) {};
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2751,6 +2751,8 @@ void CCC_RegisterCommands()
 
 	CMD3(CCC_Mask, "weapon_sway", &psDeviceFlags2, rsAimSway);
 
+	CMD3(CCC_Mask, "blend_move_anims", &psDeviceFlags2, rsBlendMoveAnims);
+
 #ifdef DEBUG
 	//extern BOOL g_use_new_ballistics;
 	//CMD4(CCC_Integer,	"use_new_ballistics",	&g_use_new_ballistics, 0, 1);

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -712,16 +712,20 @@ player_hud::player_hud()
 		char temp[20];
 		string512 tmp;
 		strconcat(sizeof(temp), temp, "movement_layer_", std::to_string(i).c_str());
-		R_ASSERT2(pSettings->line_exist("hud_movement_layers", temp), make_string("Missing definition for [hud_movement_layers] %s", temp));
-		LPCSTR layer_def = pSettings->r_string("hud_movement_layers", temp);
-		R_ASSERT2(_GetItemCount(layer_def) > 0, make_string("Wrong definition for [hud_movement_layers] %s", temp));
 		
-		_GetItem(layer_def, 0, tmp);
-		anm->Load(tmp);
-		_GetItem(layer_def, 1, tmp);
-		anm->anm->Speed() = (atof(tmp) ? atof(tmp) : 1.f);
-		_GetItem(layer_def, 2, tmp);
-		anm->m_power = (atof(tmp) ? atof(tmp) : 1.f);
+		if (pSettings->line_exist("hud_movement_layers", temp))
+		{
+			LPCSTR layer_def = pSettings->r_string("hud_movement_layers", temp);
+			R_ASSERT2(_GetItemCount(layer_def) > 0, make_string("Wrong definition for [hud_movement_layers] %s", temp));
+
+			_GetItem(layer_def, 0, tmp);
+			anm->Load(tmp);
+			_GetItem(layer_def, 1, tmp);
+			anm->anm->Speed() = (atof(tmp) ? atof(tmp) : 1.f);
+			_GetItem(layer_def, 2, tmp);
+			anm->m_power = (atof(tmp) ? atof(tmp) : 1.f);
+		}
+
 		m_movement_layers.push_back(anm);
 	}
 }
@@ -1313,30 +1317,39 @@ void player_hud::updateMovementLayerState()
 
 	bool need_blend = (script_anim_part != u8(-1) || (m_attached_items[0] && m_attached_items[0]->m_parent_hud_item->NeedBlendAnm()) || (m_attached_items[1] && m_attached_items[1]->m_parent_hud_item->NeedBlendAnm()));
 
-	if (pActor->AnyMove() && need_blend)
+	if (need_blend)
 	{
-		CEntity::SEntityState state;
-		pActor->g_State(state);
-
 		CWeapon* wep = nullptr;
 
 		if (m_attached_items[0] && m_attached_items[0]->m_parent_hud_item->has_object() && m_attached_items[0]->m_parent_hud_item->object().cast_weapon())
 			wep = m_attached_items[0]->m_parent_hud_item->object().cast_weapon();
 
 		if (wep && wep->IsZoomed()) {
-			state.bCrouch ? m_movement_layers[eAimCrouch]->Play() : m_movement_layers[eAimWalk]->Play();
+			m_movement_layers[eAimIdle]->Play();
+		} else {
+			m_movement_layers[eIdle]->Play();
 		}
-		else if (state.bCrouch) {
-			m_movement_layers[eCrouch]->Play();
-		}
-		else if (state.bSprint) {
-			m_movement_layers[eSprint]->Play();
-		}
-		else if (!isActorAccelerated(pActor->MovingState(), false)) {
-			m_movement_layers[eWalk]->Play();
-		}
-		else {
-			m_movement_layers[eRun]->Play();
+
+		if (pActor->AnyMove())
+		{
+			CEntity::SEntityState state;
+			pActor->g_State(state);
+
+			if (wep && wep->IsZoomed()) {
+				state.bCrouch ? m_movement_layers[eAimCrouch]->Play() : m_movement_layers[eAimWalk]->Play();
+			}
+			else if (state.bCrouch) {
+				m_movement_layers[eCrouch]->Play();
+			}
+			else if (state.bSprint) {
+				m_movement_layers[eSprint]->Play();
+			}
+			else if (!isActorAccelerated(pActor->MovingState(), false)) {
+				m_movement_layers[eWalk]->Play();
+			}
+			else {
+				m_movement_layers[eRun]->Play();
+			}
 		}
 	}
 }

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -47,6 +47,8 @@ enum eMovementLayers
 	eWalk,
 	eRun,
 	eSprint,
+	eAimIdle,
+	eIdle,
 	move_anms_end
 };
 
@@ -77,7 +79,7 @@ struct movement_layer
 
 	void Play(bool bLoop = true)
 	{
-		if (!anm->Name())
+		if (!anm->Name() || !xr_strcmp("", anm->Name()))
 			return;
 
 		if (IsPlaying())

--- a/src/xrGame/weaponBM16.cpp
+++ b/src/xrGame/weaponBM16.cpp
@@ -203,44 +203,46 @@ void CWeaponBM16::PlayAnimIdle()
 			return;
 		}
 
-		if (st.bSprint)
-		{
-			PlayAnimIdleSprint();
-			return;
-		}
-		else if (!st.bCrouch)
-		{
-			PlayAnimIdleMoving();
-			return;
-		}
-		else if (st.bCrouch)
-		{
-			switch (m_magazine.size())
+		if (MovingAnimAllowedNow()) {
+			if (st.bSprint)
 			{
-			case 0:
-			{
-				HudAnimationExist("anm_idle_moving_crouch_0")
-					? PlayHUDMotion("anm_idle_moving_crouch_0", TRUE, NULL, GetState())
-					: PlayHUDMotion("anm_idle_moving_0", TRUE, NULL, GetState(), .7f);
+				PlayAnimIdleSprint();
+				return;
 			}
-			break;
-			case 1:
+			else if (!st.bCrouch)
 			{
-				HudAnimationExist("anm_idle_moving_crouch_1")
-					? PlayHUDMotion("anm_idle_moving_crouch_1", TRUE, NULL, GetState())
-					: PlayHUDMotion("anm_idle_moving_1", TRUE, NULL, GetState(), .7f);
+				PlayAnimIdleMoving();
+				return;
 			}
-			break;
-			case 2:
+			else if (st.bCrouch)
 			{
-				HudAnimationExist("anm_idle_moving_crouch_2")
-					? PlayHUDMotion("anm_idle_moving_crouch_2", TRUE, NULL, GetState())
-					: PlayHUDMotion("anm_idle_moving_2", TRUE, NULL, GetState(), .7f);
-			}
-			break;
-			};
+				switch (m_magazine.size())
+				{
+				case 0:
+				{
+					HudAnimationExist("anm_idle_moving_crouch_0")
+						? PlayHUDMotion("anm_idle_moving_crouch_0", TRUE, NULL, GetState())
+						: PlayHUDMotion("anm_idle_moving_0", TRUE, NULL, GetState(), .7f);
+				}
+				break;
+				case 1:
+				{
+					HudAnimationExist("anm_idle_moving_crouch_1")
+						? PlayHUDMotion("anm_idle_moving_crouch_1", TRUE, NULL, GetState())
+						: PlayHUDMotion("anm_idle_moving_1", TRUE, NULL, GetState(), .7f);
+				}
+				break;
+				case 2:
+				{
+					HudAnimationExist("anm_idle_moving_crouch_2")
+						? PlayHUDMotion("anm_idle_moving_crouch_2", TRUE, NULL, GetState())
+						: PlayHUDMotion("anm_idle_moving_2", TRUE, NULL, GetState(), .7f);
+				}
+				break;
+				};
 
-			return;
+				return;
+			}
 		}
 	}
 	


### PR DESCRIPTION
- Added "idle" and "idle aim" animation movement layers
- Removed assert for movement layer animation being specified, they're optional now
- Added a flag which enables movement layers for all states and disables weapons own move animations