### PR TITLE
Implement `SetHudMode` on `CScriptParticles` and `CParticlesObject`

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -138,6 +138,11 @@
     	void SetColorAnimation(string name, number flags, float delay)
 		void ResetColorAnimation()
 		void RemoveColorAnimation()
+    }
+
+    class particles_object {
+        void set_hud_mode(bool hud_mode)
+    }
 
     // Debug shapes
     enum DebugRenderType {

--- a/src/xrGame/ParticlesObject.cpp
+++ b/src/xrGame/ParticlesObject.cpp
@@ -72,7 +72,6 @@ void CParticlesObject::Init(LPCSTR p_name, IRender_Sector* S, BOOL bAutoRemove)
 	mt_dt = 0;
 }
 
-//----------------------------------------------------
 CParticlesObject::~CParticlesObject()
 {
 	VERIFY(0==mt_dt);
@@ -123,7 +122,6 @@ const shared_str CParticlesObject::Name()
 	return (V) ? V->Name() : "";
 }
 
-//----------------------------------------------------
 void CParticlesObject::Play(bool bHudMode)
 {
 	if (g_dedicated_server) return;
@@ -288,6 +286,15 @@ void CParticlesObject::SetAutoRemove(bool auto_remove)
 {
 	VERIFY(m_bStopping || !IsLooped());
 	m_bAutoRemove = auto_remove;
+}
+
+void CParticlesObject::SetHudMode(bool bHudMode)
+{
+	if (g_dedicated_server) return;
+
+	IParticleCustom* V = smart_cast<IParticleCustom*>(renderable.visual);
+	VERIFY(V);
+	V->SetHudMode(bHudMode);
 }
 
 //играются ли партиклы, отличается от PSI_Alive, тем что после

--- a/src/xrGame/ParticlesObject.h
+++ b/src/xrGame/ParticlesObject.h
@@ -47,6 +47,7 @@ public:
 	bool IsAutoRemove();
 	bool IsPlaying();
 	void SetAutoRemove(bool auto_remove);
+	void SetHudMode(bool bHudMode);
 
 	const shared_str Name();
 public:

--- a/src/xrGame/script_particles.cpp
+++ b/src/xrGame/script_particles.cpp
@@ -13,25 +13,13 @@
 CScriptParticlesCustom::CScriptParticlesCustom(CScriptParticles* owner, LPCSTR caParticlesName): CParticlesObject(
 	caParticlesName,FALSE, true)
 {
-	//	CScriptParticlesCustom* self = this;
-	//	Msg							("CScriptParticlesCustom: 0x%08x",*(int*)&self);
 	m_owner = owner;
 	m_animator = 0;
 }
 
-//XRCORE_API		fastdelegate::FastDelegate< void () >	g_verify_stalkers;
-
 CScriptParticlesCustom::~CScriptParticlesCustom()
 {
-	//	CScriptParticlesCustom* self = this;
-	//	Msg							("~CScriptParticlesCustom: 0x%08x",*(int*)&self);
-	//	if ( g_verify_stalkers )
-	//		g_verify_stalkers		();
-
 	xr_delete(m_animator);
-
-	//	if ( g_verify_stalkers )
-	//		g_verify_stalkers		();
 }
 
 void CScriptParticlesCustom::PSI_internal_delete()
@@ -143,10 +131,6 @@ void CScriptParticles::StopDeffered()
 
 void CScriptParticles::MoveTo(const Fvector& pos, const Fvector& vel)
 {
-	//VERIFY						(m_particles);
-	//Fmatrix						XF;
-	//XF.translate				(pos);
-	//m_particles->UpdateParent	(XF,vel);
 	VERIFY(m_particles);
 	m_transform.translate_over(pos);
 	m_particles->UpdateParent(m_transform, vel);
@@ -177,6 +161,11 @@ void CScriptParticles::SetOrientation(float yaw, float pitch, float roll)
 	matrix.translate_over(m_transform.c);
 	m_transform.set(matrix);
 	m_particles->UpdateParent(matrix, zero_vel);
+}
+
+void CScriptParticles::SetHudMode(bool bHudMode)
+{
+	m_particles->SetHudMode(bHudMode);
 }
 
 bool CScriptParticles::IsPlaying() const

--- a/src/xrGame/script_particles.h
+++ b/src/xrGame/script_particles.h
@@ -54,6 +54,7 @@ public:
 	void XFORMMoveTo(const Fvector & pos);
 	void SetDirection(const Fvector& dir);
 	void SetOrientation(float yaw, float pitch, float roll);
+	void SetHudMode(bool bHudMode);
 	Fvector LastPosition() const { return m_transform.c; }
 	void LoadPath(LPCSTR caPathName);
 	void StartPath(bool looped);

--- a/src/xrGame/script_particles_script.cpp
+++ b/src/xrGame/script_particles_script.cpp
@@ -30,6 +30,7 @@ void CScriptParticles::script_register(lua_State* L)
 		.def("set_position", &CScriptParticles::XFORMMoveTo)
 		.def("set_direction", &CScriptParticles::SetDirection)
 		.def("set_orientation", &CScriptParticles::SetOrientation)
+		.def("set_hud_mode", &CScriptParticles::SetHudMode)
 
 		.def("last_position", &CScriptParticles::LastPosition)
 		.def("load_path", &CScriptParticles::LoadPath)


### PR DESCRIPTION
As simple as the name suggests.

When playing a particle object, we have the option to set HUD mode. Problem is, once the particle is playing, there wasn't really a way to make the switch. Stopping and playing again would create weird behaviors.

Turns out, in-engine, HUD mode is just a flag. So I created a function to transit HUD mode to the internals of the particle system, and the flag is picked-up dynamically, without the need to do much of anything else.

Obviously :
- If one plays a `particles_object` with HUD mode `false`;
- Sets HUD mode `true` using the new function;
- Then, a new position in HUD space has to be provided using `particles_object::move_to`.

Ideally, HUD mode would have been an argument of `particles_object::move_to`, but I wasn't sure how to make it and not break backward compatibility. I'm open to change my code if someone thinks this is possible, and is willing to give directions.

Right now, it is to be used like this :
```lua
-- Initialize the particle object
local pfx = particles_object([[damage_fx\burn_creatures]])

-- Play it in world mode and move it to a world position
pfx:play(false)
pfx:move_to(db.actor:bone_position(0, false), VEC_ZERO)

-- Set HUD mode enabled and move it to a HUD position
pfx:set_hud_mode(true)
pfx:move_to(db.actor:bone_position(0, true), VEC_ZERO)
```

Unrelated, but I also took the liberty to remove dead code, because god I hate dead code.