### PR TITLE
Export color animation functions & implemented RemoveColorAnimation

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -134,6 +134,11 @@
         CUIStatic GetProgressStatic()
     }
 
+    class CUIStatic {
+    	void SetColorAnimation(string name, number flags, float delay)
+		void ResetColorAnimation()
+		void RemoveColorAnimation()
+
     // Debug shapes
     enum DebugRenderType {
         line,

--- a/src/xrGame/ui/UILanimController.h
+++ b/src/xrGame/ui/UILanimController.h
@@ -61,6 +61,16 @@ public:
 		R_ASSERT((m_lanim_clr.m_lanim==NULL) || m_lanim_clr.m_lanimFlags.test(LA_TEXTCOLOR|LA_TEXTURECOLOR));
 	}
 
+	virtual void RemoveColorAnimation()
+	{
+		m_lanim_clr.m_lanim = nullptr;
+		m_lanim_clr.m_lanim_start_time = -1.0f;
+		m_lanim_clr.m_lanim_delay_time = 0.0f;
+		m_lanim_clr.m_lanimFlags.zero();
+		// Reset texture color
+		ColorAnimationSetTextureColor(color_rgba(255, 255, 255, 255), false);
+	}
+
 	virtual void ResetColorAnimation()
 	{
 		m_lanim_clr.m_lanim_start_time = Device.dwTimeContinual / 1000.0f + m_lanim_clr.m_lanim_delay_time / 1000.0f;
@@ -91,8 +101,7 @@ public:
 		if (t < m_lanim_clr.m_lanim_start_time) // consider animation delay
 			return;
 
-		if (m_lanim_clr.m_lanimFlags.test(LA_CYCLIC) || t - m_lanim_clr.m_lanim_start_time < m_lanim_clr
-		                                                                                     .m_lanim->Length_sec())
+		if (m_lanim_clr.m_lanimFlags.test(LA_CYCLIC) || t - m_lanim_clr.m_lanim_start_time < m_lanim_clr.m_lanim->Length_sec())
 		{
 			int frame;
 			u32 clr = m_lanim_clr.m_lanim->CalculateRGB(t - m_lanim_clr.m_lanim_start_time, frame);

--- a/src/xrGame/ui/UIStatic_script.cpp
+++ b/src/xrGame/ui/UIStatic_script.cpp
@@ -37,6 +37,9 @@ void CUIStatic::script_register(lua_State* L)
 		.def("SetHeading", &CUIStatic::SetHeading)
 		.def("SetConstHeading", &CUIStatic::SetConstHeading)
 		.def("GetConstHeading", &CUIStatic::GetConstHeading)
+		.def("SetColorAnimation", &CUIStatic::SetColorAnimation)
+		.def("ResetColorAnimation", &CUIStatic::ResetColorAnimation)
+		.def("RemoveColorAnimation", &CUIStatic::RemoveColorAnimation)
 		,
 
 		class_<CUITextWnd, CUIWindow>("CUITextWnd")


### PR DESCRIPTION
Hello,

In this PR, I added new script exports for :
- `CUIStatic::SetColorAnimation`
- `CUIStatic::ResetColorAnimation`
- `CUIStatic::RemoveColorAnimation`

`CUIStatic::RemoveColorAnimation` is a new method that unsets color animation variables, and sets the texture color to white.