### PR TITLE
Lua export: CUIDialogWnd::AllowWorkInPause and render_device:pause_ex

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -141,6 +141,15 @@
 		void RemoveColorAnimation()
     }
 
+    class CUIDialogWnd : CUIWindow {
+        void AllowWorkInPause(bool state)
+    }
+
+    class render_device {
+        // Switch the pause, with sound emitters and without hint on screen
+        void pause_ex(bool state)
+    }
+
     class particles_object {
         void set_hud_mode(bool hud_mode)
     }

--- a/src/xrGame/script_render_device_script.cpp
+++ b/src/xrGame/script_render_device_script.cpp
@@ -21,6 +21,14 @@ void set_device_paused(CRenderDevice* d, bool b)
 	Device.Pause(b, TRUE, FALSE, "set_device_paused_script");
 }
 
+extern ENGINE_API BOOL bShowPauseString;
+
+void set_device_paused_ex(CRenderDevice* d, bool b)
+{
+	Device.Pause(b, TRUE, TRUE, "set_device_paused_ex_script");
+	bShowPauseString = FALSE;
+}
+
 extern ENGINE_API BOOL g_appLoaded;
 
 bool is_app_ready()
@@ -64,7 +72,8 @@ void CScriptRenderDevice::script_register(lua_State* L)
 		.def_readonly("precache_frame", &CRenderDevice::dwPrecacheFrame)
 		.def_readonly("frame", &CRenderDevice::dwFrame)
 		.def("is_paused", &is_device_paused)
-		.def("pause", &set_device_paused),
+		.def("pause", &set_device_paused)
+		.def("pause_ex", &set_device_paused_ex),
 		def("app_ready", &is_app_ready)
 	];
 }

--- a/src/xrGame/ui/UIDialogWnd.h
+++ b/src/xrGame/ui/UIDialogWnd.h
@@ -28,6 +28,7 @@ public:
 	void AllowMovement(bool b) { m_bAllowMovement = b; }
 	void AllowCursor(bool b) { m_bNeedCursor = b; }
 	void AllowCenterCursor(bool b) { m_bNeedCenterCursor = b; }
+	void AllowWorkInPause(bool b) { m_bWorkInPause = b; }
 	virtual bool StopAnyMove() { return !m_bAllowMovement; }
 	virtual bool NeedCursor() const { return m_bNeedCursor; }
 	virtual bool NeedCenterCursor() const { return m_bNeedCenterCursor; }

--- a/src/xrGame/ui/UIWindow_script.cpp
+++ b/src/xrGame/ui/UIWindow_script.cpp
@@ -162,7 +162,8 @@ void CUIWindow::script_register(lua_State* L)
 		.def("GetHolder", &CUIDialogWnd::GetHolder)
 		.def("AllowMovement", &CUIDialogWnd::AllowMovement)
 		.def("AllowCursor", &CUIDialogWnd::AllowCursor)
-		.def("AllowCenterCursor", &CUIDialogWnd::AllowCenterCursor),
+		.def("AllowCenterCursor", &CUIDialogWnd::AllowCenterCursor)
+		.def("AllowWorkInPause", &CUIDialogWnd::AllowWorkInPause),
 
 		class_<CUIFrameWindow, CUIWindow>("CUIFrameWindow")
 		.def(constructor<>())


### PR DESCRIPTION
This change will finally allow dialog windows to work while pauses, like the main menu.
Exported  **pause_ex** to the **render_device** class with hide on-screen hint and pause sound emitters.

Tested with my mod, which did the same thing, but through a hack with opening the main menu via console command and immediately hiding it.