### PR TITLE
Exported `_keyboard`'s `key_name` and `key_local_name` to Lua

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -86,6 +86,7 @@
     }
 
     globals {
+        string dik_to_keyname(number dik, boolean localize)
         int get_modded_exes_version() // Returns modded exes version in integer format
         table get_string_table() // Returns all translated strings in [string id] = string text format 
     }

--- a/src/xrGame/key_binding_registrator_script.cpp
+++ b/src/xrGame/key_binding_registrator_script.cpp
@@ -21,6 +21,7 @@ void key_binding_registrator::script_register(lua_State* L)
 {
 	module(L)
 	[
+		def("dik_to_keyname", &dik_to_keyname),
 		def("dik_to_bind", &dik_to_bind),
 		def("bind_to_dik", &get_action_dik),
 		def("key_state", &key_state),

--- a/src/xrGame/xr_level_controller.cpp
+++ b/src/xrGame/xr_level_controller.cpp
@@ -269,11 +269,14 @@ _action* action_name_to_ptr(LPCSTR _name)
 	return NULL;
 }
 
-LPCSTR dik_to_keyname(int _dik)
+LPCSTR dik_to_keyname(int _dik, bool bLocalize)
 {
 	_keyboard* kb = dik_to_ptr(_dik, true);
 	if (kb)
-		return kb->key_name;
+		if (bLocalize)
+			return kb->key_local_name.c_str();
+		else
+			return kb->key_name;
 	else
 		return NULL;
 }
@@ -668,7 +671,7 @@ void ConsoleBindCmds::save(IWriter* F)
 
 	for (; it != m_bindConsoleCmds.end(); ++it)
 	{
-		LPCSTR keyname = dik_to_keyname(it->first);
+		LPCSTR keyname = dik_to_keyname(it->first, false);
 		F->w_printf("bind_console %s %s\n", *it->second.cmd, keyname);
 	}
 }

--- a/src/xrGame/xr_level_controller.h
+++ b/src/xrGame/xr_level_controller.h
@@ -141,7 +141,7 @@ struct _action
 	_key_group key_group;
 };
 
-LPCSTR dik_to_keyname(int _dik);
+LPCSTR dik_to_keyname(int _dik, bool bLocalize);
 int keyname_to_dik(LPCSTR _name);
 _keyboard* keyname_to_ptr(LPCSTR _name);
 _keyboard* dik_to_ptr(int _dik, bool bSafe);


### PR DESCRIPTION
A couple of addons need to display a human readable version of a DIK key. This includes MCM, Western Goods and now an addon Private Pirate is working on.

The accepted solution so far was to define a long list in an LTX file that would associate each DIK key code with its human readable version.

This worked relatively well, but had two drawbacks :
- This either causes addon inter-dependancy (if one addon defines the list, and others require it to use the list) or code duplication (if all addons make their own copy of that list and copy the code needed to read it);
- This didn't handle keyboard layouts. In France, keyboards use the AZERTY layout. And using the LTX map solution would display the key `Z` as `W`, because `Z` is placed where `W` on the QWERTY layout.

Turns out, once again the engine already supported it. So this PR exports `dik_to_keyname`, an existing function that I slightly reworked to also support localization.

Even though that's very shitty, this function is exported in the global namespace, for consistency's sake (given other DIK related functions are also global).