### PR TITLE
Dynamic Devices turn on/off

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -428,7 +428,7 @@
         function get_artefact_additional_inventory_weight()
         function set_artefact_additional_inventory_weight(float)
 
-	/Devices
+	// Devices
 	function set_device_enabled(bool)
 	function is_device_enabled()
 

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -428,6 +428,10 @@
         function get_artefact_additional_inventory_weight()
         function set_artefact_additional_inventory_weight(float)
 
+	/Devices
+	function set_device_enabled(bool)
+	function is_device_enabled()
+
         // Bones
         u16 get_bone_id(string)
         u16 get_bone_id(string, bool bHud)

--- a/src/xrGame/CustomDevice.cpp
+++ b/src/xrGame/CustomDevice.cpp
@@ -15,6 +15,7 @@ CCustomDevice::CCustomDevice()
 	m_bZoomed = false;
 	m_fZoomfactor = 0.f;
 	m_bOldZoom = false;
+	m_CustomDeviceEnabled = true;
 }
 
 CCustomDevice::~CCustomDevice()
@@ -133,7 +134,7 @@ void CCustomDevice::OnStateSwitch(u32 S, u32 oldState)
 	{
 		g_player_hud->attach_item(this);
 
-		if (!IsUsingCondition() || (IsUsingCondition() && GetCondition() >= m_fLowestBatteryCharge))
+		if (!IsUsingCondition() || (m_CustomDeviceEnabled && IsUsingCondition() && GetCondition() >= m_fLowestBatteryCharge))
 			TurnDeviceInternal(true);
 
 		m_sounds.PlaySound("sndShow", Fvector().set(0, 0, 0), this, true, false);
@@ -464,9 +465,9 @@ void CCustomDevice::UpdateCL()
 
 	if (IsUsingCondition())
 	{
-		if (m_bWorking && GetCondition() < m_fLowestBatteryCharge)
+		if (m_bWorking && (!m_CustomDeviceEnabled || GetCondition() < m_fLowestBatteryCharge))
 			TurnDeviceInternal(false);
-		else if (!m_bWorking && (GetState() == eIdle || GetState() == eIdleZoom) && GetCondition() >= m_fLowestBatteryCharge)
+		else if (m_CustomDeviceEnabled && !m_bWorking && (GetState() == eIdle || m_CustomDeviceEnabled && GetState() == eIdleZoom) && GetCondition() >= m_fLowestBatteryCharge)
 			TurnDeviceInternal(true);
 	}
 

--- a/src/xrGame/CustomDevice.h
+++ b/src/xrGame/CustomDevice.h
@@ -57,6 +57,7 @@ public:
 	virtual bool render_item_3d_ui_query();
 
 	bool m_bZoomed;
+	bool m_CustomDeviceEnabled;
 	float m_fZoomfactor;
 	Fvector m_hud_offset[2];
 protected:

--- a/src/xrGame/PDA.cpp
+++ b/src/xrGame/PDA.cpp
@@ -32,6 +32,7 @@ CPda::CPda(void)
 	m_fLR_InertiaFactor = 0.f;
 	m_fUD_InertiaFactor = 0.f;
 	m_bNoticedEmptyBattery = false;
+	m_PdaEnabled = true;
 }
 
 CPda::~CPda() {}

--- a/src/xrGame/PDA.h
+++ b/src/xrGame/PDA.h
@@ -95,7 +95,7 @@ protected:
 	float m_fLR_MovingFactor;
 	float m_fLR_InertiaFactor;
 	float m_fUD_InertiaFactor;
-	bool hasEnoughBatteryPower(){ return (!IsUsingCondition() || (IsUsingCondition() && GetCondition() > m_fLowestBatteryCharge)); }
+	bool hasEnoughBatteryPower(){ return (!IsUsingCondition() || (m_PdaEnabled && IsUsingCondition() && GetCondition() > m_fLowestBatteryCharge)); }
 	static void _BCL JoystickCallback(CBoneInstance* B);
 	bool m_bNoticedEmptyBattery;
 	bool m_LastMBZoom;
@@ -127,6 +127,7 @@ public:
 	eDeferredEnableState m_eDeferredEnable;
 	bool m_bPowerSaving;
 	float m_psy_factor;
+	bool m_PdaEnabled;
 	float m_thumb_rot[2];
 	float m_nearwall_zoomed_range;
 };

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -48,6 +48,7 @@
 #include "Pda.h"
 #include "player_hud.h"
 #include "script_attachment_manager.h"
+#include "CustomDevice.h"
 
 class CScriptBinderObject;
 
@@ -779,6 +780,38 @@ void CScriptGameObject::SetPsyFactor(float val)
 		return;
 	}
 	pda->m_psy_factor = val;
+}
+
+// Added by Ncenka - allow turn on/off devices
+bool CScriptGameObject::IsDeviceEnabled() const
+{
+	CPda* pda = smart_cast<CPda*>(m_game_object);
+	if (pda)
+		return pda->m_PdaEnabled;
+
+	CCustomDevice* custom_device = smart_cast<CCustomDevice*>(m_game_object);
+	if (custom_device)
+		return custom_device->m_CustomDeviceEnabled;
+
+	return false;
+}
+
+// Added by Ncenka - allow turn on/off devices
+void CScriptGameObject::SetDeviceEnabled(bool enabled)
+{
+	CPda* pda = smart_cast<CPda*>(m_game_object);
+	if (pda)
+	{
+		pda->m_PdaEnabled = enabled;
+		return;
+	}
+
+	CCustomDevice* custom_device = smart_cast<CCustomDevice*>(m_game_object);
+	if (custom_device)
+	{
+		custom_device->m_CustomDeviceEnabled = enabled;
+		return;
+	}
 }
 
 void CScriptGameObject::eat(CScriptGameObject* item)

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -198,6 +198,10 @@ public:
 	float GetPsyFactor() const;
 	void SetPsyFactor(float val);
 
+	// Added by Ncenka - allow turn on/off devices
+	_DECLARE_FUNCTION10(IsDeviceEnabled, bool);
+	_DECLARE_FUNCTION11(SetDeviceEnabled, void, bool);
+
 	// CEntity
 	_DECLARE_FUNCTION10(DeathTime, u32);
 	_DECLARE_FUNCTION10(MaxHealth, float);

--- a/src/xrGame/script_game_object_script2.cpp
+++ b/src/xrGame/script_game_object_script2.cpp
@@ -109,6 +109,11 @@ class_<CScriptGameObject>& script_register_game_object1(class_<CScriptGameObject
 		.def("power_critical", &CScriptGameObject::GetPowerCritical)
 		.def("psy_factor", &CScriptGameObject::GetPsyFactor)
 		.def("set_psy_factor", &CScriptGameObject::SetPsyFactor)
+
+		// Added by Ncenka - allow turn on/off devices
+		.def("is_device_enabled", &CScriptGameObject::IsDeviceEnabled)
+		.def("set_device_enabled", &CScriptGameObject::SetDeviceEnabled)
+		
 		.def("death_time", &CScriptGameObject::DeathTime)
 		//		.def("armor",						&CScriptGameObject::Armor)
 		.def("max_health", &CScriptGameObject::MaxHealth)


### PR DESCRIPTION
Allow to dynamically turn on/off devices by `set_device_enabled(bool)` and check if device is turned on/off by `is_device_enabled()`.