### PR TITLE
Gasmask performance edit and ltx aim fov

### DIFF
--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
@@ -270,7 +270,10 @@ void CRenderTarget::phase_combine()
 	if(ps_r2_mask_control.x > 0)
 	{
 		phase_gasmask_dudv();
-		phase_gasmask_drops();
+		if (ps_r2_drops_control.x > 0)
+		{
+			phase_gasmask_drops();
+		}
 	}
 	
 	if(ps_r2_nightvision > 0)

--- a/src/Layers/xrRenderPC_R3/r3_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_rendertarget_phase_combine.cpp
@@ -391,7 +391,10 @@ void CRenderTarget::phase_combine()
 	if(ps_r2_mask_control.x > 0)
 	{
 		phase_gasmask_dudv();
-		phase_gasmask_drops();
+		if (ps_r2_drops_control.x > 0)
+		{
+			phase_gasmask_drops();
+		}
 	}
 	
 	if(ps_r2_nightvision > 0)

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -548,7 +548,10 @@ void CRenderTarget::phase_combine()
 	if(ps_r2_mask_control.x > 0)
 	{
 		phase_gasmask_dudv();
-		phase_gasmask_drops();
+		if (ps_r2_drops_control.x > 0)
+		{
+			phase_gasmask_drops();
+		}
 	}
 	
 	if(ps_r2_nightvision > 0)

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -51,6 +51,7 @@ extern float scope_radius;
 Flags32 zoomFlags = {};
 extern float n_zoom_step_count;
 float sens_multiple = 1.0f;
+float hud_fov_aim_multiplier = 1.0f;
 
 extern int g_nearwall;
 
@@ -505,17 +506,25 @@ void CWeapon::SetZoomType(u8 new_zoom_type)
 
 extern float g_ironsights_factor;
 
-inline float smoothstep(float x)
+// new easing for hud_fov_aim_factor
+inline float easeInQuart(float x)
 {
-	return x * x * (3 - 2 * x);
+	return x * x * x * x;
+}
+
+// new easing for hud_fov_aim_factor
+inline float easeOutQuart(float x)
+{
+	return 1 - pow(1 - x, 4);
 }
 
 float CWeapon::GetTargetHudFov()
 {
 	float base = inherited::GetTargetHudFov();
 
-	float x = smoothstep(m_zoom_params.m_fZoomRotationFactor);
-	float factor = hud_fov_aim_factor > 0 ? hud_fov_aim_factor : 1;
+	// check aim state to determine easing
+	float x = IsZoomed() ? easeOutQuart(m_zoom_params.m_fZoomRotationFactor) : easeInQuart(m_zoom_params.m_fZoomRotationFactor);
+	float factor = hud_fov_aim_factor > 0 ? hud_fov_aim_factor * hud_fov_aim_multiplier : 1; // ltx hud_fov_aim_factor
 	base = (base * factor) * x + base * (1 - x);
 
 	/*
@@ -870,6 +879,7 @@ void CWeapon::Load(LPCSTR section)
 	m_bCanBeLowered = READ_IF_EXISTS(pSettings, r_bool, section, "can_be_lowered", false);
 
 	m_fSafeModeRotateTime = READ_IF_EXISTS(pSettings, r_float, section, "weapon_lower_speed", 1.f);
+	hud_fov_aim_multiplier = READ_IF_EXISTS(pSettings, r_float, section, "hud_fov_aim_factor", 1.f);
 
 	UpdateUIScope();
 


### PR DESCRIPTION
Skip rendering gasmask raindrops when its not raining.
Added hud_fov_aim_factor to ltx with a better easing, doesnt do anything if its not present in the config.