### PR TITLE
Script Attachment improvements

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -450,6 +450,7 @@
         function add_attachment(string, string)
         function get_attachment(string)
         function remove_attachment(string)
+        function remove_attachment(script_attachment)
         function iterate_attachments(function)
 		
 		// Shader/Textures
@@ -677,143 +678,107 @@
         function set_position(number, number, number);
     }
     
+    enum script_attachment_type {
+        Hud         = 1,
+        World       = 2,
+        CamAttached = 4,
+    }
+
     class ScriptAttachment {
-        function add_attachment(string, string);
-        function attach_light(attachment_script_light*);
-        function bone_callback(number, number, boolean);
-        function bone_callback(number, const function<matrix>&, boolean);
-        function detach_light();
-        function get_attachment(string);
-        function get_bone_matrix(number);
-        function get_bone_visible(number);
-        function get_center();
-        function get_flags();
-        function get_light();
-        function get_light_bone();
-        function get_model();
-        function get_origin();
-        function get_parent();
-        function get_parent_bone();
-        function get_position();
-        function get_rotation();
-        function get_scale();
-        function get_transform();
-        function get_ui();
-        function get_ui_bone();
-        function get_ui_rotation();
-        function iterate_attachments(function);
-        function play_motion(string, boolean, number);
-        function remove_attachment(string);
-        function remove_bone_callback(number);
-        function set_bone_visible(number, boolean);
-        function set_flags(number);
-        function set_light_bone(number);
-        function set_model(string, boolean);
-        function set_origin(vector);
-        function set_origin(number, number, number);
+        -- Parent
         function set_parent(ScriptAttachment*);
         function set_parent(game_object*);
-        function set_parent_bone(number);
+        function get_parent();
+
+        -- Child
+        function add_attachment(string, string);
+        function get_attachment(string);
+        function remove_attachment(string);
+        function remove_attachment(script_attachment);
+        function iterate_attachments(function<boolean>);
+
+        -- Offset
         function set_position(vector);
         function set_position(number, number, number);
+        function get_position();
         function set_rotation(vector);
         function set_rotation(number, number, number);
+        function get_rotation();
+        function set_origin(vector);
+        function set_origin(number, number, number);
+        function get_origin();
         function set_scale(vector);
         function set_scale(number, number, number);
         function set_scale(number);
+        function get_scale();
+        function get_transform();
+        function get_center();
+
+        -- Bones
+        function bone_id(string)
+        function bone_name(number)
+        function bone_visible(number)
+        function bone_visible(string)
+        function set_bone_visible(number, boolean, boolean)
+        function set_bone_visible(string, boolean, boolean)
+        function bone_transform(number)
+        function bone_transform(string)
+        function bone_position(number)
+        function bone_position(string)
+        function bone_direction(number)
+        function bone_direction(string)
+        function bone_parent(number)
+        function bone_parent(string)
+        function set_parent_bone(number);
+        function set_parent_bone(string);
+        function get_parent_bone();
+        function list_bones()
+
+        -- Bone Callbacks
+        function bone_callback(number, number, boolean);
+        function bone_callback(string, string, boolean);
+        function bone_callback(number, string, boolean);
+        function bone_callback(string, number, boolean);
+        function bone_callback(number, function<matrix>, boolean);
+        function bone_callback(string, function<matrix>, boolean);
+        function remove_bone_callback(number);
+        function remove_bone_callback(string);
+
+        -- Other
+        function set_type(number); -- ex. script_attachment_type.Hud
+        function get_type();
+        function set_model(string, boolean);
+        function get_model();
+        function set_name();
+        function get_name();
+        function play_motion(string, boolean, number);
+
+        -- Script 3D UI
         function set_ui(string);
+        function get_ui();
         function set_ui_bone(number);
+        function get_ui_bone();
         function set_ui_position(vector);
         function set_ui_position(number, number, number);
         function get_ui_position();
         function set_ui_rotation(vector);
         function set_ui_rotation(number, number, number);
         function get_ui_rotation();
+
+        -- Script Light
+        function attach_light(attachment_script_light*);
+        function detach_light();
+        function get_light();
+        function set_light_bone(number);
+        function set_light_bone(string);
+        function get_light_bone();
+
+        -- Shader and Texture
 		function get_shaders()
 		function get_default_shaders()
 		function set_shader(number, string, string)
 		function reset_shader(number)
     }
     
-    flags:
-    ["eSA_RenderHUD"] = 1,
-    ["eSA_RenderWorld"] = 2,
-    ["eSA_CamAttached"] = 4,
-    
-    Script Attachment examples:
-    
-    -- adds script attachment with name "test" and model gamedata\meshes\test\box.ogf to the actor's current active item
-    local att = db.actor:active_item():add_attachment("test", "test\\box")
-    
-    -- setting attachment parameters
-    
-    -- functions accept both vectors or three values, scale even accepts one value
-    att:set_position(0,1,2)
-    att:set_rotation(vector():set(0,90,0))
-    att:set_scale(0.9)
-    
-    -- render both on hud and world model (default is 2 -> only on world model)
-    att:set_flags(3)
-    
-    -- create an attachment_script_light (can use script_light functions and properties)
-    -- ! make sure to keep a reference to the script light or it will be garbage collected !
-    att_light = attachment_script_light()
-    att_light.type = 2
-    att_light.hud_mode = true
-    
-    -- attachment_script_light position and direction work as an offset to the attachment position/direction
-    att_light:set_position(0,0,2)
-    att_light:set_direction(0,90,0)
-    att_light:set_cone(math.rad(0.5))
-    att_light.color = fcolor():set(1,0,0,1)
-    
-    -- attach it to the script attachment
-    att:attach_light(att_light)
-    
-    
-    -- attach the model to the actor instead of their active item
-    att:set_parent(db.actor)
-    
-    -- make it a camera attachment
-    att:set_flags(4)
-    
-    -- you can attach attachments to other attachments
-    att2 = att:add_attachment("box2", "test\\box2")
-    att3 = att2:add_attachment("box2", "test\\box2")
-    
-    -- and transfer the whole chain of attachments to another parent
-    -- this will transfer att and its child attachments to the new parent
-    att:set_parent(db.actor:active_item())
-    
-    -- same for child attachments
-    att3:set_parent(npc)
-    
-    -- it's also possible to change the model at any time
-    -- the boolean tells the engine if existing bone callbacks should be kept in place or if they should be removed
-    att3:set_model("armor\\boots", false)
-    
-    -- bone callbacks can be added like this
-    -- there are two types of bone callbacks
-    -- this makes the bone 1 of the attachment model follow the position of bone 6 of its parent object, the boolean tells the engine to overwrite any animation positions
-    -- same with bone 2 of the attachment model to bone 10 of the parent object
-    att3:bone_callback(1, 6, false)
-    att3:bone_callback(2, 10, false)
-    
-    -- the second type of bone callbacks uses a script callback to change the position of a bone in real time
-    local lock = db.actor:add_attachment("lock", "interface\\lockpick\\lock3")
-    lock:set_flags(4)
-    lock:set_rotation(90,0,0)
-    lock:set_position(0,0,0.09)
-    -- the callback function "cylinder_callback" will be used to adjust the position of bone 1
-    lock:bone_callback(1, cylinder_callback, false)
-    
-    -- example callback function
-    -- this will adjust the rotation of the bone
-    function cylinder_callback(mat)
-        local temp = mat.c
-        local hpb = mat:getHPB()
-        mat:setHPB(hpb.x, hpb.y + cylinder_rotation, hpb.z)
-        mat.c = temp
-        return mat
-    end
+    Script Attachment Guide: https://igigog.github.io/anomaly-modding-book/tutorials/scripting/script-attachments.html
 --]]

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1936,8 +1936,8 @@ void CActor::RenderCamAttached()
 			{
 				script_attachment* att = pair.second;
 
-				if (att->GetFFlags().test(eSA_CamAttached))
-					att->Render(nullptr, &cam, true);
+				if (att->GetType() == eSA_CamAttached)
+					att->Render(nullptr, &cam);
 			}
 
 			::Render->set_CamAttached(FALSE);

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -748,14 +748,14 @@ void CGameObject::RenderAttachments()
 		for (auto& pair : m_script_attachments)
 		{
 			script_attachment* att = pair.second;
-			if (att->GetFFlags().test(eSA_RenderWorld))
+			if (att->GetType() == eSA_World)
 			{
 				att->Render(Visual()->dcast_PKinematics(), &XFORM());
 
 				if (::Render->get_generation() == ::Render->GENERATION_R1)
 					g_pGamePersistent->AttachmentUIsToRender.push_back(att);
 				else
-					att->RenderUI(false);
+					att->RenderUI();
 			}
 		}
 	}
@@ -764,7 +764,7 @@ void CGameObject::RenderAttachments()
 script_attachment* CGameObject::add_attachment(LPCSTR name, script_attachment* att)
 {
 	R_ASSERT(att);
-	remove_attachment(name, true);
+	remove_child(name, true);
 	m_script_attachments.emplace(mk_pair(name, att));
 	return att;
 }
@@ -781,7 +781,7 @@ script_attachment* CGameObject::get_attachment(LPCSTR name)
 	return nullptr;
 }
 
-void CGameObject::remove_attachment(LPCSTR name, bool destroy)
+void CGameObject::remove_child(LPCSTR name, bool destroy)
 {
 	if (m_script_attachments.size())
 	{
@@ -794,6 +794,29 @@ void CGameObject::remove_attachment(LPCSTR name, bool destroy)
 			
 		m_script_attachments.erase(name);
 	}
+}
+
+void CGameObject::remove_attachment(script_attachment* child)
+{
+	if (!child) return;
+	if (m_script_attachments.size())
+	{
+		script_attachment* attachment = get_attachment(child->GetName());
+		if (!attachment || attachment != child)
+			return;
+
+		remove_child(child->GetName(), true);
+	}
+}
+
+void CGameObject::iterate_attachments(::luabind::functor<bool> functor)
+{
+	if (!m_script_attachments.size())
+		return;
+
+	for (auto& pair : m_script_attachments)
+		if (functor(pair.first.c_str(), pair.second) == true)
+			return;
 }
 
 /*

--- a/src/xrGame/GameObject.h
+++ b/src/xrGame/GameObject.h
@@ -183,7 +183,10 @@ public:
 
 	virtual script_attachment* add_attachment(LPCSTR name, script_attachment* att);
 	virtual script_attachment* get_attachment(LPCSTR name);
-	virtual void remove_attachment(LPCSTR name, bool destroy = false);
+	virtual void remove_child(LPCSTR name, bool destroy = false);
+	virtual void remove_attachment(LPCSTR name) { remove_child(name, true); }
+	virtual void remove_attachment(script_attachment* child);
+	virtual void iterate_attachments(::luabind::functor<bool> functor);
 
 private:
 	bool m_bCrPr_Activated;

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -280,7 +280,7 @@ bool CHUDManager::RenderCamAttachedUIQuery()
 	for (auto& pair : *g_actor->GetAttachments())
 	{
 		script_attachment* att = pair.second;
-		if (att->GetFFlags().test(eSA_CamAttached))
+		if (att->GetType() == eSA_CamAttached)
 			return true;
 	}
 	return false;
@@ -299,8 +299,8 @@ void CHUDManager::RenderCamAttachedUI()
 	for (auto& pair : *g_actor->GetAttachments())
 	{
 		script_attachment* att = pair.second;
-		if (att->GetFFlags().test(eSA_CamAttached))
-			att->RenderUI(false);
+		if (att->GetType() == eSA_CamAttached)
+			att->RenderUI();
 	}
 }
 

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -329,8 +329,8 @@ void attachable_hud_item::render()
 	{
 		for (auto& pair : *m_parent_hud_item->object().GetAttachments())
 		{
-			if (pair.second->GetFFlags().test(eSA_RenderHUD))
-				pair.second->Render(m_model, &m_item_transform, true);
+			if (pair.second->GetType() == eSA_HUD)
+				pair.second->Render(m_model, &m_item_transform);
 		}
 	}
 }
@@ -348,8 +348,8 @@ void attachable_hud_item::render_item_ui()
 	{
 		for (auto& pair : *m_parent_hud_item->object().GetAttachments())
 		{
-			if (pair.second->GetFFlags().test(eSA_RenderHUD))
-				pair.second->RenderUI(true);
+			if (pair.second->GetType() == eSA_HUD)
+				pair.second->RenderUI();
 		}
 	}
 }
@@ -900,15 +900,15 @@ void player_hud::render_item_ui()
 	if (m_attached_items[SCOPE_ATTACH_IDX])
 		m_attached_items[SCOPE_ATTACH_IDX]->render_item_ui();
 
+	UIRender->CacheSetCullMode(IUIRender::cmCCW);
+	UI().m_currentPointType = bk;
+
 	if (g_actor->GetAttachments()->size())
 	{
 		for (auto& pair : *g_actor->GetAttachments())
-			if (pair.second->GetFFlags().test(eSA_RenderHUD))
-				pair.second->RenderUI(true);
+			if (pair.second->GetType() == eSA_HUD)
+				pair.second->RenderUI();
 	}
-
-	UIRender->CacheSetCullMode(IUIRender::cmCCW);
-	UI().m_currentPointType = bk;
 }
 
 void player_hud::render_hud()
@@ -944,15 +944,15 @@ void player_hud::render_hud()
 		{
 			script_attachment* att = pair.second;
 
-			if (att->GetFFlags().test(eSA_RenderHUD))
+			if (att->GetType() == eSA_HUD)
 			{
 				// Left arm
 				if (att->GetParentBone() < 21)
-					att->Render(m_model_2->dcast_PKinematics(), &m_transform_2, true);
+					att->Render(m_model_2->dcast_PKinematics(), &m_transform_2);
 
 				// Right arm
 				else
-					att->Render(m_model->dcast_PKinematics(), &m_transform, true);
+					att->Render(m_model->dcast_PKinematics(), &m_transform);
 			}
 		}
 	}

--- a/src/xrGame/script_attachment_manager.cpp
+++ b/src/xrGame/script_attachment_manager.cpp
@@ -8,6 +8,10 @@
 script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 {
 	m_name = name;
+	m_model = nullptr;
+	m_kinematics = nullptr;
+	m_parent_attachment = nullptr;
+	m_parent_object = nullptr;
 	m_script_ui = nullptr;
 	m_script_ui_func = 0;
 	m_script_ui_mat = Fidentity;
@@ -25,7 +29,7 @@ script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 	m_scale.set(1, 1, 1);
 	m_bStopAtEndAnimIsRunning = false;
 	m_anim_end = 0;
-	m_flags.assign(eSA_RenderWorld);
+	m_type = eSA_World;
 	m_last_upd_frame = 0;
 	m_current_motion = "idle";
 	m_model_name = "";
@@ -42,7 +46,13 @@ script_attachment* script_attachment::AddAttachment(LPCSTR name, LPCSTR model_na
 	return att;
 }
 
-void script_attachment::Render(IKinematics* model, Fmatrix* mat, bool hud_mode)
+void script_attachment::RemoveAttachment(script_attachment* child)
+{
+	if (!child || child->m_parent_attachment != this) return;
+	RemoveAttachment(child->GetName());
+}
+
+void script_attachment::Render(IKinematics* model, Fmatrix* mat)
 {
 	if (!model || (m_bone_callbacks[0] && m_bone_callbacks[0]->m_bone_id != BI_NONE))
 		m_transform = *mat;
@@ -51,23 +61,25 @@ void script_attachment::Render(IKinematics* model, Fmatrix* mat, bool hud_mode)
 
 	m_transform.mulB_43(m_offset);
 
-	if (m_script_light && (hud_mode != !!m_flags.test(eSA_RenderWorld)))
+	if (m_script_light)
 	{
 		Fmatrix LM;
 		Fmatrix light_bone;
-		if (m_model->dcast_PKinematics()->LL_BoneCount() > m_script_light_bone)
-			light_bone = m_model->dcast_PKinematics()->LL_GetTransform(m_script_light_bone);
+		if (m_kinematics->LL_BoneCount() > m_script_light_bone)
+			light_bone = m_kinematics->LL_GetTransform(m_script_light_bone);
 		else
-			light_bone = m_model->dcast_PKinematics()->LL_GetTransform(m_model->dcast_PKinematics()->LL_GetBoneRoot());
+			light_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
 
 		LM.mul(m_transform, light_bone);
 		m_script_light->SetXFORM(LM);
 	}
 
 	if (m_model->dcast_PKinematicsAnimated())
+	{
 		m_model->dcast_PKinematicsAnimated()->UpdateTracks();
-	m_model->dcast_PKinematics()->CalculateBones_Invalidate();
-	m_model->dcast_PKinematics()->CalculateBones(TRUE);
+		m_kinematics->CalculateBones_Invalidate();
+		m_kinematics->CalculateBones(TRUE);
+	}
 
 	::Render->set_Transform(&m_transform);
 	::Render->add_Visual(m_model);
@@ -76,7 +88,7 @@ void script_attachment::Render(IKinematics* model, Fmatrix* mat, bool hud_mode)
 	{
 		for (auto& pair : m_children)
 		{
-			pair.second->Render(m_model->dcast_PKinematics(), &m_transform);
+			pair.second->Render(m_kinematics, &m_transform);
 		}
 	}
 }
@@ -97,18 +109,16 @@ void script_attachment::Update()
 
 	if (m_bone_callbacks.size())
 	{
-		xr_map<u16, script_attachment_bone_cb*>::iterator it = m_bone_callbacks.begin();
-		xr_map<u16, script_attachment_bone_cb*>::iterator it_e = m_bone_callbacks.end();
-		for (; it != it_e; ++it)
+		for (auto& pair : m_bone_callbacks)
 		{
-			script_attachment_bone_cb* cb = (*it).second;
+			script_attachment_bone_cb* cb = pair.second;
 			if (!cb) continue;
 			
 			if (cb->m_func)
 			{
 				cb->m_mat.set((*(cb->m_func))(
-					m_model->dcast_PKinematics()->LL_GetBoneInstance(cb->m_attachment_bone_id).mTransformHidden, //Transform without bone callback modifier
-					m_model->dcast_PKinematics()->LL_BoneName_dbg((*it).first)));
+					m_kinematics->LL_GetBoneInstance(cb->m_attachment_bone_id).mTransformHidden, //Transform without bone callback modifier
+					m_kinematics->LL_BoneName_dbg(pair.first)));
 
 				continue;
 			}
@@ -118,7 +128,7 @@ void script_attachment::Update()
 
 			if (m_parent_object)
 			{
-				if (GetFFlags().test(eSA_RenderHUD))
+				if (GetType() == eSA_HUD)
 				{
 					CHudItem* itm = smart_cast<CHudItem*>(m_parent_object);
 					if (itm)
@@ -155,10 +165,10 @@ void script_attachment::Update()
 
 			if (m_parent_attachment)
 			{
-				if (bone >= m_parent_attachment->m_model->dcast_PKinematics()->LL_BoneCount())
+				if (bone >= m_parent_attachment->m_kinematics->LL_BoneCount())
 					target = Fidentity;
 				else
-					target = m_parent_attachment->m_model->dcast_PKinematics()->LL_GetTransform(bone);
+					target = m_parent_attachment->m_kinematics->LL_GetTransform(bone);
 			}
 		}
 	}
@@ -172,46 +182,37 @@ void script_attachment::Update()
 	}
 }
 
-void script_attachment::RenderUI(bool hud_mode)
+void script_attachment::RenderUI()
 {
-	if (hud_mode || (!hud_mode && (m_flags.test(eSA_RenderWorld) || m_flags.test(eSA_CamAttached))))
+	if (m_script_ui)
 	{
-		if (m_script_ui)
-		{
-			IUIRender::ePointType bk;
+		IUIRender::ePointType bk;
 
-			if (!hud_mode)
-			{
-				bk = UI().m_currentPointType;
-				UI().m_currentPointType = IUIRender::pttLIT;
-				UIRender->CacheSetCullMode(IUIRender::cmNONE);
-			}
+		bk = UI().m_currentPointType;
+		UI().m_currentPointType = IUIRender::pttLIT;
+		UIRender->CacheSetCullMode(IUIRender::cmNONE);
 
-			Fmatrix LM;
-			Fmatrix ui_bone;
-			if (m_model->dcast_PKinematics()->LL_BoneCount() > m_script_ui_bone)
-				ui_bone = m_model->dcast_PKinematics()->LL_GetTransform(m_script_ui_bone);
-			else
-				ui_bone = m_model->dcast_PKinematics()->LL_GetTransform(m_model->dcast_PKinematics()->LL_GetBoneRoot());
+		Fmatrix LM;
+		Fmatrix ui_bone;
+		if (m_kinematics->LL_BoneCount() > m_script_ui_bone)
+			ui_bone = m_kinematics->LL_GetTransform(m_script_ui_bone);
+		else
+			ui_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
 
-			LM.mul(m_transform, ui_bone);
-			LM.mulB_43(m_script_ui_mat);
-			UIRender->CacheSetXformWorld(LM);
-			m_script_ui->Draw();
-
-			if (!hud_mode)
-			{
-				UIRender->CacheSetCullMode(IUIRender::cmCCW);
-				UI().m_currentPointType = bk;
-			}
-		}
+		LM.mul(m_transform, ui_bone);
+		LM.mulB_43(m_script_ui_mat);
+		UIRender->CacheSetXformWorld(LM);
+		m_script_ui->Draw();
+		
+		UIRender->CacheSetCullMode(IUIRender::cmCCW);
+		UI().m_currentPointType = bk;
 	}
 
 	if (m_children.size())
 	{
 		for (auto& pair : m_children)
 		{
-			pair.second->RenderUI(hud_mode);
+			pair.second->RenderUI();
 		}
 	}
 }
@@ -298,15 +299,15 @@ void script_attachment::SetParent(script_attachment* att)
 		if (m_parent_attachment == att)
 			return;
 
-		m_parent_attachment->RemoveChild(*m_name);
+		m_parent_attachment->RemoveChild(GetName());
 	}
 
 	if (m_parent_object)
-		m_parent_object->remove_attachment(*m_name);
+		m_parent_object->remove_child(GetName());
 
 	m_parent_object = nullptr;
 	m_parent_attachment = att;
-	m_parent_attachment->AddChild(*m_name, this);
+	m_parent_attachment->AddChild(GetName(), this);
 }
 
 void script_attachment::SetParent(CGameObject* obj)
@@ -315,20 +316,20 @@ void script_attachment::SetParent(CGameObject* obj)
 		return;
 
 	if (m_parent_attachment)
-		m_parent_attachment->RemoveChild(*m_name);
+		m_parent_attachment->RemoveChild(GetName());
 
 	if (m_parent_object)
 	{
 		if (m_parent_object == obj)
 			return;
 
-		m_parent_object->remove_attachment(*m_name);
+		m_parent_object->remove_child(GetName());
 	}
 		
 
 	m_parent_object = obj;
 	m_parent_attachment = nullptr;
-	m_parent_object->add_attachment(*m_name, this);
+	m_parent_object->add_attachment(GetName(), this);
 }
 
 void script_attachment::SetParent(CScriptGameObject* obj)
@@ -337,20 +338,20 @@ void script_attachment::SetParent(CScriptGameObject* obj)
 		return;
 
 	if (m_parent_attachment)
-		m_parent_attachment->RemoveChild(*m_name);
+		m_parent_attachment->RemoveChild(GetName());
 
 	if (m_parent_object)
 	{
 		if (m_parent_object == &obj->object())
 			return;
 
-		m_parent_object->remove_attachment(*m_name);
+		m_parent_object->remove_child(GetName());
 	}
 
 
 	m_parent_object = &obj->object();
 	m_parent_attachment = nullptr;
-	m_parent_object->add_attachment(*m_name, this);
+	m_parent_object->add_attachment(GetName(), this);
 }
 
 luabind::object script_attachment::GetParent()
@@ -415,19 +416,21 @@ Fmatrix& script_attachment::BoneTransform(IKinematics* model)
 
 u32 script_attachment::PlayMotion(LPCSTR name, bool mixin, float speed)
 {
-	if (!m_model->dcast_PKinematicsAnimated())
+	IKinematicsAnimated* k = m_model->dcast_PKinematicsAnimated();
+
+	if (!k)
 		return 0;
 
-	MotionID M2 = m_model->dcast_PKinematicsAnimated()->ID_Cycle_Safe(name);
+	MotionID M2 = k->ID_Cycle_Safe(name);
 	if (!M2.valid())
-		M2 = m_model->dcast_PKinematicsAnimated()->ID_Cycle_Safe("idle");
+		M2 = k->ID_Cycle_Safe("idle");
 
 	if (!M2.valid())
 		return 0;
 
-	u16 pc = m_model->dcast_PKinematicsAnimated()->partitions().count();
+	u16 pc = k->partitions().count();
 	for (u16 pid = 0; pid < pc; ++pid)
-		CBlend* B = m_model->dcast_PKinematicsAnimated()->PlayCycle(pid, M2, mixin, 0, 0, 0, speed);
+		CBlend* B = k->PlayCycle(pid, M2, mixin, 0, 0, 0, speed);
 
 	const CMotionDef* md;
 	u32 length = motion_length(M2, md, speed);
@@ -442,44 +445,129 @@ u32 script_attachment::PlayMotion(LPCSTR name, bool mixin, float speed)
 
 	m_current_motion = name;
 
-	m_model->dcast_PKinematicsAnimated()->UpdateTracks();
-	m_model->dcast_PKinematics()->CalculateBones_Invalidate();
-	m_model->dcast_PKinematics()->CalculateBones(true);
+	k->UpdateTracks();
+	m_kinematics->CalculateBones_Invalidate();
+	m_kinematics->CalculateBones(true);
 
 	return length;
 }
 
 u32 script_attachment::motion_length(const MotionID& M, const CMotionDef*& md, float speed)
 {
-	if (!m_model->dcast_PKinematicsAnimated())
+	IKinematicsAnimated* k = m_model->dcast_PKinematicsAnimated();
+
+	if (!k)
 		return 0;
 
-	md = m_model->dcast_PKinematicsAnimated()->LL_GetMotionDef(M);
+	md = k->LL_GetMotionDef(M);
 	VERIFY(md);
 	if (md->flags & esmStopAtEnd)
 	{
-		CMotion* motion = m_model->dcast_PKinematicsAnimated()->LL_GetRootMotion(M);
+		CMotion* motion = k->LL_GetRootMotion(M);
 		return iFloor(0.5f + 1000.f * motion->GetLength() / (md->Dequantize(md->speed) * speed));
 	}
 	return 0;
 }
 
-void script_attachment::SetBoneVisible(u16 bone_id, bool bVisibility)
+void script_attachment::SetBoneVisible(u16 bone_id, bool bVisibility, bool bRecursive)
 {
-	if (m_model->dcast_PKinematics()->LL_BoneCount() > bone_id)
+	if (m_kinematics->LL_BoneCount() > bone_id)
 	{
-		bool bVisibleNow = m_model->dcast_PKinematics()->LL_GetBoneVisible(bone_id);
+		bool bVisibleNow = m_kinematics->LL_GetBoneVisible(bone_id);
 		if (bVisibleNow != bVisibility)
-			m_model->dcast_PKinematics()->LL_SetBoneVisible(bone_id, bVisibility, TRUE);
+			m_kinematics->LL_SetBoneVisible(bone_id, bVisibility, TRUE);
 	}
 }
 
 bool script_attachment::GetBoneVisible(u16 bone_id)
 {
-	if (m_model->dcast_PKinematics()->LL_BoneCount() > bone_id)
-		return m_model->dcast_PKinematics()->LL_GetBoneVisible(bone_id);
+	if (m_kinematics->LL_BoneCount() > bone_id)
+		return m_kinematics->LL_GetBoneVisible(bone_id);
 
 	return false;
+}
+
+void script_attachment::SetParentBone(LPCSTR bone)
+{
+	if (m_parent_object)
+	{
+		m_parent_bone = m_parent_object->lua_game_object()->bone_id(bone, m_type == eSA_HUD);
+		return;
+	}
+
+	if (m_parent_attachment)
+	{
+		m_parent_bone = m_parent_attachment->bone_id(bone);
+		return;
+	}
+
+	m_parent_bone = 0;
+}
+
+u16 script_attachment::bone_id(LPCSTR bone_name)
+{
+	u16 bone_id = BI_NONE;
+	if (xr_strlen(bone_name))
+		bone_id = m_kinematics->LL_BoneID(bone_name);
+
+	return bone_id;
+}
+
+extern BOOL print_bone_warnings;
+
+Fmatrix script_attachment::bone_transform(u16 bone_id)
+{
+	if (bone_id == BI_NONE || bone_id >= m_kinematics->LL_BoneCount()) {
+		if (strstr(Core.Params, "-dbg") && print_bone_warnings) {
+			Msg("![bone_position] Incorrect bone_id provided for %s (%s), fallback to root bone", GetName(), GetModelScript());
+			ai().script_engine().print_stack();
+		}
+		bone_id = m_kinematics->LL_GetBoneRoot();
+	}
+
+	Fmatrix matrix;
+	matrix.mul_43(m_transform, m_kinematics->LL_GetTransform(bone_id));
+	return matrix;
+}
+
+Fvector script_attachment::bone_position(u16 bone_id)
+{
+	return bone_transform(bone_id).c;
+}
+
+Fvector script_attachment::bone_direction(u16 bone_id)
+{
+	Fmatrix matrix = bone_transform(bone_id);
+	Fvector res;
+	matrix.getHPB(res);
+	return res;
+}
+
+u16 script_attachment::bone_parent(u16 bone_id)
+{
+	if (bone_id == m_kinematics->LL_GetBoneRoot() || bone_id >= m_kinematics->LL_BoneCount()) return BI_NONE;
+
+	CBoneData* data = &m_kinematics->LL_GetData(bone_id);
+	u16 ParentID = data->GetParentID();
+	return ParentID;
+}
+
+LPCSTR script_attachment::bone_name(u16 bone_id)
+{
+	if (bone_id == BI_NONE) return "";
+	return (m_kinematics->LL_BoneName_dbg(bone_id));
+}
+
+// demonized: list all bones
+luabind::object script_attachment::list_bones()
+{
+	luabind::object result = luabind::newtable(ai().script_engine().lua());
+
+	auto bones = m_kinematics->list_bones();
+	for (const auto& bone : bones)
+		result[bone.first] = bone.second.c_str();
+
+	return result;
 }
 
 void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
@@ -489,29 +577,72 @@ void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
 
 	m_model_name = model_name;
 
-	u16 count_prev;
+	u16 count_prev = 0;
 
 	if (m_model)
 	{
-		count_prev = m_model->dcast_PKinematics()->LL_BoneCount();
+		count_prev = m_kinematics->LL_BoneCount();
 		::Render->model_Delete(m_model);
 	}
 	
 	m_model = ::Render->model_Create(*m_model_name);
 	R_ASSERT(m_model);
+	m_kinematics = m_model->dcast_PKinematics();
+	R_ASSERT(m_kinematics);
 
 	//Bone Callbacks
-	if (keep_bc && m_bone_callbacks.size() && count_prev <= m_model->dcast_PKinematics()->LL_BoneCount())
+	if (keep_bc && m_bone_callbacks.size() && count_prev <= m_kinematics->LL_BoneCount())
 	{
-		xr_map<u16, script_attachment_bone_cb*>::const_iterator it = m_bone_callbacks.cbegin();
-		xr_map<u16, script_attachment_bone_cb*>::const_iterator it_e = m_bone_callbacks.cend();
-		for (; it != it_e; ++it)
+		for (auto& pair : m_bone_callbacks)
 		{
-			m_model->dcast_PKinematics()->LL_GetBoneInstance((*it).first).set_callback(bctCustom, ScriptAttachmentBoneCallback, (*it).second, (*it).second->m_overwrite);
+			m_kinematics->LL_GetBoneInstance(pair.first).set_callback(bctCustom, ScriptAttachmentBoneCallback, pair.second, pair.second->m_overwrite);
 		}
 
 		PlayMotion(*m_current_motion, false);
 	}
+}
+
+void script_attachment::SetName(LPCSTR name)
+{
+	if (m_parent_object)
+	{
+		// Remove old instance from parent (without destroying it)
+		m_parent_object->remove_child(GetName(), false);
+
+		auto& pair = m_parent_object->GetAttachments()->find(name);
+		if (pair != m_parent_object->GetAttachments()->end())
+		{
+			// Attachment with name exists, replace it
+			xr_delete(pair->second);
+			pair->second = this;
+		}
+		else
+		{
+			// Attachment with name does not exist, add it
+			m_parent_object->add_attachment(name, this);
+		}
+	}
+
+	else if (m_parent_attachment)
+	{
+		// Remove old instance from parent (without destroying it)
+		m_parent_attachment->RemoveChild(GetName(), false);
+
+		auto& pair = m_parent_attachment->m_children.find(name);
+		if (pair != m_parent_attachment->m_children.end())
+		{
+			// Attachment with name exists, replace it
+			xr_delete(pair->second);
+			pair->second = this;
+		}
+		else
+		{
+			// Attachment with name does not exist, add it
+			m_parent_attachment->AddChild(name, this);
+		}
+	}
+
+	m_name = name;
 }
 
 void script_attachment::SetScriptUI(LPCSTR ui_func)
@@ -558,38 +689,43 @@ void script_attachment::ScriptAttachmentBoneCallback(CBoneInstance* B)
 	target = params->m_mat;
 }
 
-void script_attachment::SetBoneCallback(u16 bone_id, u16 parent_bone, bool overwrite)
+void script_attachment::SetBoneCallback(u16 bone_id, LPCSTR parent_bone, bool overwrite)
 {
-	if (m_model && m_model->dcast_PKinematics())
+	if (m_parent_object)
 	{
-		if (bone_id >= m_model->dcast_PKinematics()->LL_BoneCount())
-		{
-			Msg("![SetBoneCallback]: Attachment has no bone with id %i", bone_id);
-			return;
-		}
-
-		if (m_bone_callbacks[bone_id])
-		{
-			m_model->dcast_PKinematics()->LL_GetBoneInstance(bone_id).reset_callback();
-			m_bone_callbacks.erase(bone_id);
-		}
-
-		m_bone_callbacks[bone_id] = xr_new<script_attachment_bone_cb>(parent_bone, this, bone_id, overwrite);
-		m_model->dcast_PKinematics()->LL_GetBoneInstance(bone_id).set_callback(bctCustom, ScriptAttachmentBoneCallback, m_bone_callbacks[bone_id], overwrite);
-	}
-	else
-		Msg("![SetBoneCallback]: Attachment has no visual with bones");
-}
-
-void script_attachment::SetBoneCallback(u16 bone_id, const luabind::functor<Fmatrix>& func, bool overwrite)
-{
-	if (!(m_model && m_model->dcast_PKinematics()))
-	{
-		Msg("![SetBoneCallback]: Attachment has no visual with bones");
+		SetBoneCallback(bone_id, m_parent_object->lua_game_object()->bone_id(parent_bone, m_type == eSA_HUD), overwrite);
 		return;
 	}
 
-	if (bone_id >= m_model->dcast_PKinematics()->LL_BoneCount())
+	if (m_parent_attachment)
+	{
+		SetBoneCallback(bone_id, m_parent_attachment->bone_id(parent_bone), overwrite);
+		return;
+	}
+
+	Msg("![SetBoneCallback]: Parent has no bone with name %i", parent_bone);
+}
+
+void script_attachment::SetBoneCallback(LPCSTR bone, LPCSTR parent_bone, bool overwrite)
+{
+	if (m_parent_object)
+	{
+		SetBoneCallback(bone_id(bone), m_parent_object->lua_game_object()->bone_id(parent_bone, m_type == eSA_HUD), overwrite);
+		return;
+	}
+
+	if (m_parent_attachment)
+	{
+		SetBoneCallback(bone_id(bone), m_parent_attachment->bone_id(parent_bone), overwrite);
+		return;
+	}
+
+	Msg("![SetBoneCallback]: Parent has no bone with name %i", parent_bone);
+}
+
+void script_attachment::SetBoneCallback(u16 bone_id, u16 parent_bone, bool overwrite)
+{
+	if (bone_id >= m_kinematics->LL_BoneCount())
 	{
 		Msg("![SetBoneCallback]: Attachment has no bone with id %i", bone_id);
 		return;
@@ -597,37 +733,41 @@ void script_attachment::SetBoneCallback(u16 bone_id, const luabind::functor<Fmat
 
 	if (m_bone_callbacks[bone_id])
 	{
-		m_model->dcast_PKinematics()->LL_GetBoneInstance(bone_id).reset_callback();
+		m_kinematics->LL_GetBoneInstance(bone_id).reset_callback();
+		m_bone_callbacks.erase(bone_id);
+	}
+
+	m_bone_callbacks[bone_id] = xr_new<script_attachment_bone_cb>(parent_bone, this, bone_id, overwrite);
+	m_kinematics->LL_GetBoneInstance(bone_id).set_callback(bctCustom, ScriptAttachmentBoneCallback, m_bone_callbacks[bone_id], overwrite);
+}
+
+void script_attachment::SetBoneCallback(u16 bone_id, const luabind::functor<Fmatrix>& func, bool overwrite)
+{
+	if (bone_id >= m_kinematics->LL_BoneCount())
+	{
+		Msg("![SetBoneCallback]: Attachment has no bone with id %i", bone_id);
+		return;
+	}
+
+	if (m_bone_callbacks[bone_id])
+	{
+		m_kinematics->LL_GetBoneInstance(bone_id).reset_callback();
 		m_bone_callbacks.erase(bone_id);
 	}
 
 	m_bone_callbacks[bone_id] = xr_new<script_attachment_bone_cb>(func, this, bone_id, overwrite);
-	CBoneInstance& bInst = m_model->dcast_PKinematics()->LL_GetBoneInstance(bone_id);
+	CBoneInstance& bInst = m_kinematics->LL_GetBoneInstance(bone_id);
 	bInst.set_callback(bctCustom, ScriptAttachmentBoneCallback, m_bone_callbacks[bone_id], overwrite);
 	(m_bone_callbacks[bone_id]->m_mat).set(GetBoneVisible(bone_id) ? bInst.mTransformHidden : bInst.mTransform);
 }
 
 void script_attachment::RemoveBoneCallback(u16 bone_id)
 {
-	if (!(m_model && m_model->dcast_PKinematics()))
-		return;
-
 	if (m_bone_callbacks[bone_id])
 	{
-		m_model->dcast_PKinematics()->LL_GetBoneInstance(bone_id).reset_callback();
+		m_kinematics->LL_GetBoneInstance(bone_id).reset_callback();
 		m_bone_callbacks.erase(bone_id);
 	}
-}
-
-Fmatrix script_attachment::GetBoneMatrix(u16 bone_id)
-{
-	if (!(m_model && m_model->dcast_PKinematics()))
-		return Fidentity;
-
-	if (bone_id >= m_model->dcast_PKinematics()->LL_BoneCount())
-		return Fidentity;
-
-	return m_model->dcast_PKinematics()->LL_GetTransform(bone_id);
 }
 
 Fvector script_attachment::GetCenter()

--- a/src/xrGame/script_attachment_manager.h
+++ b/src/xrGame/script_attachment_manager.h
@@ -3,11 +3,12 @@
 #include "script_game_object.h"
 #include "script_light_inline.h"
 
-enum script_attachment_flags
+enum script_attachment_type
 {
-	eSA_RenderHUD = (1 << 0),
-	eSA_RenderWorld = (1 << 1),
+	eSA_HUD = (1 << 0),
+	eSA_World = (1 << 1),
 	eSA_CamAttached = (1 << 2),
+	eSA_undefined = (1 << 3)
 };
 
 struct script_attachment_bone_cb
@@ -20,8 +21,8 @@ struct script_attachment_bone_cb
 
 	script_attachment_bone_cb(const ::luabind::functor<Fmatrix>& func, script_attachment* att, u16 id, bool overwrite)
 	{
-		m_attachment = att;
 		m_attachment_bone_id = id;
+		m_attachment = att;
 		m_func = xr_new<::luabind::functor<Fmatrix>>(func);
 		m_mat = Fidentity;
 		m_bone_id = BI_NONE;
@@ -50,6 +51,7 @@ private:
 	Fvector m_position, m_rotation, m_scale, m_origin;
 
 	IRenderVisual* m_model;
+	IKinematics* m_kinematics;
 	shared_str m_model_name;
 	shared_str m_current_motion;
 	u16 m_parent_bone;
@@ -66,7 +68,7 @@ private:
 	bool m_bStopAtEndAnimIsRunning;
 	u32 m_anim_end;
 
-	Flags32 m_flags;
+	u16 m_type;
 	script_attachment* m_parent_attachment;
 	CGameObject* m_parent_object;
 	xr_map<shared_str, script_attachment*> m_children;
@@ -84,14 +86,15 @@ public:
 		delete_data(m_bone_callbacks);
 	}
 
-	void Render(IKinematics* model, Fmatrix* mat, bool hud_mode = false);
+	void Render(IKinematics* model, Fmatrix* mat);
 	void Update();
-	void RenderUI(bool hud_mode = false);
+	void RenderUI();
 
 	void AttachLight(AttachmentScriptLight* light);
 	AttachmentScriptLight* DetachLight();
 	AttachmentScriptLight* GetLight();
 	void SetScriptLightBone(u16 bone) { m_script_light_bone = bone; }
+	void SetScriptLightBone(LPCSTR bone) { m_script_light_bone = bone_id(bone); }
 	u16 GetScriptLightBone() { return m_script_light_bone; }
 
 	void RecalcOffset();
@@ -119,10 +122,14 @@ public:
 	::luabind::object GetParent();
 
 	void SetParentBone(u16 bone_id) { m_parent_bone = bone_id; }
+	void SetParentBone(LPCSTR bone);
 	u16 GetParentBone() { return m_parent_bone; }
 
 	void LoadModel(LPCSTR model_name, bool keep_bc = false);
 	LPCSTR GetModelScript() { return *m_model_name; }
+
+	void SetName(LPCSTR name);
+	LPCSTR GetName() { return *m_name; }
 
 	void SetScriptUI(LPCSTR ui_func);
 	LPCSTR GetScriptUI() { return m_script_ui_func; }
@@ -133,32 +140,58 @@ public:
 	void SetScriptUIRotation(float x, float y, float z) { SetScriptUIRotation(Fvector().set(x, y, z)); }
 	Fvector GetScriptUIRotation() { return m_script_ui_offset[1]; }
 	void SetScriptUIBone(u16 bone) { m_script_ui_bone = bone; }
+	void SetScriptUIBone(LPCSTR bone) { m_script_ui_bone = bone_id(bone); }
 	u16 GetScriptUIBone() { return m_script_ui_bone; }
 
 	script_attachment* AddAttachment(LPCSTR name, LPCSTR model_name);
 	void RemoveAttachment(LPCSTR name) { RemoveChild(name, true); }
+	void RemoveAttachment(script_attachment* child);
 	script_attachment* AddChild(LPCSTR name, script_attachment* att);
 	script_attachment* GetChild(LPCSTR name);
 	void RemoveChild(LPCSTR name, bool destroy = false);
 	void IterateAttachments(::luabind::functor<bool> functor);
 
-	void SetFlags(u32 flags) { m_flags.assign(flags); }
-	u32 GetFlags() { return m_flags.get(); }
-	const Flags32& GetFFlags() { return m_flags; }
+	void SetType(u16 type) { m_type = type < eSA_undefined ? type : eSA_World; }
+	u16 GetType() { return m_type; }
 
 	u32 PlayMotion(LPCSTR name, bool mixin = true, float speed = 1.f);
 	u32 motion_length(const MotionID& M, const CMotionDef*& md, float speed);
+	
+	u16 bone_id(LPCSTR bone_name);
+	LPCSTR bone_name(u16 bone_id);
 
-	void SetBoneVisible(u16 bone_id, bool bVisibility);
 	bool GetBoneVisible(u16 bone_id);
+	bool GetBoneVisible(LPCSTR bone_name) { return GetBoneVisible(bone_id(bone_name)); }
+
+	void SetBoneVisible(u16 bone_id, bool bVisibility, bool bRecursive = true);
+	void SetBoneVisible(LPCSTR bone_name, bool bVisibility, bool bRecursive = true) { SetBoneVisible(bone_id(bone_name), bVisibility, bRecursive); }
+
+	Fmatrix bone_transform(u16 bone_id);
+	Fmatrix bone_transform(LPCSTR bone_name) { return bone_transform(bone_id(bone_name)); }
+
+	Fvector bone_position(u16 bone_id);
+	Fvector bone_position(LPCSTR bone_name) { return bone_position(bone_id(bone_name)); }
+
+	Fvector bone_direction(u16 bone_id);
+	Fvector bone_direction(LPCSTR bone_name) { return bone_direction(bone_id(bone_name)); }
+
+	u16 bone_parent(u16 bone_id);
+	u16 bone_parent(LPCSTR bone_name) { return bone_parent(bone_id(bone_name)); }
+
+	::luabind::object list_bones();
+	
 	Fmatrix& BoneTransform(IKinematics* model);
 
 	static void _BCL ScriptAttachmentBoneCallback(CBoneInstance* B);
 	void SetBoneCallback(u16 bone_id, u16 parent_bone, bool overwrite = false);
+	void SetBoneCallback(LPCSTR bone, LPCSTR parent_bone, bool overwrite = false);
+	void SetBoneCallback(u16 bone, LPCSTR parent_bone, bool overwrite = false);
+	void SetBoneCallback(LPCSTR bone, u16 parent_bone, bool overwrite = false) { SetBoneCallback(bone_id(bone), parent_bone, overwrite); }
 	void SetBoneCallback(u16 bone_id, const ::luabind::functor<Fmatrix>& func, bool overwrite = false);
+	void SetBoneCallback(LPCSTR bone, const ::luabind::functor<Fmatrix>& func, bool overwrite = false) { SetBoneCallback(bone_id(bone), func, overwrite); }
 	void RemoveBoneCallback(u16 bone_id);
+	void RemoveBoneCallback(LPCSTR bone) { RemoveBoneCallback(bone_id(bone)); }
 
-	Fmatrix GetBoneMatrix(u16 bone_id);
 	Fmatrix GetTransform() { return m_transform; };
 	Fvector GetCenter();
 

--- a/src/xrGame/script_attachment_manager.h
+++ b/src/xrGame/script_attachment_manager.h
@@ -5,10 +5,10 @@
 
 enum script_attachment_type
 {
-	eSA_HUD = (1 << 0),
-	eSA_World = (1 << 1),
-	eSA_CamAttached = (1 << 2),
-	eSA_undefined = (1 << 3)
+	eSA_HUD = 0,
+	eSA_World,
+	eSA_CamAttached,
+	eSA_undefined
 };
 
 struct script_attachment_bone_cb

--- a/src/xrGame/script_attachment_script.cpp
+++ b/src/xrGame/script_attachment_script.cpp
@@ -9,11 +9,30 @@ void script_attachment::script_register(lua_State* L)
 {
 	module(L)
 	[
+		//Type
+		class_<enum_exporter<script_attachment_type>>("script_attachment_type")
+		.enum_("script_attachment_type")
+		[
+			value("Hud", (int)eSA_HUD),
+			value("World", (int)eSA_World),
+			value("CamAttached", (int)eSA_CamAttached)
+		],
+
 		class_<script_attachment>("ScriptAttachment")
 
+		//Parent
 		.def("set_parent", (void (script_attachment::*)(script_attachment*)) &script_attachment::SetParent)
 		.def("set_parent", (void (script_attachment::*)(CScriptGameObject*)) &script_attachment::SetParent)
 		.def("get_parent", &script_attachment::GetParent)
+
+		//Child
+		.def("add_attachment", &script_attachment::AddAttachment)
+		.def("get_attachment", &script_attachment::GetChild)
+		.def("remove_attachment", (void (script_attachment::*)(LPCSTR)) &script_attachment::RemoveAttachment)
+		.def("remove_attachment", (void (script_attachment::*)(script_attachment*)) &script_attachment::RemoveAttachment)
+		.def("iterate_attachments", &script_attachment::IterateAttachments)
+
+		//Offset
 		.def("set_position", (void (script_attachment::*)(Fvector)) &script_attachment::SetPosition)
 		.def("set_position", (void (script_attachment::*)(float, float, float)) &script_attachment::SetPosition)
 		.def("get_position", &script_attachment::GetPosition)
@@ -23,26 +42,57 @@ void script_attachment::script_register(lua_State* L)
 		.def("set_origin", (void (script_attachment::*)(Fvector)) &script_attachment::SetOrigin)
 		.def("set_origin", (void (script_attachment::*)(float, float, float)) &script_attachment::SetOrigin)
 		.def("get_origin", &script_attachment::GetOrigin)
-		.def("set_bone_visible", &script_attachment::SetBoneVisible)
-		.def("get_bone_visible", &script_attachment::GetBoneVisible)
-		.def("set_parent_bone", &script_attachment::SetParentBone)
-		.def("get_parent_bone", &script_attachment::GetParentBone)
-		.def("set_scale", (void (script_attachment::*)(Fvector)) & script_attachment::SetScale)
-		.def("set_scale", (void (script_attachment::*)(float, float, float)) & script_attachment::SetScale)
-		.def("set_scale", (void (script_attachment::*)(float)) & script_attachment::SetScale)
+		.def("set_scale", (void (script_attachment::*)(Fvector)) &script_attachment::SetScale)
+		.def("set_scale", (void (script_attachment::*)(float, float, float)) &script_attachment::SetScale)
+		.def("set_scale", (void (script_attachment::*)(float)) &script_attachment::SetScale)
 		.def("get_scale", &script_attachment::GetScale)
-		.def("set_flags", &script_attachment::SetFlags)
-		.def("get_flags", &script_attachment::GetFlags)
-		.def("play_motion", &script_attachment::PlayMotion)
-		.def("add_attachment", &script_attachment::AddAttachment)
-		.def("get_attachment", &script_attachment::GetChild)
-		.def("remove_attachment", &script_attachment::RemoveAttachment)
-		.def("iterate_attachments", &script_attachment::IterateAttachments)
+		.def("get_transform", &script_attachment::GetTransform)
+		.def("get_center", &script_attachment::GetCenter)
+
+		//Bones
+		.def("bone_id", &script_attachment::bone_id)
+		.def("bone_name", &script_attachment::bone_name)
+		.def("bone_visible", (bool (script_attachment::*)(u16)) &script_attachment::GetBoneVisible)
+		.def("bone_visible", (bool (script_attachment::*)(LPCSTR)) &script_attachment::GetBoneVisible)
+		.def("set_bone_visible", (void (script_attachment::*)(u16, bool, bool)) &script_attachment::SetBoneVisible)
+		.def("set_bone_visible", (void (script_attachment::*)(LPCSTR, bool, bool)) &script_attachment::SetBoneVisible)
+		.def("bone_transform", (Fmatrix (script_attachment::*)(u16)) &script_attachment::bone_transform)
+		.def("bone_transform", (Fmatrix (script_attachment::*)(LPCSTR)) &script_attachment::bone_transform)
+		.def("bone_position", (Fvector (script_attachment::*)(u16)) &script_attachment::bone_position)
+		.def("bone_position", (Fvector (script_attachment::*)(LPCSTR)) &script_attachment::bone_position)
+		.def("bone_direction", (Fvector (script_attachment::*)(u16)) &script_attachment::bone_direction)
+		.def("bone_direction", (Fvector (script_attachment::*)(LPCSTR)) &script_attachment::bone_direction)
+		.def("bone_parent", (u16 (script_attachment::*)(u16)) &script_attachment::bone_parent)
+		.def("bone_parent", (u16 (script_attachment::*)(LPCSTR)) &script_attachment::bone_parent)
+		.def("set_parent_bone", (void (script_attachment::*)(u16)) &script_attachment::SetParentBone)
+		.def("set_parent_bone", (void (script_attachment::*)(LPCSTR)) &script_attachment::SetParentBone)
+		.def("get_parent_bone", &script_attachment::GetParentBone)
+		.def("list_bones", &script_attachment::list_bones)
+
+		//Bone Callbacks
+		.def("bone_callback", (void (script_attachment::*)(u16, u16, bool)) &script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(LPCSTR, LPCSTR, bool)) &script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(u16, LPCSTR, bool)) &script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(LPCSTR, u16, bool)) &script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(u16, const ::luabind::functor<Fmatrix>&, bool)) & script_attachment::SetBoneCallback)
+		.def("bone_callback", (void (script_attachment::*)(LPCSTR, const ::luabind::functor<Fmatrix>&, bool)) & script_attachment::SetBoneCallback)
+		.def("remove_bone_callback", (void (script_attachment::*)(u16)) &script_attachment::RemoveBoneCallback)
+		.def("remove_bone_callback", (void (script_attachment::*)(LPCSTR)) &script_attachment::RemoveBoneCallback)
+
+		//Other
+		.def("set_type", &script_attachment::SetType)
+		.def("get_type", &script_attachment::GetType)
 		.def("set_model", &script_attachment::LoadModel)
 		.def("get_model", &script_attachment::GetModelScript)
+		.def("set_name", &script_attachment::SetName)
+		.def("get_name", &script_attachment::GetName)
+		.def("play_motion", &script_attachment::PlayMotion)
+		
+		//Script 3D UI
 		.def("set_ui", &script_attachment::SetScriptUI)
 		.def("get_ui", &script_attachment::GetScriptUI)
-		.def("set_ui_bone", &script_attachment::SetScriptUIBone)
+		.def("set_ui_bone", (void (script_attachment::*)(u16)) &script_attachment::SetScriptUIBone)
+		.def("set_ui_bone", (void (script_attachment::*)(LPCSTR)) &script_attachment::SetScriptUIBone)
 		.def("get_ui_bone", &script_attachment::GetScriptUIBone)
 		.def("set_ui_position", (void (script_attachment::*)(Fvector)) &script_attachment::SetScriptUIPosition)
 		.def("set_ui_position", (void (script_attachment::*)(float, float, float)) &script_attachment::SetScriptUIPosition)
@@ -50,17 +100,16 @@ void script_attachment::script_register(lua_State* L)
 		.def("set_ui_rotation", (void (script_attachment::*)(Fvector)) &script_attachment::SetScriptUIRotation)
 		.def("set_ui_rotation", (void (script_attachment::*)(float, float, float)) &script_attachment::SetScriptUIRotation)
 		.def("get_ui_rotation", &script_attachment::GetScriptUIRotation)
+
+		//Script Light
 		.def("attach_light", &script_attachment::AttachLight)
 		.def("detach_light", &script_attachment::DetachLight)
 		.def("get_light", &script_attachment::GetLight)
-		.def("set_light_bone", &script_attachment::SetScriptLightBone)
+		.def("set_light_bone", (void (script_attachment::*)(u16)) &script_attachment::SetScriptLightBone)
+		.def("set_light_bone", (void (script_attachment::*)(LPCSTR)) &script_attachment::SetScriptLightBone)
 		.def("get_light_bone", &script_attachment::GetScriptLightBone)
-		.def("remove_bone_callback", &script_attachment::RemoveBoneCallback)
-		.def("get_bone_matrix", &script_attachment::GetBoneMatrix)
-		.def("get_transform", &script_attachment::GetTransform)
-		.def("get_center", &script_attachment::GetCenter)
-		.def("bone_callback", (void (script_attachment::*)(u16,u16,bool)) &script_attachment::SetBoneCallback)
-		.def("bone_callback", (void (script_attachment::*)(u16, const ::luabind::functor<Fmatrix>&,bool)) &script_attachment::SetBoneCallback)
+
+		//Shader and Texture
 		.def("get_shaders", &script_attachment::GetShaders)
 		.def("get_default_shaders", &script_attachment::GetDefaultShaders)
 		.def("set_shader", &script_attachment::SetShaderTexture)

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -1076,17 +1076,17 @@ script_attachment* CScriptGameObject::GetAttachment(LPCSTR name)
 
 void CScriptGameObject::RemoveAttachment(LPCSTR name)
 {
-	object().remove_attachment(name, true);
+	object().remove_attachment(name);
+}
+
+void CScriptGameObject::RemoveAttachment(script_attachment* child)
+{
+	object().remove_attachment(child);
 }
 
 void CScriptGameObject::IterateAttachments(::luabind::functor<bool> functor)
 {
-	if (!object().GetAttachments()->size())
-		return;
-
-	for (auto& pair : *object().GetAttachments())
-		if (functor(pair.first.c_str(), pair.second) == true)
-			return;
+	object().iterate_attachments(functor);
 }
 
 CGameObject& CScriptGameObject::object() const

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1137,6 +1137,7 @@ public:
 	script_attachment* AddAttachment(LPCSTR name, LPCSTR model_name);
 	script_attachment* GetAttachment(LPCSTR name);
 	void RemoveAttachment(LPCSTR name);
+	void RemoveAttachment(script_attachment* child);
 	void IterateAttachments(::luabind::functor<bool> functor);
 
 	doors::door* m_door;

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -641,7 +641,8 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		// Lucy: Script Attachments
 		.def("add_attachment", &CScriptGameObject::AddAttachment)
 		.def("get_attachment", &CScriptGameObject::GetAttachment)
-		.def("remove_attachment", &CScriptGameObject::RemoveAttachment)
+		.def("remove_attachment", (void (CScriptGameObject::*)(LPCSTR)) &CScriptGameObject::RemoveAttachment)
+		.def("remove_attachment", (void (CScriptGameObject::*)(script_attachment*)) &CScriptGameObject::RemoveAttachment)
 		.def("iterate_attachments", &CScriptGameObject::IterateAttachments)
 
 		.def("get_shaders", &CScriptGameObject::GetShaders)


### PR DESCRIPTION
- Some improvements to code quality
- Bone functions are similar to those of game_objects (can use both IDs and names)
- remove_attachment() now accepts script_attachment objects
- Removed get_bone_matrix() in favor of bone_transform()
- Added set_name() and get_name() to get/set script_attachment names after they were attached to something
- Attachments now use a type instead of multiple flags (eg. only render in the world or hud, not both at once)
- Replaced get_flags() and set_flags() with get_type() and set_type()
- Exported attachment types enum to lua (ex. script_attachment_type.Hud)
- Reflected changes in lua_bind_ex and added a link to modding book script attachments guide