### PR TITLE
Fix black default crosshair

### DIFF
--- a/gamedata/scripts/options_builder.script
+++ b/gamedata/scripts/options_builder.script
@@ -127,17 +127,6 @@ end
 function crosshair_color(args)
 	return
 		track {
-			id = args.id .. "_a",
-			hint = "modded_exes_color_a",
-			min = 0,
-			max = 255,
-			def = 255,
-			step = 1,
-			curr = {curr_crosshair_clr, args.id, "a"},
-			functor = {func_crosshair_clr, args.id, "a"},
-			cmd = false
-		},
-		track {
 			id = args.id .. "_r",
 			hint = "modded_exes_color_r",
 			min = 0,
@@ -168,6 +157,17 @@ function crosshair_color(args)
 			step = 1,
 			curr = {curr_crosshair_clr, args.id, "b"},
 			functor = {func_crosshair_clr, args.id, "b"},
+			cmd = false
+		},
+		track {
+			id = args.id .. "_a",
+			hint = "modded_exes_color_a",
+			min = 0,
+			max = 255,
+			def = 255,
+			step = 1,
+			curr = {curr_crosshair_clr, args.id, "a"},
+			functor = {func_crosshair_clr, args.id, "a"},
 			cmd = false
 		}
 end

--- a/src/xrEngine/xr_ioc_cmd.h
+++ b/src/xrEngine/xr_ioc_cmd.h
@@ -562,7 +562,14 @@ private:
 
 public:
 	CCC_Color(LPCSTR N, u32* v) :
-		CCC_IVector4(N, &temp, Ivector4().set(0, 0, 0, 0), Ivector4().set(255, 255, 255, 255)) {
+		temp(Ivector4().set(
+			color_get_R(*v),
+			color_get_G(*v),
+			color_get_B(*v),
+			color_get_A(*v)
+		)),
+		CCC_IVector4(N, &temp, Ivector4().set(0, 0, 0, 0), Ivector4().set(255, 255, 255, 255))
+	{
 		color = v;
 	};
 

--- a/src/xrGame/HUDCrosshair.cpp
+++ b/src/xrGame/HUDCrosshair.cpp
@@ -17,6 +17,8 @@ float crosshair_far_size = 1.f;
 float crosshair_depth_begin = 0.f;
 float crosshair_depth_end = 100.f;
 
+u32 C_CROSS D3DCOLOR_RGBA(0xff, 0xff, 0xff, 0xff);
+
 CHUDCrosshair::CHUDCrosshair()
 {
 	crosshairShader = NULL;
@@ -26,7 +28,7 @@ CHUDCrosshair::CHUDCrosshair()
 	transform = Fmatrix().identity();
 	minRadius = 0.001f;
 	maxRadius = 0.004f;
-	crossColor = 0;
+	crossColor = C_CROSS;
 	dispersionRadius = 0.f;
 }
 

--- a/src/xrGame/HUDCrosshair.h
+++ b/src/xrGame/HUDCrosshair.h
@@ -8,7 +8,6 @@
 
 #include "ui_defs.h"
 
-
 class CHUDCrosshair
 {
 private:


### PR DESCRIPTION
Ensures crosshair color settings are initialized correctly on first boot, and reorders applicable color controls from ARGB to the more intuitive RGBA.