### PR TITLE
Callback for GAME path build fail

### DIFF
--- a/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/scripts/callbacks_gameobject.script
@@ -447,6 +447,15 @@ function on_imgui_render(name)
 	SendScriptCallback("imgui_on_render", name)
 end
 
+--on GAME path build fail callback (can be used when npc tries to get to currently unavailable smart), 
+--can be used to intercept and redirect squad to available smart, also can suppress error message with flags.ret_value = false
+AddScriptCallback("npc_on_game_path_build_fail")
+_G.CAI_Stalker__PathBuildFailCallback = function(npc)
+	local flags = {ret_value = true}
+	SendScriptCallback("npc_on_game_path_build_fail",npc,flags)
+	return flags.ret_value
+end
+
 -- Improve NPCs pathfinding by reducing actual anomaly damage radius
 -- Works only when npc:get_enable_anomalies_pathfinding() == true or ai_die_in_anomalies cvar is 1
 function is_outside_damage_radius(zone, obj)

--- a/src/xrGame/movement_manager_game.cpp
+++ b/src/xrGame/movement_manager_game.cpp
@@ -22,6 +22,7 @@
 #include "level_path_builder.h"
 #include "detail_path_builder.h"
 #include "mt_config.h"
+#include "../../script_game_object.h"
 
 void CMovementManager::show_game_path_info()
 {
@@ -91,7 +92,13 @@ void CMovementManager::process_game_path()
 
 				if (game_path().failed())
 				{
-					show_game_path_info();
+					::luabind::functor<bool> funct;
+					if (ai().script_engine().functor("_G.CAI_Stalker__PathBuildFailCallback", funct))
+					{
+						if (funct(object().lua_game_object()))
+							show_game_path_info();
+					}
+					
 					break;
 				}
 


### PR DESCRIPTION
Once squad tries to go on unavailable smart (disabled gvids, etc), it stucks with "Cannot build GAME path" error. This callback allows redirecting squads to other smarts.