### PR TITLE
Don't apply rendering optimizations to cars and helicopters

### DIFF
--- a/src/xrGame/Car.cpp
+++ b/src/xrGame/Car.cpp
@@ -205,6 +205,18 @@ BOOL CCar::net_Spawn(CSE_Abstract* DC)
 		m_memory = xr_new<car_memory>(this);
 		m_memory->reload(pUserData->r_string("visual_memory_definition", "section"));
 	}
+	
+	renderable.visual->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+
+	if (children)
+	{
+		for (auto* child : *children)
+		{
+			child->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+		}
+	}
 
 	return (CScriptEntity::net_Spawn(DC));
 }

--- a/src/xrGame/Helicopter.cpp
+++ b/src/xrGame/Helicopter.cpp
@@ -224,10 +224,8 @@ BOOL CHelicopter::net_Spawn(CSE_Abstract* DC)
 
 	CShootingObject::Light_Create();
 
-
 	setVisible(TRUE);
 	setEnabled(TRUE);
-
 
 	m_stepRemains = 0.0f;
 
@@ -245,6 +243,18 @@ BOOL CHelicopter::net_Spawn(CSE_Abstract* DC)
 #ifdef DEBUG
 	Device.seqRender.Add(this,REG_PRIORITY_LOW-1);
 #endif
+
+	renderable.visual->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+
+	if (children)
+	{
+		for (auto* child : *children)
+		{
+			child->flags.set(IRenderVisualFlags::eIgnoreOptimization, TRUE);
+		}
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
Исправляет невидимые машины (и по большей части вертолёты) при включённой оптимизации геометрии.