### PR TITLE
CMake: Janitorial Supplies

### DIFF
--- a/.github/actions/check-line-endings/action.yml
+++ b/.github/actions/check-line-endings/action.yml
@@ -1,10 +1,22 @@
+inputs:
+  commit:
+    type: boolean
+    required: false
+    default: false
+
+outputs:
+  commit-hash:
+    value: ${{steps.commit.outputs.commit_hash || github.ref}}
+
 runs:
   using: composite
 
   steps:
     - name: Install
-      shell: bash
-      run: sudo apt-get install dos2unix recode
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: dos2unix
+        version: 1.0
 
     - name: Line Endings / BOM
       shell: bash
@@ -17,3 +29,11 @@ runs:
       with:
         message-ok: No files contain LF line endings or BOM
         message-error: Contains non-LF line endings or BOM
+
+    - name: Commit
+      id: commit
+      if: ${{inputs.commit == 'true'}}
+      uses: stefanzweifel/git-auto-commit-action@v6
+      with:
+        file_pattern: ":!.github/"
+        commit_message: Fix line endings

--- a/.github/actions/check-mixed-tabs/action.yml
+++ b/.github/actions/check-mixed-tabs/action.yml
@@ -1,10 +1,22 @@
+inputs:
+  commit:
+    type: boolean
+    required: false
+    default: false
+
+outputs:
+  commit-hash:
+    value: ${{steps.commit.outputs.commit_hash || github.ref}}
+
 runs:
   using: composite
 
   steps:
     - name: Install
-      shell: bash
-      run: sudo apt-get install moreutils
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: moreutils
+        version: 1.0
 
     - name: Mixed tabs and spaces
       shell: bash
@@ -17,3 +29,11 @@ runs:
       with:
         message-ok: All files are space-indented
         message-error: Not space-indented
+
+    - name: Commit
+      id: commit
+      if: ${{inputs.commit == 'true'}}
+      uses: stefanzweifel/git-auto-commit-action@v6
+      with:
+        file_pattern: ":!.github/"
+        commit_message: Fix indentation

--- a/.github/actions/check-result/action.yml
+++ b/.github/actions/check-result/action.yml
@@ -6,7 +6,7 @@ inputs:
   message-error:
     type: string
     required: true
-  
+
   warning:
     type: bool
     required: false
@@ -15,13 +15,14 @@ inputs:
 runs:
   using: composite
 
-  env:
-    message-ok: ${{inputs.message-ok || env.message-ok}}
-    message-error: ${{inputs.message-error || env.message-error}}
-    warning: ${{inputs.warning && 'warning' || 'error'}}
-
   steps:
     - name: Report result
+
+      env:
+        message-ok: ${{inputs.message-ok || env.message-ok}}
+        message-error: ${{inputs.message-error || env.message-error}}
+        warning: ${{inputs.warning && 'warning' || 'error'}}
+
       shell: bash
       run: |
         if [ -z "$(git status -s)" ]; then

--- a/.github/actions/check-result/action.yml
+++ b/.github/actions/check-result/action.yml
@@ -6,19 +6,29 @@ inputs:
   message-error:
     type: string
     required: true
+  
+  warning:
+    type: bool
+    required: false
+    default: true
 
 runs:
   using: composite
+
+  env:
+    message-ok: ${{inputs.message-ok || env.message-ok}}
+    message-error: ${{inputs.message-error || env.message-error}}
+    warning: ${{inputs.warning && 'warning' || 'error'}}
 
   steps:
     - name: Report result
       shell: bash
       run: |
         if [ -z "$(git status -s)" ]; then
-          echo "::notice::${{inputs.message-ok}}"
+          echo "::notice::${{env.message-ok}}"
         else
           echo Affected files:
-          git status --short | sed "s/^ M /::warning::${{inputs.message-error}}: /"
+          git status --short | sed "s/^ M /::${{env.warning}}::${{env.message-error}}: /"
 
           echo
           echo Details:

--- a/.github/actions/check-terminating-newline/action.yml
+++ b/.github/actions/check-terminating-newline/action.yml
@@ -1,11 +1,17 @@
+inputs:
+  commit:
+    type: boolean
+    required: false
+    default: false
+
+outputs:
+  commit-hash:
+    value: ${{steps.commit.outputs.commit_hash || github.ref}}
+
 runs:
   using: composite
 
   steps:
-    - name: Install
-      shell: bash
-      run: sudo apt-get install moreutils
-
     - name: Newline ending
       shell: bash
       run: |
@@ -17,3 +23,11 @@ runs:
       with:
         message-ok: All files contain a terminating newline
         message-error: Missing terminating newline
+
+    - name: Commit
+      id: commit
+      if: ${{inputs.commit == 'true'}}
+      uses: stefanzweifel/git-auto-commit-action@v6
+      with:
+        file_pattern: ":!.github/"
+        commit_message: Fix terminating newlines

--- a/.github/actions/check-trailing-whitespace/action.yml
+++ b/.github/actions/check-trailing-whitespace/action.yml
@@ -1,11 +1,17 @@
+inputs:
+  commit:
+    type: boolean
+    required: false
+    default: false
+
+outputs:
+  commit-hash:
+    value: ${{steps.commit.outputs.commit_hash || github.ref}}
+
 runs:
   using: composite
 
   steps:
-    - name: Install
-      shell: bash
-      run: sudo apt-get install moreutils
-
     - name: Trailing whitespace
       shell: bash
       run: |
@@ -17,3 +23,11 @@ runs:
       with:
         message-ok: No files contain trailing whitespace
         message-error: Contains trailing whitespace
+
+    - name: Commit
+      id: commit
+      if: ${{inputs.commit == 'true'}}
+      uses: stefanzweifel/git-auto-commit-action@v6
+      with:
+        file_pattern: ":!.github/"
+        commit_message: Fix trailing whitespace

--- a/.github/actions/check-utf8/action.yml
+++ b/.github/actions/check-utf8/action.yml
@@ -1,10 +1,22 @@
+inputs:
+  commit:
+    type: boolean
+    required: false
+    default: false
+
+outputs:
+  commit-hash:
+    value: ${{steps.commit.outputs.commit_hash || github.ref}}
+
 runs:
   using: composite
 
   steps:
     - name: Install
-      shell: bash
-      run: sudo apt-get install dos2unix recode
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: recode
+        version: 1.0
 
     - name: UTF-8 Encoding
       shell: bash
@@ -17,3 +29,12 @@ runs:
       with:
         message-ok: All files are UTF-8 encoded
         message-error: Not UTF-8 encoded
+
+    - name: Commit
+      id: commit
+      if: ${{inputs.commit}}
+      uses: stefanzweifel/git-auto-commit-action@v6
+      with:
+        file_pattern: ":!.github/"
+        commit_message: Fix UTF-8 encoding
+

--- a/.github/actions/pack-binaries/action.yml
+++ b/.github/actions/pack-binaries/action.yml
@@ -2,7 +2,7 @@ inputs:
   configure-preset:
     required: false
     type: string
-    
+
   build-preset:
     required: false
     type: string

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - uses: actions/upload-artifact@v4.6.0
-      
+
       env:
         configure-preset: ${{inputs.configure-preset || env.configure-preset}}
 

--- a/.github/workflows/anomaly-development.yml
+++ b/.github/workflows/anomaly-development.yml
@@ -27,7 +27,7 @@ jobs:
       configure-preset-gnu: ${{vars.CONFIGURE_PRESET_GNU || 'System.GNU'}}
       build-preset: ${{vars.BUILD_PRESET || 'Verified'}}
       target: ${{vars.TARGET || 'Anomaly.DX11'}}
-  
+
   # Compilation subcategory
   compile:
     name: Compile
@@ -60,13 +60,13 @@ jobs:
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Binary
       uses: ./.github/actions/cmake
-    
+
     - name: Upload Binary
       uses: ./.github/actions/upload-binary
-    
+
     - name: Upload PDB
       uses: ./.github/actions/upload-pdb
 
@@ -87,13 +87,13 @@ jobs:
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Binary
       uses: ./.github/actions/cmake
-    
+
     - name: Upload Binary
       uses: ./.github/actions/upload-binary
-    
+
     - name: Upload PDB
       uses: ./.github/actions/upload-pdb
 
@@ -116,16 +116,16 @@ jobs:
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Binary
       uses: ./.github/actions/cmake
-    
+
     - name: Upload Binary
       uses: ./.github/actions/upload-binary
-    
+
     - name: Upload PDB
       uses: ./.github/actions/upload-pdb
-  
+
   # Packing subcategory
   pack:
     name: Pack
@@ -144,20 +144,20 @@ jobs:
       configure-preset: 'MSVS.MSVC.Ninja.AVX'
       build-preset: 'Verified'
       target: 'Gamedata'
-      
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Gamedata
       uses: ./.github/actions/build-gamedata
-    
+
     - name: Upload Gamedata
       uses: ./.github/actions/upload-gamedata
-  
+
   # Checking subcategory
   check:
     name: Check

--- a/.github/workflows/anomaly-pull-request.yml
+++ b/.github/workflows/anomaly-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
     environment: Anomaly.PullRequest
     steps:
       - run: echo "Building Anomaly"
-  
+
   # Compilation subcategory
   compile:
     name: Compile
@@ -66,13 +66,13 @@ jobs:
 
     - name: Build Binary
       uses: ./.github/actions/cmake
-    
+
     - name: Upload Binary
       uses: ./.github/actions/upload-binary
-    
+
     - name: Upload PDB
       uses: ./.github/actions/upload-pdb
-  
+
   # Packing subcategory
   pack:
     name: Pack
@@ -85,27 +85,27 @@ jobs:
   gamedata:
     name: Gamedata
     needs: pack
-    
+
     runs-on: windows-latest
 
     env:
       configure-preset: 'MSVS.MSVC.Ninja.AVX'
       build-preset: 'RelWithDebInfo'
       target: 'Gamedata'
-      
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Gamedata
       uses: ./.github/actions/build-gamedata
-    
+
     - name: Upload Gamedata
       uses: ./.github/actions/upload-gamedata
-  
+
   # Checking subcategory
   check:
     name: Check

--- a/.github/workflows/anomaly-release.yml
+++ b/.github/workflows/anomaly-release.yml
@@ -24,7 +24,7 @@ jobs:
     environment: Anomaly.Release
     steps:
       - run: echo "Building Anomaly"
-  
+
   # Compilation subcategory
   compile:
     name: Compile
@@ -69,13 +69,13 @@ jobs:
 
     - name: Build Binary
       uses: ./.github/actions/cmake
-    
+
     - name: Upload Binary
       uses: ./.github/actions/upload-binary
-    
+
     - name: Upload PDB
       uses: ./.github/actions/upload-pdb
-  
+
   # Packing subcategory
   pack:
     name: Pack
@@ -94,20 +94,20 @@ jobs:
       configure-preset: 'MSVS.MSVC.Ninja.AVX'
       build-preset: 'RelWithDebInfo'
       target: 'Gamedata'
-      
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Configure build environment
       uses: ./.github/actions/setup-env
-    
+
     - name: Build Gamedata
       uses: ./.github/actions/build-gamedata
-    
+
     - name: Upload Gamedata
       uses: ./.github/actions/upload-gamedata
-  
+
   # Checking subcategory
   check:
     name: Check
@@ -199,17 +199,17 @@ jobs:
       build-preset: RelWithDebInfo
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Get Datetime
       id: datetime
       run: echo "::set-output name=today::$(date +'%-Y.%-m.%-d')"
-        
+
     # Use the output from the `datetime` step
     - name: Print Version
       env:
         VERSION: "${{steps.datetime.outputs.today}}"
       run: echo "VERSION ${{steps.datetime.outputs.today}}"
-    
+
     - name: Download Artifacts
       uses: ./.github/actions/download-artifacts
 
@@ -220,7 +220,7 @@ jobs:
 
     - name: Pack PDBs
       uses: ./.github/actions/pack-pdbs
-    
+
     - name: Publish
       uses: ./.github/actions/publish-release
       with:

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,0 +1,96 @@
+name: Format Code
+
+on:
+  workflow_dispatch:
+
+# Cancel previous run if re-triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: write-all
+
+jobs:
+  check-utf8:
+    name: UTF-8 Encoding
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.ref}}
+
+    - name: UTF-8
+      uses: ./.github/actions/check-utf8
+      with:
+        commit: true
+
+  check-mixed-tabs:
+    name: Mixed Spaces & Tabs
+    needs: check-utf8
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.ref}}
+
+    - uses: ./.github/actions/check-mixed-tabs
+      with:
+        commit: true
+
+  check-trailing-whitespace:
+    name: Trailing Whitespace
+    needs: check-mixed-tabs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.ref}}
+
+    - name: Trailing Whitespace
+      uses: ./.github/actions/check-trailing-whitespace
+      with:
+        commit: true
+
+  check-line-endings:
+    name: Line Endings
+    needs: check-trailing-whitespace
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.ref}}
+
+    - name: Line Endings
+      uses: ./.github/actions/check-line-endings
+      with:
+        commit: true
+
+
+  check-terminating-newline:
+    name: Terminating Newlines
+    needs: check-line-endings
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.ref}}
+
+    - name: Newline Endings
+      uses: ./.github/actions/check-terminating-newline
+      with:
+        commit: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# exclude all dot files except .gitignore
+# exclude all dot files except those we need to track
 .*
 !.gitignore
 !.gitattributes
 !.github
+!.clang-format
 
 # exclude binaries and temporary files
 _build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,26 +28,10 @@ message(STATUS)
 message(STATUS "S.T.A.L.K.E.R. Anomaly")
 message(STATUS "      Version: ${TODAY_DOTS}")
 
+# Glob top-level CMake directory into Build target for developer convenience
 add_custom_target(Build)
-target_sources(Build
-  PRIVATE
-  CMake/Today.cmake
-  CMake/XRay.AVX.cmake
-  CMake/XRay.cmake
-  CMake/XRay.Compiler.cmake
-  CMake/XRay.Compiler.Definitions.cmake
-  CMake/XRay.Compiler.MSVC.cmake
-  CMake/XRay.Compiler.Clang.cmake
-  CMake/XRay.Compiler.Unsupported.cmake
-  CMake/XRay.Configs.cmake
-  CMake/XRay.Folders.cmake
-  CMake/XRay.Git.cmake
-  CMake/XRay.Linker.cmake
-  CMake/XRay.Modules.cmake
-  CMake/XRay.Paths.cmake
-  CMake/XRay.Platform.cmake
-  CMake/XRay.Win32.cmake
-)
+file(GLOB_RECURSE SOURCES_GAMEDATA CMake/*)
+target_sources(Build PRIVATE ${SOURCES_GAMEDATA})
 
 # Hand off to our XRay entrypoint
 include(XRay)

--- a/gamedata/CMakeLists.txt
+++ b/gamedata/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_custom_target(Gamedata)
 
+# Get a native version of our gamedata path
 cmake_path(
   CONVERT ${CMAKE_SOURCE_DIR}/gamedata
   TO_NATIVE_PATH_LIST XRAY_GAMEDATA
@@ -9,6 +10,7 @@ set(
   CACHE PATH "X-Ray Gamedata"
 )
 
+# Generated gamedata file
 set(
   XRAY_GAMEDATA_SOURCE_NAME gamedata.db0
   CACHE PATH "X-Ray Gamedata DB Source Name"
@@ -18,6 +20,7 @@ set(
   ${CMAKE_SOURCE_DIR}/${XRAY_GAMEDATA_SOURCE_NAME}
 )
 
+# Final gamedata file
 set(
   XRAY_GAMEDATA_BINARY_NAME 00_modded_exes_gamedata.db0
   CACHE PATH "X-Ray Gamedata DB Binary Name"
@@ -27,6 +30,7 @@ set(
   ${CMAKE_CURRENT_BINARY_DIR}/${XRAY_GAMEDATA_BINARY_NAME}
 )
 
+# Add a custom command to generate our final .db0 file
 add_custom_command(
   OUTPUT ${XRAY_GAMEDATA_BINARY_DB}
   COMMAND ${XRAY_COMPRESSOR}
@@ -44,147 +48,8 @@ add_custom_command(
   VERBATIM
 )
 
-target_sources(Gamedata
-  PRIVATE
-  ${XRAY_GAMEDATA_BINARY_NAME}
-)
+target_sources(Gamedata PRIVATE ${XRAY_GAMEDATA_BINARY_NAME})
 
-target_sources(Gamedata
-  PRIVATE
-  configs/unlocalizers/unlocalizer_modded_exes_axr_trade_manager.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_global.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_item_device_script_fixes.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_item_weapon.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_pda.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_utils_item.ltx
-  configs/unlocalizers/unlocalizer_modded_exes_xrs_facer_script_fixes.ltx
-  configs/unlocalizers/unlocalizer_test.ltx
-  configs/unlocalizers/unlocalizer_ui_options.ltx
-)
-
-target_sources(Gamedata
-  PRIVATE
-  configs/ui/ui_ctrl_hdr.xml
-  configs/ui/ui_ctrl_hdr_16.xml
-)
-
-target_sources(Gamedata
-  PRIVATE
-  configs/text/eng/ui_mm_modded_exes.xml
-)
-
-target_sources(Gamedata
-  PRIVATE
-  configs/text/rus/ui_mm_modded_exes.xml
-)
-
-target_sources(Gamedata
-  PRIVATE
-  configs/mod_script_dxml.ltx
-  configs/mod_system_base_hud.ltx
-  configs/mod_system_flashlight_definition.ltx
-  configs/mod_system_knife.ltx
-  configs/mod_system_shader_crosshair.ltx
-  configs/patrol_paths.ltx
-)
-
-target_sources(Gamedata
-  PRIVATE
-  materials/material_pairs.ltx
-  materials/materials.ltx
-)
-
-target_sources(Gamedata
-  PRIVATE
-  scripts/_g_patches.script
-  scripts/aaa_sound_object_patch.script
-  scripts/aaaa_script_fixes_mp.script
-  scripts/axr_beh_patches.script
-  scripts/callbacks_gameobject.script
-  scripts/class_registrator_modded_exes.script
-  scripts/dxml_core.script
-  scripts/fakelens.script
-  scripts/imgui_helper.script
-  scripts/ltx_help_ex.script
-  scripts/lua_help_ex.script
-  scripts/lua_help_imgui.script
-  scripts/modxml_inject_keybinds.script
-  scripts/modxml_test.script
-  scripts/options_builder.script
-  scripts/options_modded_exes.script
-  scripts/options_modded_exes_3d_ballistics.script
-  scripts/options_modded_exes_3d_scopes.script
-  scripts/options_modded_exes_aim.script
-  scripts/options_modded_exes_camera.script
-  scripts/options_modded_exes_control.script
-  scripts/options_modded_exes_crash_saves.script
-  scripts/options_modded_exes_crosshair.script
-  scripts/options_modded_exes_debug.script
-  scripts/options_modded_exes_doppler.script
-  scripts/options_modded_exes_first_person_death.script
-  scripts/options_modded_exes_gameplay.script
-  scripts/options_modded_exes_hdr10.script
-  scripts/options_modded_exes_keyboard.script
-  scripts/options_modded_exes_logging.script
-  scripts/options_modded_exes_optimizations.script
-  scripts/options_modded_exes_monsters.script
-  scripts/options_modded_exes_mouse.script
-  scripts/options_modded_exes_particles.script
-  scripts/options_modded_exes_pda.script
-  scripts/options_modded_exes_saves.script
-  scripts/options_modded_exes_sound.script
-  scripts/options_modded_exes_ui_hud.script
-  scripts/options_modded_exes_visual.script
-  scripts/options_modded_exes_wallmarks.script
-  scripts/scopeRadii.script
-  scripts/slaxml.script
-  scripts/true_first_person_death.script
-  scripts/ui_options_modded_exes.script
-)
-
-target_sources(Gamedata
-  PRIVATE
-  shaders/r2/combine_2_naa.ps
-  shaders/r2/fakescope.ps
-  shaders/r2/heatvision.ps
-)
-
-target_sources(Gamedata
-  PRIVATE
-  shaders/r3/combine_2_naa.ps
-  shaders/r3/common_functions.h
-  shaders/r3/deffer_tree_branch_bump_d-hq.vs
-  shaders/r3/deffer_tree_branch_bump-hq.vs
-  shaders/r3/deffer_tree_branch_flat.vs
-  shaders/r3/editor.vs
-  shaders/r3/effects_sun.ps
-  shaders/r3/effects_sun.s
-  shaders/r3/fakescope.ps
-  shaders/r3/hdr10.h
-  shaders/r3/hdr10_bloom.h
-  shaders/r3/hdr10_bloom_blur.ps
-  shaders/r3/hdr10_bloom_downsample.ps
-  shaders/r3/hdr10_bloom_upsample.ps
-  shaders/r3/hdr10_lens_flare.h
-  shaders/r3/hdr10_lens_flare_blur.ps
-  shaders/r3/hdr10_lens_flare_downsample.ps
-  shaders/r3/hdr10_lens_flare_fgen.ps
-  shaders/r3/hdr10_lens_flare_upsample.ps
-  shaders/r3/hud_cursor.s
-  shaders/r3/hud_default.ps
-  shaders/r3/hud_default.s
-  shaders/r3/hud_font.ps
-  shaders/r3/models_selflight_det.s
-  shaders/r3/night_vision.h
-  shaders/r3/postprocess.ps
-  shaders/r3/postprocess_cm.ps
-  shaders/r3/simple_color.ps
-  shaders/r3/yuv2rgb.ps
-)
-
-target_sources(Gamedata
-  PRIVATE
-  textures/ui/cursor_dot.dds
-  textures/ui/cursor_cross.dds
-  textures/ui/cursor_plus.dds
-)
+# Glob source files so they display in IDEs
+file(GLOB_RECURSE SOURCES_GAMEDATA *)
+target_sources(Gamedata PRIVATE ${SOURCES_GAMEDATA})


### PR DESCRIPTION
#### Summary
- Glob `Gamedata` and `Build` sources to cut down on project specification busywork
- Add boolean param for warnings vs errors to CI checks, defaulting to warnings
- Implement triggerable `Format Code` workflow

I had a go at adapting OXR's `clang-format` handling (relevant: https://github.com/OpenXRay/xray-16/issues/1474#issuecomment-1783819230,) but concluded that it's not worth it, since they apply it only to new commits, and we don't have any of those; if Anomaly code were to be migrated, it'd be subject to fixup anyway.

(They also use a bleeding-edge version of `clang-format` that isn't available on our cached LLVM installer, which complicates matters vis-a-vis direct compatibility.)

So, our triggerable workflow automates the fundamental stuff that they do unconditionally - UTF-8, line endings, terminating newlines etc. - which, if kept on top of, should go some way to easing future efforts like https://github.com/OpenXRay/xray-16/issues/1373

On that note, I could also configure these jobs to run as part of the Release pipeline; since releases occur often and force contributors to merge the main branch, it seems like a good candidate for sneaking in automatic fix-ups without interfering with moment-to-moment development.

[Example post-fixup branch](https://github.com/ProfLander/xray-monolith/commits/refs/heads/cmake-janitorial-applied/) - not as bad as expected, sweeping changes are mainly isolated to the top and bottom of files.

Relevant workflow runs:
[Format Code](https://github.com/ProfLander/xray-monolith/actions/runs/16384301341)
[Post-Format Check Passes](https://github.com/ProfLander/xray-monolith/actions/runs/16384358168)