### PR TITLE
Add emacs temp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ src/3rd party/luajit-2/src/lj_libdef.h
 src/3rd party/luajit-2/src/lj_recdef.h
 src/3rd party/luajit-2/src/host/buildvm_arch.h
 src/3rd party/luajit-2/src/jit/vmdef.lua
+
+# emacs temp file
+\#*\#
+*~


### PR DESCRIPTION
Simple tweak so emacs users can keep undo trees and other useful editor metadata in-tree without complicating the commit process.