### PR TITLE
Add fail-safe in CGameObject::net_Spawn to try to update a missing model

### DIFF
--- a/src/Layers/xrRender/ModelPool.cpp
+++ b/src/Layers/xrRender/ModelPool.cpp
@@ -432,6 +432,19 @@ void CModelPool::Prefetch_One(LPCSTR N, bool assert)
 		Delete(V,FALSE);
 }
 
+bool CModelPool::Exists(LPCSTR N)
+{
+	dxRender_Visual* V = Create(N, 0, false);
+	if (V) {
+		Delete(V, FALSE);
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
 dxRender_Visual* CModelPool::CreatePE(PS::CPEDef* source)
 {
 	PS::CParticleEffect* V = (PS::CParticleEffect*)Instance_Create(MT_PARTICLE_EFFECT);

--- a/src/Layers/xrRender/ModelPool.h
+++ b/src/Layers/xrRender/ModelPool.h
@@ -76,6 +76,7 @@ public:
 
 	void Prefetch();
 	void Prefetch_One(LPCSTR N, bool assert = true);
+	bool Exists(LPCSTR N);
 	void ClearPool(BOOL b_complete);
 
 	void dump();

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -232,6 +232,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name, bool assert) { Models->Prefetch_One(name, assert); }
 void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
+bool CRender::models_Exists(LPCSTR name) { return Models->Exists(name); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -204,6 +204,7 @@ public:
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name, bool assert = true);
 	virtual void models_Clear(BOOL b_complete);
+	virtual bool models_Exists(LPCSTR name);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R2/r2.cpp
+++ b/src/Layers/xrRenderPC_R2/r2.cpp
@@ -526,6 +526,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name, bool assert) { Models->Prefetch_One(name, assert); }
 void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
+bool CRender::models_Exists(LPCSTR name) { return Models->Exists(name); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R2/r2.h
+++ b/src/Layers/xrRenderPC_R2/r2.h
@@ -302,6 +302,7 @@ public:
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name, bool assert = true);
 	virtual void models_Clear(BOOL b_complete);
+	virtual bool models_Exists(LPCSTR name);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R3/r3.cpp
+++ b/src/Layers/xrRenderPC_R3/r3.cpp
@@ -668,6 +668,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name, bool assert) { Models->Prefetch_One(name, assert); }
 void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
+bool CRender::models_Exists(LPCSTR name) { return Models->Exists(name); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R3/r3.h
+++ b/src/Layers/xrRenderPC_R3/r3.h
@@ -349,6 +349,7 @@ public:
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name, bool assert = true);
 	virtual void models_Clear(BOOL b_complete);
+	virtual bool models_Exists(LPCSTR name);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -749,6 +749,7 @@ IRenderVisual* CRender::model_CreateParticles(LPCSTR name)
 void CRender::models_Prefetch() { Models->Prefetch(); }
 void CRender::models_PrefetchOne(LPCSTR name, bool assert) { Models->Prefetch_One(name, assert); }
 void CRender::models_Clear(BOOL b_complete) { Models->ClearPool(b_complete); }
+bool CRender::models_Exists(LPCSTR name) { return Models->Exists(name); }
 
 ref_shader CRender::getShader(int id)
 {

--- a/src/Layers/xrRenderPC_R4/r4.h
+++ b/src/Layers/xrRenderPC_R4/r4.h
@@ -374,6 +374,7 @@ public:
 	virtual void models_Prefetch();
 	virtual void models_PrefetchOne(LPCSTR name, bool assert = true);
 	virtual void models_Clear(BOOL b_complete);
+	virtual bool models_Exists(LPCSTR name);
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V);

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -329,7 +329,8 @@ public:
 	virtual void model_Logging(BOOL bEnable) = 0;
 	virtual void models_Prefetch() = 0;
 	virtual void models_PrefetchOne(LPCSTR name, bool assert = true) = 0;
-	virtual void models_Clear(BOOL b_complete) = 0;
+	virtual void models_Clear(BOOL b_complete) = 0; 
+	virtual bool models_Exists(LPCSTR name) = 0;
 
 	// Occlusion culling
 	virtual BOOL occ_visible(vis_data& V) = 0;

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -277,7 +277,19 @@ BOOL CGameObject::net_Spawn(CSE_Abstract* DC)
 	const CSE_Visual* visual = smart_cast<const CSE_Visual*>(E);
 	if (visual)
 	{
-		cNameVisual_set(visual_name(E));
+		auto visualName = visual_name(E);
+
+		// If model doesn't exist, and object config has "visual" field, try to update the model
+		if(!Render->models_Exists(visualName) && pSettings->line_exist(cNameSect(), "visual")) {
+			auto visualFromSec = pSettings->r_string(cNameSect(), "visual");
+			Msg("~WARNING : Failed to load '%s', falling back to '%s'", visualName, visualFromSec);
+			cNameVisual_set(visualFromSec);
+		}
+		// Otherwise... proceed as normal (will CTD if model doesn't exist)
+		else {
+			cNameVisual_set(visualName);
+		}
+
 		if (visual->flags.test(CSE_Visual::flObstacle))
 		{
 			ISpatial* self = smart_cast<ISpatial*>(this);


### PR DESCRIPTION
Hello,

It sometimes happen that modders must move `.ogf` meshes around, whether it'd be to resolve conflicts, or after they find out who ever coded `death_manager.script` thought it was a good idea to hard-code the fact that NPC visuals must be exactly 2 folder deep inside `gamedata\meshes`.

The issue is, once an object has spawned, its visual is cached in its server object. When the object is loaded after the path to its visual has changed, the game will still try to make it load the old visual, and unsurprisingly, will fail causing a crash to desktop.

This PR does the following : when confronted with this scenario (where the mesh cannot be found), we try to read the property `visual` from the object's config and load it instead. If the original mesh exists, or if the object's config does not have this property, the code behaves as before this PR.