### PR TITLE
Some more changes

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -775,6 +775,9 @@
         function set_ui_rotation(vector);
         function set_ui_rotation(number, number, number);
         function get_ui_rotation();
+        function set_ui_scale(vector2);
+        function set_ui_scale(number, number);
+        function get_ui_scale();
 
         -- Script Light
         function attach_light(attachment_script_light*);
@@ -789,6 +792,9 @@
 		function get_default_shaders()
 		function set_shader(number, string, string)
 		function reset_shader(number)
+
+        -- Userdata
+        property userdata
     }
     
     Script Attachment Guide: https://igigog.github.io/anomaly-modding-book/tutorials/scripting/script-attachments.html

--- a/src/Include/xrRender/Kinematics.h
+++ b/src/Include/xrRender/Kinematics.h
@@ -85,6 +85,7 @@ public:
 	//	Callback: data manipulation
 	virtual void SetUpdateCallback(UpdateCallback pCallback) = 0;
 	virtual void SetUpdateCallbackParam(void* pCallbackParam) = 0;
+	virtual bool NeedUCalc() = 0;
 
 	virtual UpdateCallback GetUpdateCallback() = 0;
 	virtual void* GetUpdateCallbackParam() = 0;

--- a/src/Layers/xrRender/SkeletonAnimated.cpp
+++ b/src/Layers/xrRender/SkeletonAnimated.cpp
@@ -188,9 +188,9 @@ u16 CKinematicsAnimated::LL_PartID(LPCSTR B)
 	if (0 == m_Partition) return BI_NONE;
 	for (u16 id = 0; id < MAX_PARTS; id++)
 	{
-		CPartDef& P = (*m_Partition)[id];
-		if (0 == P.Name) continue;
-		if (0 == stricmp(B, *P.Name)) return id;
+		CPartDef* P = (*m_Partition)[id];
+		if (nullptr == P) continue;
+		if (0 == stricmp(B, *P->Name)) return id;
 	}
 	return BI_NONE;
 }
@@ -274,9 +274,10 @@ void CKinematicsAnimated::LL_CloseCycle(u16 part, u8 mask_channel /*= (1<<0)*/)
 		//B.blend = CBlend::eFREE_SLOT;
 		B.set_free_state();
 
-		CPartDef& P = (*m_Partition)[B.bone_or_part];
-		for (u32 i = 0; i < P.bones.size(); i++)
-			Bone_Motion_Stop_IM((*bones)[P.bones[i]], *I);
+		CPartDef* P = (*m_Partition)[B.bone_or_part];
+		if (nullptr == P) return;
+		for (u32 i = 0; i < P->bones.size(); i++)
+			Bone_Motion_Stop_IM((*bones)[P->bones[i]], *I);
 
 		blend_cycles[part].erase(I); // ?
 		E = blend_cycles[part].end();
@@ -381,7 +382,7 @@ CBlend* CKinematicsAnimated::LL_PlayCycle(u16 part, MotionID motion_ID, BOOL bMi
 		return 0;
 	}
 	if (part >= MAX_PARTS) return 0;
-	if (0 == m_Partition->part(part).Name) return 0;
+	if (0 == m_Partition->part(part)) return 0;
 
 	//	shared_motions* s_mots	= &m_Motions[motion.slot];
 	//	CMotionDef* m_def		= s_mots->motion_def(motion.idx);
@@ -393,19 +394,19 @@ CBlend* CKinematicsAnimated::LL_PlayCycle(u16 part, MotionID motion_ID, BOOL bMi
 		if (bMixing) LL_FadeCycle(part, blendFalloff, 1 << channel);
 		else LL_CloseCycle(part, 1 << channel);
 	}
-	CPartDef& P = (*m_Partition)[part];
+	CPartDef* P = (*m_Partition)[part];
 	CBlend* B = IBlend_Create();
 	if (!B) return 0;
 
 	_DBG_SINGLE_USE_MARKER;
 	IBlendSetup(*B, part, channel, motion_ID, bMixing, blendAccrue, blendFalloff, Speed, noloop, Callback,
 	            CallbackParam);
-	for (u32 i = 0; i < P.bones.size(); i++)
+	for (u32 i = 0; i < P->bones.size(); i++)
 	{
-		if (!(*bones)[P.bones[i]])
+		if (!(*bones)[P->bones[i]])
 			Debug.fatal(DEBUG_INFO, "! MODEL: missing bone/wrong armature? : %s", *getDebugName());
 
-		Bone_Motion_Start_IM((*bones)[P.bones[i]], B);
+		Bone_Motion_Start_IM((*bones)[P->bones[i]], B);
 	}
 	blend_cycles[part].push_back(B);
 	return B;
@@ -526,9 +527,10 @@ void CKinematicsAnimated::DestroyCycle(CBlend& B)
 		GetBlendDestroyCallback()->BlendDestroy(B);
 	//B.blend 		= CBlend::eFREE_SLOT;
 	B.set_free_state();
-	const CPartDef& P = m_Partition->part(B.bone_or_part);
-	for (u32 i = 0; i < P.bones.size(); i++)
-		Bone_Motion_Stop_IM((*bones)[P.bones[i]], &B);
+	const CPartDef* P = m_Partition->part(B.bone_or_part);
+	if (nullptr == P) return;
+	for (u32 i = 0; i < P->bones.size(); i++)
+		Bone_Motion_Stop_IM((*bones)[P->bones[i]], &B);
 }
 
 
@@ -540,7 +542,7 @@ void CKinematicsAnimated::LL_UpdateTracks(float dt, bool b_force, bool leave_ble
 	// Cycles
 	for (u16 part = 0; part < MAX_PARTS; part++)
 	{
-		if (0 == m_Partition->part(part).Name)
+		if (nullptr == m_Partition->part(part))
 			continue;
 		I = blend_cycles[part].begin();
 		E = blend_cycles[part].end();

--- a/src/Layers/xrRender/SkeletonCustom.cpp
+++ b/src/Layers/xrRender/SkeletonCustom.cpp
@@ -113,6 +113,7 @@ CKinematics::CKinematics()
 #endif
 
 	m_is_original_lod = false;
+	UCalc_ThisFrame = false;
 }
 
 CKinematics::~CKinematics()

--- a/src/Layers/xrRender/SkeletonCustom.h
+++ b/src/Layers/xrRender/SkeletonCustom.h
@@ -140,6 +140,7 @@ protected:
 	BOOL Update_Visibility;
 	u32 UCalc_Time;
 	s32 UCalc_Visibox;
+	bool UCalc_ThisFrame;
 
 	Flags64 visimask;
 	Flags64 hidden_bones;
@@ -290,6 +291,8 @@ public:
 
 	virtual UpdateCallback GetUpdateCallback() { return Update_Callback; }
 	virtual void* GetUpdateCallbackParam() { return Update_Callback_Param; }
+
+	virtual bool NeedUCalc() { return UCalc_ThisFrame; }
 
 	// debug
 #ifdef DEBUG

--- a/src/Layers/xrRender/SkeletonRigid.cpp
+++ b/src/Layers/xrRender/SkeletonRigid.cpp
@@ -45,6 +45,7 @@ void CKinematics::CalculateBones(BOOL bForceExact)
 	{
 		// mark
 		UCalc_Visibox = -(::Random.randI(psSkeletonUpdate - 1));
+		UCalc_ThisFrame = true;
 
 		// the update itself
 		Fbox Box;
@@ -109,7 +110,8 @@ void CKinematics::CalculateBones(BOOL bForceExact)
 		VERIFY3	(vis.sphere.R<1000.f,						"Invalid bones-xform in model", dbg_name.c_str());
 #endif
 	}
-
+	else
+		UCalc_ThisFrame = false;
 	//
 	if (Update_Callback) Update_Callback(this);
 }

--- a/src/xrEngine/FDemoPlay.cpp
+++ b/src/xrEngine/FDemoPlay.cpp
@@ -309,9 +309,11 @@ BOOL CDemoPlay::ProcessCam(SCamEffectorInfo& info)
 			spline1(t, &(v[0]), (Fvector*)&(Device.mView.m[i][0]));
 		}
 
-		info.n.set(Device.mInvView._21, Device.mInvView._22, Device.mInvView._23);
-		info.d.set(Device.mInvView._31, Device.mInvView._32, Device.mInvView._33);
-		info.p.set(Device.mInvView._41, Device.mInvView._42, Device.mInvView._43);
+		Fmatrix mInvCamera;
+		mInvCamera.invert(Device.mView);
+		info.n.set(mInvCamera._21, mInvCamera._22, mInvCamera._23);
+		info.d.set(mInvCamera._31, mInvCamera._32, mInvCamera._33);
+		info.p.set(mInvCamera._41, mInvCamera._42, mInvCamera._43);
 
 		fLifeTime -= Device.fTimeDelta;
 	}

--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -84,7 +84,7 @@ CDemoRecord::CDemoRecord(const char* name, float life_time, BOOL return_ctrl_inp
 	{
 		g_position.set_position = false;
 		IR_Capture(); // capture input
-		m_Camera = Device.mInvView;
+		m_Camera.invert(Device.mView);
 		m_fCameraBoundary = 100.f;
 
 		// parse yaw

--- a/src/xrEngine/SkeletonMotions.cpp
+++ b/src/xrEngine/SkeletonMotions.cpp
@@ -14,8 +14,8 @@ u16 CPartition::part_id(const shared_str& name) const
 {
 	for (u16 i = 0; i < MAX_PARTS; ++i)
 	{
-		const CPartDef& pd = part(i);
-		if (pd.Name == name)
+		const CPartDef* pd = part(i);
+		if (pd && pd->Name == name)
 			return i;
 	}
 	Msg("!there is no part named [%s]", name.c_str());
@@ -44,21 +44,23 @@ void CPartition::load(IKinematics* V, LPCSTR model_name)
 		CInifile::Sect S = ini.r_section(buff);
 		CInifile::SectCIt it = S.Data.begin();
 		CInifile::SectCIt it_e = S.Data.end();
-		if (S.Data.size())
-		{
-			P[i].bones.clear_not_free();
-		}
+
+		if (!S.Data.size()) continue;
+
+		while (!P[i]) create();
+		P[i]->bones.clear_not_free();
+
 		for (; it != it_e; ++it)
 		{
 			const CInifile::Item& I = *it;
 			if (I.first == part_name)
 			{
-				P[i].Name = I.second;
+				P[i]->Name = I.second;
 			}
 			else
 			{
 				u32 bid = V->LL_BoneID(I.first.c_str());
-				P[i].bones.push_back(bid);
+				P[i]->bones.push_back(bid);
 			}
 		}
 	}
@@ -89,17 +91,17 @@ BOOL motions_value::load(LPCSTR N, IReader* data, vecBones* bones)
 		R_ASSERT3(vers <= xrOGF_SMParamsVersion, "Invalid OGF/OMF version:", N);
 
 		// partitions
-		u16 part_count;
-		part_count = MP->r_u16();
+		u16 part_count = MP->r_u16();
 
 		for (u16 part_i = 0; part_i < part_count; part_i++)
 		{
-			CPartDef& PART = m_partition[part_i];
+			CPartDef* PART = m_partition[part_i];
+			while (!PART) PART = m_partition.create();
 			MP->r_stringZ(buf, sizeof(buf));
-			PART.Name = _strlwr(buf);
-			PART.bones.resize(MP->r_u16());
+			PART->Name = _strlwr(buf);
+			PART->bones.resize(MP->r_u16());
 
-			for (xr_vector<u32>::iterator b_it = PART.bones.begin(); b_it < PART.bones.end(); b_it++)
+			for (xr_vector<u32>::iterator b_it = PART->bones.begin(); b_it < PART->bones.end(); b_it++)
 			{
 				MP->r_stringZ(buf, sizeof(buf));
 				u16 m_idx = u16(MP->r_u32());
@@ -121,7 +123,7 @@ BOOL motions_value::load(LPCSTR N, IReader* data, vecBones* bones)
 #endif
 				if (bRes) rm_bones[m_idx] = u16(*b_it);
 			}
-			part_bone_cnt = u16(part_bone_cnt + (u16)PART.bones.size());
+			part_bone_cnt = u16(part_bone_cnt + (u16)PART->bones.size());
 		}
 
 #ifdef _EDITOR

--- a/src/xrEngine/SkeletonMotions.h
+++ b/src/xrEngine/SkeletonMotions.h
@@ -186,20 +186,32 @@ public:
 
 class ENGINE_API CPartition
 {
-	CPartDef P[MAX_PARTS];
+	xr_vector<CPartDef*> P;
 public:
-	IC CPartDef& operator[](u16 id) { return P[id]; }
-	IC const CPartDef& part(u16 id) const { return P[id]; }
+	IC CPartDef* operator[](u16 id) { return P.size() > id ? P.at(id) : nullptr; }
+	IC const CPartDef* part(u16 id) const { return P.size() > id ? P.at(id) : nullptr; }
+	CPartDef* create()
+	{
+		if (P.size() > MAX_PARTS) return nullptr;
+		P.emplace_back(xr_new<CPartDef>());
+		return P.back();
+	}
 	u16 part_id(const shared_str& name) const;
-	u32 mem_usage() { return P[0].mem_usage() * MAX_PARTS; }
+	u32 mem_usage() { return P[0]->mem_usage() * P.size(); }
 	void load(IKinematics* V, LPCSTR model_name);
 
-	u8 count() const
+	u8 count() const { return P.size(); };
+
+	CPartition()
 	{
-		u8 ret = 0;
-		for (u8 i = 0; i < MAX_PARTS; ++i) if (P[i].Name.size())ret++;
-		return ret;
-	};
+		P.reserve(MAX_PARTS);
+	}
+
+	~CPartition()
+	{
+		for (auto& PartDef : P)
+			xr_delete(PartDef);
+	}
 };
 
 // shared motions

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -33,6 +33,7 @@
 #include "animation_movement_controller.h"
 #include "../xrengine/xr_collide_form.h"
 #include "script_attachment_manager.h"
+#include "player_hud.h"
 extern MagicBox3 MagicMinBox(int iQuantity, const Fvector* akPoint);
 
 #pragma warning(push)
@@ -761,11 +762,118 @@ void CGameObject::RenderAttachments()
 	}
 }
 
+//#define DEBUG_VISBOX
+
+#ifdef DEBUG_VISBOX
+#include "debug_renderer.h"
+#endif
+
+static void update_visbox(IKinematics* k)
+{
+	CGameObject* obj = static_cast<CGameObject*>(k->GetUpdateCallbackParam());
+	if (!obj) return;
+
+	if (k->NeedUCalc())
+	{
+		for (auto& pair : *obj->GetAttachments())
+		{
+			script_attachment* att = pair.second;
+			if (att->GetType() != eSA_World) continue;
+
+			Fbox Box = att->Box();
+
+			Fmatrix offset;
+			offset.mul(att->BoneTransform(k), att->GetOffset());
+			Box.xform(offset);
+
+			// Update Box
+			Fbox& kbox = const_cast<Fbox&>(k->GetBox());
+			kbox.merge(Box);
+
+			// Update Sphere
+			Fsphere& kshere = k->dcast_RenderVisual()->getVisData().sphere;
+			kbox.getsphere(kshere.P, kshere.R);
+		}
+	}
+	
+#ifdef DEBUG_VISBOX
+	Fmatrix box, cent;
+	cent.translate(k->dcast_RenderVisual()->getVisData().sphere.P);
+	box.mul(obj->XFORM(), cent);
+
+	const Fbox& kbox = k->GetBox();
+	Fvector radius;
+	kbox.getradius(radius);
+	CDebugRenderer& render = Level().debug_renderer();
+	render.draw_obb(box, radius, D3DCOLOR_XRGB(0, 255, 0), false);
+#endif
+}
+
+static void update_visbox_hud(IKinematics* k)
+{
+	CHudItem* obj = static_cast<CHudItem*>(k->GetUpdateCallbackParam());
+	if (!obj) return;
+
+	if (k->NeedUCalc())
+	{
+		for (auto& pair : *obj->object().GetAttachments())
+		{
+			script_attachment* att = pair.second;
+			if (att->GetType() != eSA_HUD) continue;
+
+			Fbox Box = att->Box();
+
+			Fmatrix offset;
+			offset.mul(att->BoneTransform(k), att->GetOffset());
+			Box.xform(offset);
+
+			// Update Box
+			Fbox& kbox = const_cast<Fbox&>(k->GetBox());
+			kbox.merge(Box);
+
+			// Update Sphere
+			Fsphere& kshere = k->dcast_RenderVisual()->getVisData().sphere;
+			kbox.getsphere(kshere.P, kshere.R);
+		}
+	}
+	
+#ifdef DEBUG_VISBOX
+	Fmatrix box, cent;
+	cent.translate(k->dcast_RenderVisual()->getVisData().sphere.P);
+	box.mul(obj->HudItemData()->m_item_transform, cent);
+
+	const Fbox& kbox = k->GetBox();
+	Fvector radius;
+	kbox.getradius(radius);
+	CDebugRenderer& render = Level().debug_renderer();
+	render.draw_obb(box, radius, D3DCOLOR_XRGB(100, 100, 0), true);
+#endif
+}
+
 script_attachment* CGameObject::add_attachment(LPCSTR name, script_attachment* att)
 {
 	R_ASSERT(att);
 	remove_child(name, true);
 	m_script_attachments.emplace(mk_pair(name, att));
+
+	if (!Visual()->dcast_PKinematics()->GetUpdateCallback())
+	{
+		Visual()->dcast_PKinematics()->SetUpdateCallback(update_visbox);
+		Visual()->dcast_PKinematics()->SetUpdateCallbackParam(this);
+	}
+
+	CHudItem* obj = smart_cast<CHudItem*>(this);
+	if (obj)
+	{
+		IKinematics* k = obj->HudItemData()->m_model;
+
+		if (!k->GetUpdateCallback())
+		{
+			k->SetUpdateCallback(update_visbox_hud);
+			k->SetUpdateCallbackParam(obj);
+		}
+	}
+
 	return att;
 }
 
@@ -783,16 +891,34 @@ script_attachment* CGameObject::get_attachment(LPCSTR name)
 
 void CGameObject::remove_child(LPCSTR name, bool destroy)
 {
-	if (m_script_attachments.size())
-	{
-		script_attachment* attachment = get_attachment(name);
-		if (!attachment)
-			return;
+	script_attachment* attachment = get_attachment(name);
+	if (!attachment)
+		return;
 
-		if (destroy)
-			xr_delete(attachment);
-			
-		m_script_attachments.erase(name);
+	if (destroy)
+		xr_delete(attachment);
+
+	m_script_attachments.erase(name);
+
+	if (!m_script_attachments.size())
+	{
+		if (Visual()->dcast_PKinematics()->GetUpdateCallbackParam() == this)
+		{
+			Visual()->dcast_PKinematics()->SetUpdateCallback(nullptr);
+			Visual()->dcast_PKinematics()->SetUpdateCallbackParam(nullptr);
+		}
+
+		CHudItem* obj = smart_cast<CHudItem*>(this);
+		if (obj)
+		{
+			IKinematics* k = obj->HudItemData()->m_model;
+
+			if (k->GetUpdateCallbackParam() == obj)
+			{
+				k->SetUpdateCallback(nullptr);
+				k->SetUpdateCallbackParam(nullptr);
+			}
+		}
 	}
 }
 

--- a/src/xrGame/script_attachment_manager.cpp
+++ b/src/xrGame/script_attachment_manager.cpp
@@ -5,6 +5,53 @@
 #include "actor.h"
 #include "ui\UIScriptWnd.h"
 
+//#define DEBUG_VISBOX
+
+#ifdef DEBUG_VISBOX
+#include "debug_renderer.h"
+#endif
+
+static void update_visbox_attachment(IKinematics* k)
+{
+	script_attachment* att = static_cast<script_attachment*>(k->GetUpdateCallbackParam());
+	if (!att) return;
+
+	if (k->NeedUCalc())
+	{
+		for (auto& pair : *att->GetAttachments())
+		{
+			script_attachment* child_att = pair.second;
+			if (child_att->GetType() != att->GetType()) continue;
+
+			Fbox Box = child_att->Box();
+
+			Fmatrix offset;
+			offset.mul(child_att->BoneTransform(k), child_att->GetOffset());
+			Box.xform(offset);
+
+			// Update Box
+			Fbox& kbox = const_cast<Fbox&>(k->GetBox());
+			kbox.merge(Box);
+
+			// Update Sphere
+			Fsphere& kshere = k->dcast_RenderVisual()->getVisData().sphere;
+			kbox.getsphere(kshere.P, kshere.R);
+		}
+	}
+
+#ifdef DEBUG_VISBOX
+	Fmatrix box, cent;
+	cent.translate(k->dcast_RenderVisual()->getVisData().sphere.P);
+	box.mul(att->GetTransform(), cent);
+
+	const Fbox& kbox = k->GetBox();
+	Fvector radius;
+	kbox.getradius(radius);
+	CDebugRenderer& render = Level().debug_renderer();
+	render.draw_obb(box, radius, D3DCOLOR_XRGB(150, 0, 150), att->GetType() == eSA_HUD);
+#endif
+}
+
 script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 {
 	m_name = name;
@@ -17,6 +64,7 @@ script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 	m_script_ui_mat = Fidentity;
 	m_script_ui_offset[0].set(0, 0, 0);
 	m_script_ui_offset[1].set(0, 0, 0);
+	m_script_ui_scale.set(1, 1);
 	m_script_ui_bone = 0;
 	m_script_light = nullptr;
 	m_script_light_bone = 0;
@@ -33,6 +81,7 @@ script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 	m_last_upd_frame = 0;
 	m_current_motion = "idle";
 	m_model_name = "";
+	m_userdata = nullptr;
 	LoadModel(model_name);
 	PlayMotion("idle", false);
 }
@@ -199,6 +248,9 @@ void script_attachment::RenderUI()
 		else
 			ui_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
 
+		ui_bone.m[1][1] = m_script_ui_scale.x;
+		ui_bone.m[2][2] = m_script_ui_scale.y;
+
 		LM.mul(m_transform, ui_bone);
 		LM.mulB_43(m_script_ui_mat);
 		UIRender->CacheSetXformWorld(LM);
@@ -243,7 +295,7 @@ void script_attachment::RecalcOffset()
 	{
 		Fmatrix rotation_matrix;
 		
-		m_offset.translate(m_origin);
+		m_offset.translate(-m_origin.x, -m_origin.y, -m_origin.z);
 
 		Fvector rotation = m_rotation;
 		rotation.mul(PI / 180.f);
@@ -265,27 +317,27 @@ void script_attachment::RecalcOffset()
 	}
 }
 
-void script_attachment::SetPosition(Fvector pos)
+void script_attachment::SetPosition(float x, float y, float z)
 {
-	m_position = pos;
+	m_position.set(x, y, z);
 	RecalcOffset();
 }
 
-void script_attachment::SetRotation(Fvector rot)
+void script_attachment::SetRotation(float x, float y, float z)
 {
-	m_rotation = rot;
+	m_rotation.set(x, y, z);
 	RecalcOffset();
 }
 
-void script_attachment::SetScale(Fvector scale)
+void script_attachment::SetScale(float x, float y, float z)
 {
-	m_scale = scale;
+	m_scale.set(x, y, z);
 	RecalcOffset();
 }
 
-void script_attachment::SetOrigin(Fvector org)
+void script_attachment::SetOrigin(float x, float y, float z)
 {
-	m_origin = org.invert();
+	m_origin.set(x, y, z);
 	RecalcOffset();
 }
 
@@ -590,7 +642,7 @@ void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
 	m_kinematics = m_model->dcast_PKinematics();
 	R_ASSERT(m_kinematics);
 
-	//Bone Callbacks
+	// Bone Callbacks
 	if (keep_bc && m_bone_callbacks.size() && count_prev <= m_kinematics->LL_BoneCount())
 	{
 		for (auto& pair : m_bone_callbacks)
@@ -600,6 +652,10 @@ void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
 
 		PlayMotion(*m_current_motion, false);
 	}
+
+	// Visibility Box Update
+	m_kinematics->SetUpdateCallback(update_visbox_attachment);
+	m_kinematics->SetUpdateCallbackParam(this);
 }
 
 void script_attachment::SetName(LPCSTR name)
@@ -643,6 +699,36 @@ void script_attachment::SetName(LPCSTR name)
 	}
 
 	m_name = name;
+}
+
+const luabind::object& script_attachment::GetUserdata() const
+{
+	if (!m_userdata)
+	{
+		const_cast<::luabind::object*>(m_userdata) = xr_new<::luabind::object>();
+		*m_userdata = ::luabind::newtable(ai().script_engine().lua());
+	}
+	return *m_userdata;
+}
+
+void script_attachment::SetUserdata(::luabind::object obj)
+{
+	if (!obj || obj.type() == LUA_TNIL)
+	{
+		xr_delete(m_userdata);
+		m_userdata = nullptr;
+		return;
+	}
+
+	if (obj.type() != LUA_TTABLE)
+	{
+		Msg("![Script Attachment]: Trying to set userdata to wrong type! (Allowed types: table, nil)");
+		return;
+	}
+
+	if (!m_userdata) m_userdata = xr_new<::luabind::object>();
+
+	*m_userdata = obj;
 }
 
 void script_attachment::SetScriptUI(LPCSTR ui_func)
@@ -768,6 +854,11 @@ void script_attachment::RemoveBoneCallback(u16 bone_id)
 		m_kinematics->LL_GetBoneInstance(bone_id).reset_callback();
 		m_bone_callbacks.erase(bone_id);
 	}
+}
+
+const Fbox& script_attachment::Box()
+{
+	return m_model->dcast_PKinematics()->GetBox();
 }
 
 Fvector script_attachment::GetCenter()

--- a/src/xrGame/script_attachment_manager.h
+++ b/src/xrGame/script_attachment_manager.h
@@ -60,6 +60,7 @@ private:
 	CUIWindow* m_script_ui;
 	Fmatrix m_script_ui_mat;
 	Fvector m_script_ui_offset[2];
+	Fvector2 m_script_ui_scale;
 	u16 m_script_ui_bone;
 
 	AttachmentScriptLight* m_script_light;
@@ -74,6 +75,8 @@ private:
 	xr_map<shared_str, script_attachment*> m_children;
 	xr_map<u16, script_attachment_bone_cb*> m_bone_callbacks;
 
+	::luabind::object* m_userdata;
+
 	u32 m_last_upd_frame;
 
 public:
@@ -84,6 +87,7 @@ public:
 		m_model = nullptr;
 		delete_data(m_children);
 		delete_data(m_bone_callbacks);
+		xr_delete(m_userdata);
 	}
 
 	void Render(IKinematics* model, Fmatrix* mat);
@@ -99,21 +103,21 @@ public:
 
 	void RecalcOffset();
 
-	void SetPosition(Fvector pos);
-	void SetPosition(float x, float y, float z) { SetPosition(Fvector().set(x, y, z)); }
+	void SetPosition(Fvector pos) { SetPosition(pos.x, pos.y, pos.z); }
+	void SetPosition(float x, float y, float z);
 	Fvector GetPosition() { return m_position; }
 
-	void SetRotation(Fvector rot);
-	void SetRotation(float x, float y, float z) { SetRotation(Fvector().set(x, y, z)); }
+	void SetRotation(Fvector rot) { SetRotation(rot.x, rot.y, rot.z); }
+	void SetRotation(float x, float y, float z);
 	Fvector GetRotation() { return m_rotation; }
 
-	void SetScale(Fvector scale);
-	void SetScale(float x, float y, float z) { SetScale(Fvector().set(x, y, z)); }
+	void SetScale(Fvector scale) { SetScale(scale.x, scale.y, scale.z); }
+	void SetScale(float x, float y, float z);
 	void SetScale(float scale) { SetScale(Fvector().set(scale, scale, scale)); }
 	Fvector GetScale() { return m_scale; }
 
-	void SetOrigin(Fvector org);
-	void SetOrigin(float x, float y, float z) { SetOrigin(Fvector().set(x, y, z)); }
+	void SetOrigin(Fvector org) { SetOrigin(org.x, org.y, org.z); }
+	void SetOrigin(float x, float y, float z);
 	Fvector GetOrigin() { return m_origin; }
 
 	void SetParent(script_attachment* att);
@@ -131,6 +135,9 @@ public:
 	void SetName(LPCSTR name);
 	LPCSTR GetName() { return *m_name; }
 
+	const ::luabind::object& GetUserdata() const;
+	void SetUserdata(::luabind::object obj);
+
 	void SetScriptUI(LPCSTR ui_func);
 	LPCSTR GetScriptUI() { return m_script_ui_func; }
 	void SetScriptUIPosition(Fvector pos);
@@ -142,6 +149,9 @@ public:
 	void SetScriptUIBone(u16 bone) { m_script_ui_bone = bone; }
 	void SetScriptUIBone(LPCSTR bone) { m_script_ui_bone = bone_id(bone); }
 	u16 GetScriptUIBone() { return m_script_ui_bone; }
+	void SetScriptUIScale(Fvector2 scale) { SetScriptUIScale(scale.x, scale.y); }
+	void SetScriptUIScale(float x, float y) { m_script_ui_scale.set(x, y); }
+	Fvector2 GetScriptUIScale() { return m_script_ui_scale; }
 
 	script_attachment* AddAttachment(LPCSTR name, LPCSTR model_name);
 	void RemoveAttachment(LPCSTR name) { RemoveChild(name, true); }
@@ -192,8 +202,11 @@ public:
 	void RemoveBoneCallback(u16 bone_id);
 	void RemoveBoneCallback(LPCSTR bone) { RemoveBoneCallback(bone_id(bone)); }
 
-	Fmatrix GetTransform() { return m_transform; };
+	Fmatrix GetTransform() { return m_transform; }
+	Fmatrix GetOffset() { return m_offset; }
 	Fvector GetCenter();
+	const Fbox& Box();
+	xr_map<shared_str, script_attachment*>* GetAttachments() { return &m_children; }
 
 	::luabind::object GetShaders();
 	::luabind::object GetDefaultShaders();

--- a/src/xrGame/script_attachment_script.cpp
+++ b/src/xrGame/script_attachment_script.cpp
@@ -100,6 +100,9 @@ void script_attachment::script_register(lua_State* L)
 		.def("set_ui_rotation", (void (script_attachment::*)(Fvector)) &script_attachment::SetScriptUIRotation)
 		.def("set_ui_rotation", (void (script_attachment::*)(float, float, float)) &script_attachment::SetScriptUIRotation)
 		.def("get_ui_rotation", &script_attachment::GetScriptUIRotation)
+		.def("set_ui_scale", (void (script_attachment::*)(Fvector2)) &script_attachment::SetScriptUIScale)
+		.def("set_ui_scale", (void (script_attachment::*)(float, float)) &script_attachment::SetScriptUIScale)
+		.def("get_ui_scale", &script_attachment::GetScriptUIScale)
 
 		//Script Light
 		.def("attach_light", &script_attachment::AttachLight)
@@ -114,5 +117,8 @@ void script_attachment::script_register(lua_State* L)
 		.def("get_default_shaders", &script_attachment::GetDefaultShaders)
 		.def("set_shader", &script_attachment::SetShaderTexture)
 		.def("reset_shader", &script_attachment::ResetShaderTexture)
+
+		//Userdata
+		.property("userdata", &script_attachment::GetUserdata, &script_attachment::SetUserdata)
 	];
 }


### PR DESCRIPTION
- Added `userdata` property to script attachments (access a lua table owned by the attachment object to store data in)
- Add 3D UI scale to attachments (`set_ui_scale`, `get_ui_scale`)
- Script attachments (and their child attachments) now dynamically adjust their parent object's visibility box
- Fix partitions reinitializing a shared_str every frame
- Fix broken demo_record and demo_play (Thanks @VodoXleb)