### PR TITLE
Fix ImGui in Verified Build

### DIFF
--- a/gamedata/scripts/modxml_inject_keybinds.script
+++ b/gamedata/scripts/modxml_inject_keybinds.script
@@ -4,7 +4,7 @@ function on_xml_read()
 	RegisterUBGLKeybindSeparationInjector()
 	
 	-- Lucy: add ImGui keybind
-	RegisterImGuiKeybindSeparationInjector()
+	RegisterImGuiKeybindInjector()
 end
 
 function RegisterUBGLKeybindSeparationInjector()
@@ -69,7 +69,7 @@ function RegisterUBGLKeybindSeparationInjector()
     end)
 end
 
-function RegisterImGuiKeybindSeparationInjector()
+function RegisterImGuiKeybindInjector()
 	RegisterScriptCallback("on_xml_read", function(xml_file_name, xml_obj)
         if xml_file_name == [[ui\ui_keybinding.xml]] then
             local group_nodes = xml_obj:query("group[name=kb_grp_common]")

--- a/src/3rd party/imgui/imconfig.h
+++ b/src/3rd party/imgui/imconfig.h
@@ -19,6 +19,13 @@
 //#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
 //#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
 
+// Print ImGui errors to console on verified build
+#ifdef USE_VERIFY_IN_RELEASE
+#pragma comment(lib, "xrCore.lib")
+extern void Msg(const char* format, ...);
+#define IM_ASSERT(_EXPR) do {if (!(_EXPR)) Msg("![ImGui Error] %s", #_EXPR);} while(0)
+#endif
+
 //---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
 // Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
 // - Windows DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
@@ -56,8 +63,8 @@
 
 //---- Include imgui_user.h at the end of imgui.h as a convenience
 // May be convenient for some users to only explicitly include vanilla imgui.h and have extra stuff included.
-//#define IMGUI_INCLUDE_IMGUI_USER_H
-//#define IMGUI_USER_H_FILENAME         "my_folder/my_imgui_user.h"
+#define IMGUI_INCLUDE_IMGUI_USER_H
+#define IMGUI_USER_H_FILENAME         "imgui_custom.h"
 
 //---- Pack vertex colors as BGRA8 instead of RGBA8 (to avoid converting from one to another). Need dedicated backend support.
 //#define IMGUI_USE_BGRA_PACKED_COLOR

--- a/src/3rd party/imgui/imgui.vcxproj
+++ b/src/3rd party/imgui/imgui.vcxproj
@@ -64,22 +64,25 @@
     <IncludePath>$(IncludePath)</IncludePath>
     <OutDir>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(xrIntDir)$(ProjectName)\</IntDir>
+    <LibraryPath>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(IncludePath)</IncludePath>
     <OutDir>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(xrIntDir)$(ProjectName)\</IntDir>
+    <LibraryPath>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-AVX|x64'">
     <IncludePath>$(IncludePath)</IncludePath>
     <OutDir>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(xrIntDir)$(ProjectName)\</IntDir>
+    <LibraryPath>$(xrGameDir)bin_dbg\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Verified|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;USE_VERIFY_IN_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)3rd party\imgui\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/src/3rd party/imgui/imgui_widgets.cpp
+++ b/src/3rd party/imgui/imgui_widgets.cpp
@@ -2597,8 +2597,6 @@ bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v
     return false;
 }
 
-#include "imgui_custom.h"
-
 // Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a Drag widget, p_min and p_max are optional.
 // Read code of e.g. DragFloat(), DragInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
 bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)

--- a/src/engine-vs2022.sln
+++ b/src/engine-vs2022.sln
@@ -247,6 +247,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ui", "ui", "{91413BC1-731E-
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "imgui", "3rd party\imgui\imgui.vcxproj", "{D0843040-7706-4FBF-A931-582748BAFBB1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A0F7D1FB-59A7-4717-A7E4-96F37E91998E} = {A0F7D1FB-59A7-4717-A7E4-96F37E91998E}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/xrEngine/imgui_base.cpp
+++ b/src/xrEngine/imgui_base.cpp
@@ -143,6 +143,8 @@ namespace xr_imgui
 
     void ide::OnFrame()
     {
+        if (!!!Device.b_is_Active) return;
+
         const float frametime = m_timer.GetElapsed_sec();
         m_timer.Start();
 
@@ -249,9 +251,7 @@ namespace xr_imgui
             ImGui::DockSpace(ImGui::GetID("DockSpace"), ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
         }
         ImGui::End();
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar(3);
     }
 
     void ide::Show(bool bShow)


### PR DESCRIPTION
- Verified build no longer crashes on alt-tab due to an ImGui error
- ImGui errors are now logged to the console/log when using the verified build
- Changed how imgui_custom.h is included to be more compatible with possible ImGui version upgrades in the future
- Renamed `RegisterImGuiKeybindSeparationInjector` to `RegisterImGuiKeybindInjector` thanks, again @nltp-ashes 😄 