### PR TITLE
Export CurrentGameUI()->m_pMessagesWnd to Lua

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -244,6 +244,10 @@
         //    level.add_bullet(t)
     }
 
+    namespace ActorMenu {
+        function get_messages_menu()
+    }
+
     // obj:get_physics_shell()
     class PHShell {
         void apply_torque(float roll, float yaw, float pitch)

--- a/src/engine-vs2022.sln
+++ b/src/engine-vs2022.sln
@@ -102,8 +102,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReShadeCompat", "ReShadeCom
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
-		..\gamedata\scripts\aaaa_script_fixes_mp.script = ..\gamedata\scripts\aaaa_script_fixes_mp.script
 		..\gamedata\scripts\aaa_sound_object_patch.script = ..\gamedata\scripts\aaa_sound_object_patch.script
+		..\gamedata\scripts\aaaa_script_fixes_mp.script = ..\gamedata\scripts\aaaa_script_fixes_mp.script
 		..\gamedata\scripts\axr_beh_patches.script = ..\gamedata\scripts\axr_beh_patches.script
 		..\gamedata\scripts\callbacks_gameobject.script = ..\gamedata\scripts\callbacks_gameobject.script
 		..\gamedata\scripts\class_registrator_modded_exes.script = ..\gamedata\scripts\class_registrator_modded_exes.script

--- a/src/xrGame/ui/UIActorMenu_script.cpp
+++ b/src/xrGame/ui/UIActorMenu_script.cpp
@@ -29,6 +29,7 @@
 #include "UIZoneMap.h"
 #include "UIMotionIcon.h"
 #include "UIHudStatesWnd.h"
+#include "UIMessagesWindow.h"
 
 using namespace luabind;
 
@@ -45,6 +46,13 @@ CUIPdaWnd* GetPDAMenu()
 CUIMainIngameWnd* GetMainGameMenu()
 {
 	return CurrentGameUI()->UIMainIngameWnd;
+}
+
+CUIWindow* GetMessagesMenu()
+{
+	CUIMessagesWindow* messagesWnd = CurrentGameUI()->m_pMessagesWnd;
+	CUIWindow* window = smart_cast<CUIWindow*>(messagesWnd);
+	return window;
 }
 
 u8 GrabMenuMode()
@@ -395,6 +403,9 @@ void CUIActorMenu::script_register(lua_State* L)
 		def("get_pda_menu", &GetPDAMenu),
 		def("get_actor_menu", &GetActorMenu),
 		def("get_menu_mode", &GrabMenuMode),
-		def("get_maingame", &GetMainGameMenu)
+		def("get_maingame", &GetMainGameMenu),
+
+		// NLTP_ASHES
+		def("get_messages_menu", &GetMessagesMenu)
 	];
 }

--- a/src/xrGame/ui/UIMessagesWindow.h
+++ b/src/xrGame/ui/UIMessagesWindow.h
@@ -22,23 +22,20 @@ public:
 	virtual ~CUIMessagesWindow();
 
 	void AddIconedPdaMessage(GAME_NEWS_DATA* news);
-
 	void AddLogMessage(const shared_str& msg);
 	void AddLogMessage(KillMessageStruct& msg);
 	void AddChatMessage(shared_str msg, shared_str author);
-	//.	void				SetChatOwner					(game_cl_GameState* owner);
 	void PendingMode(bool const is_in_pending_mode);
 	CUIChatWnd* GetChatWnd() { return m_pChatWnd; }
 	virtual void Show(bool show);
 
-
 protected:
 	virtual void Init(float x, float y, float width, float height);
-
 
 	CUIGameLog* m_pChatLog;
 	CUIChatWnd* m_pChatWnd;
 	CUIGameLog* m_pGameLog;
+
 	bool m_in_pending_mode;
 
 	Frect m_pending_chat_log_rect;


### PR DESCRIPTION
This PR exports `CurrentGameUI()->m_pMessagesWnd` to Lua under the name `ActorMenu.get_messages_menu()`.

It should be noted that right now, this is exported as a `CUIWindow`, instead of it's real type `CUIMessagesWindow`. This means that anyone trying to export additional functions from it will not work.

I do not have the skills to export it as `CUIMessagesWindow`, so I am leaving it as `CUIWindow`, as it is sufficient for my needs.