### PR TITLE
expose memory_remove_links to lua scripts

### DIFF
--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1139,6 +1139,7 @@ public:
 	void RemoveAttachment(LPCSTR name);
 	void RemoveAttachment(script_attachment* child);
 	void IterateAttachments(::luabind::functor<bool> functor);
+	void memory_remove_links(const CScriptGameObject* tpLuaGameObject);
 
 	doors::door* m_door;
 

--- a/src/xrGame/script_game_object4.cpp
+++ b/src/xrGame/script_game_object4.cpp
@@ -560,3 +560,18 @@ CBottleItem* CScriptGameObject::cast_BottleItem()
 	return ii ? smart_cast<CBottleItem*>(ii) : (0);
 }
 //end AVO
+
+void CScriptGameObject::memory_remove_links(const CScriptGameObject* tpLuaGameObject)
+{
+	CCustomMonster* monster = smart_cast<CCustomMonster*>(&object());
+	if (monster)
+	{
+		monster->memory().remove_links(&tpLuaGameObject->object());
+	}
+	else
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+			"CGameObject : cannot access class member memory_remove_links!");
+	}
+}
+

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -68,6 +68,7 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		.def("best_cover", &CScriptGameObject::best_cover)
 		.def("safe_cover", &CScriptGameObject::safe_cover)
 		.def("spawn_ini", &CScriptGameObject::spawn_ini)
+		.def("memory_remove_links", &CScriptGameObject::memory_remove_links)
 		.def("memory_visible_objects", &CScriptGameObject::memory_visible_objects, return_stl_iterator)
 		.def("memory_sound_objects", &CScriptGameObject::memory_sound_objects, return_stl_iterator)
 		.def("memory_hit_objects", &CScriptGameObject::memory_hit_objects, return_stl_iterator)


### PR DESCRIPTION
Every NPC has an in-engine memory of recently seen/heard(/and more) GameObjects. This change allows to force NPCs to forget GameObjects through LUA scripts. It is useful for me to solve a disguise issue where if a player tears off the disguise patch in a place where no one sees the player all the NPCs immediately aggro anyway because they remember the actor and actor now has a hostile community.

Short video of the issue, notice the faint sounds of aggroed bandits as i tear off the patch: https://youtu.be/Mr4yzTtrO7M

Short video showcasing the fix working along with some changes to `G.A.M.M.A. Disguise does not remove patches\gamedata\scripts\gameplay_disguise.script` file that will be submitted as a PR to GAMMA repo: https://youtu.be/5FOzGoVZVsg

Thank you SaloEater for help solving this issue.