### PR TITLE
Fix one _G.get_object_squad error

### DIFF
--- a/gamedata/scripts/_g_patches.script
+++ b/gamedata/scripts/_g_patches.script
@@ -671,6 +671,19 @@ _G.IsLauncher = function(o, c)
 	return c and launcher[c] or false
 end
 
+-- VodoXleb: get_object_squad fix
+function _G.get_object_squad(object,caller)
+	if not (object) then
+		return
+	end
+	if (object.group_id ~= nil and object.group_id ~= 65535) then
+		return alife_object(object.group_id)
+	end
+	local sim = alife()
+	local se_obj = type(object.id) == "function" and sim:object(object:id())
+	return se_obj and se_obj.group_id ~= nil and se_obj.group_id ~= 65535 and sim:object(se_obj.group_id) or nil
+end
+
 log = _G.log
 _G.log = function(str)
 	log(str)


### PR DESCRIPTION
added 1 extra check to _G.get_object_squad because if online object has group_id == nil function breaks because of alife():object(nil). I didn't replace alife():object with alife_object though.