### PR TITLE
Reapply "Launchers: Cartridge Ammo + Trajectory and Reload Options" 

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -600,6 +600,23 @@
 		<text>Gameplay</text>
 	</string>
 
+	<!-- Gameplay General -->
+	<string id="ui_mm_menu_gameplay_general">
+		<text>General</text>
+	</string>
+	<string id="ui_mm_gameplay_general_modded_exes">
+		<text>General</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost">
+		<text>Progressive stamina cost (g_progressive_stamina_cost)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost_desc">
+		<text>Stamina will drain linearly with current weight instead of cutoff point</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_auto_reload">
+		<text>Automatically reload weapon when ammo is depleted (g_auto_reload)</text>
+	</string>
+
 	<!-- Aim -->
 	<string id="ui_mm_menu_aim">
 		<text>Aim</text>
@@ -670,6 +687,30 @@
 		<text>Item</text>
 	</string>
 
+	<!-- Launchers -->
+	<string id="ui_mm_menu_launchers">
+		<text>Launchers</text>
+	</string>
+	<string id="ui_mm_launchers_modded_exes">
+		<text>Launchers</text>
+	</string>
+	
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_fire_reloads_ubgl">
+		<text>Reload under-barrel launchers with fire input (g_fire_reloads_ubgl)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range">
+		<text>Apply launcher assist while unaimed (g_launcher_dynamic_range)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_zoom">
+		<text>Apply launcher assist while aimed (g_launcher_dynamic_range_zoom)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_mode">
+		<text>Target dynamic objects with launcher assist (g_launcher_dynamic_range_mode)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_max">
+		<text>Maximum launcher assist range (g_launcher_dynamic_range_max)</text>
+	</string>
+
 	<!-- First Person Death -->
 	<string id="ui_mm_menu_first_person_death">
 		<text>First Person Death</text>
@@ -686,20 +727,6 @@
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_first_person_death_first_person_death_direction_smoothing">
 		<text>FPD Camera Direction Change Smoothing (first_person_death_direction_smoothing)</text>
-	</string>
-
-	<!-- Gameplay General -->
-	<string id="ui_mm_menu_gameplay_general">
-		<text>General</text>
-	</string>
-	<string id="ui_mm_gameplay_general_modded_exes">
-		<text>General</text>
-	</string>
-	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost">
-		<text>Progressive stamina cost (g_progressive_stamina_cost)</text>
-	</string>
-	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost_desc">
-		<text>Stamina will drain linearly with current weight instead of cutoff point</text>
 	</string>
 
 	<!-- Stalkers -->

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -578,6 +578,23 @@
 		<text>Геймплей</text>
 	</string>
 
+	<!-- Gameplay General -->
+	<string id="ui_mm_menu_gameplay_general">
+		<text>Общие</text>
+	</string>
+	<string id="ui_mm_gameplay_general_modded_exes">
+		<text>Общие</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost">
+		<text>Прогрессивная затрата выносливости (g_progressive_stamina_cost)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost_desc">
+		<text>Выносливость будет уменьшаться линейно в зависимости от текущего веса, а не по пороговому значению</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_auto_reload">
+		<text>Автоматически перезаряжать оружие при исчерпании боеприпасов (g_auto_reload)</text>
+	</string>
+
 	<!-- Aim -->
 	<string id="ui_mm_menu_aim">
 		<text>Aim</text>
@@ -648,6 +665,30 @@
 		<text>Предмет</text>
 	</string>
 
+	<!-- Launchers -->
+	<string id="ui_mm_menu_launchers">
+		<text>Гранатометы</text>
+	</string>
+	<string id="ui_mm_launchers_modded_exes">
+		<text>Гранатометы</text>
+	</string>
+	
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_fire_reloads_ubgl">
+		<text>Перезаряжать подствольные гранатометы с помощью огня (g_fire_reloads_ubgl)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range">
+		<text>Применять помощь при запуске, когда не нацеливаешься (g_launcher_dynamic_range)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_zoom">
+		<text>Применяйте помощь прицеливания при наведении (g_launcher_dynamic_range_zoom)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_mode">
+		<text>Нацеливайтесь на динамические объекты с помощью системы помощи при запуске (g_launcher_dynamic_range_mode)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_launchers_g_launcher_dynamic_range_max">
+		<text>Максимальная дальность действия пусковой установки (g_launcher_dynamic_range_max)</text>
+	</string>
+
 	<!-- First Person Death -->
 	<string id="ui_mm_menu_first_person_death">
 		<text>Смерть от первого лица</text>
@@ -664,20 +705,6 @@
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_first_person_death_first_person_death_direction_smoothing">
 		<text>Гладкость смены направления камеры (first_person_death_direction_smoothing)</text>
-	</string>
-
-	<!-- Gameplay General -->
-	<string id="ui_mm_menu_gameplay_general">
-		<text>Общие</text>
-	</string>
-	<string id="ui_mm_gameplay_general_modded_exes">
-		<text>Общие</text>
-	</string>
-	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost">
-		<text>Прогрессивная затрата выносливости (g_progressive_stamina_cost)</text>
-	</string>
-	<string id="ui_mm_modded_exes_gameplay_gameplay_general_g_progressive_stamina_cost_desc">
-		<text>Выносливость будет уменьшаться линейно в зависимости от текущего веса, а не по пороговому значению</text>
 	</string>
 
 	<!-- Stalkers -->

--- a/gamedata/scripts/options_modded_exes_gameplay.script
+++ b/gamedata/scripts/options_modded_exes_gameplay.script
@@ -3,6 +3,7 @@
 local page_gameplay_general = options_modded_exes_gameplay_general.PAGE
 local page_aim = options_modded_exes_aim.PAGE
 local page_3d_ballistics = options_modded_exes_3d_ballistics.PAGE
+local page_launchers = options_modded_exes_launchers.PAGE
 local page_first_person_death = options_modded_exes_first_person_death.PAGE
 local page_stalkers = options_modded_exes_stalkers.PAGE
 local page_monsters = options_modded_exes_monsters.PAGE
@@ -16,6 +17,7 @@ GROUP = group {
 	page_gameplay_general,
 	page_aim,
 	page_3d_ballistics,
+	page_launchers,
 	page_first_person_death,
 	page_stalkers,
 	page_monsters,

--- a/gamedata/scripts/options_modded_exes_gameplay_general.script
+++ b/gamedata/scripts/options_modded_exes_gameplay_general.script
@@ -6,4 +6,5 @@ options_builder.import_into(this)
 PAGE = page {
 	{ id = "gameplay_general" },
 	list_bool { id = "g_progressive_stamina_cost" },
+	list_bool { id = "g_auto_reload" },
 }

--- a/gamedata/scripts/options_modded_exes_launchers.script
+++ b/gamedata/scripts/options_modded_exes_launchers.script
@@ -1,0 +1,17 @@
+--- Launchers options tree
+
+-- Import smart constructors
+options_builder.import_into(this)
+
+PAGE = page {
+	{ id = "launchers" },
+	list_bool { id = "g_fire_reloads_ubgl" },
+	list_bool { id = "g_launcher_dynamic_range" },
+	list_bool { id = "g_launcher_dynamic_range_zoom" },
+	list_bool { id = "g_launcher_dynamic_range_mode" },
+	track {
+		id = "g_launcher_dynamic_range_max",
+		def = 300,
+		step = 1,
+	},
+}

--- a/src/xrGame/RocketLauncher.h
+++ b/src/xrGame/RocketLauncher.h
@@ -10,6 +10,8 @@ class CGameObject;
 
 class CRocketLauncher
 {
+	friend class CWeaponGrenadeLauncher;
+
 public:
 	CRocketLauncher();
 	~CRocketLauncher();

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -49,6 +49,8 @@ struct SafemodeAnm
 class CWeapon : public CHudItemObject,
                 public CShootingObject
 {
+	friend class CWeaponGrenadeLauncher;
+	
 private:
 	typedef CHudItemObject inherited;
 

--- a/src/xrGame/WeaponGrenadeLauncher.cpp
+++ b/src/xrGame/WeaponGrenadeLauncher.cpp
@@ -134,11 +134,6 @@ void CWeaponGrenadeLauncher::LaunchGrenade(CWeapon* wpn)
 
     if (wpn->Local() && OnServer())
     {
-        VERIFY(wm->m_magazine.size());
-        wm->m_magazine.pop_back();
-        --wm->iAmmoElapsed;
-        VERIFY((u32) wpn->iAmmoElapsed == wm->m_magazine.size());
-
         NET_Packet P;
         wpn->u_EventGen(P, GE_LAUNCH_ROCKET, wpn->ID());
         P.w_u16(rl->getCurrentRocket()->ID());

--- a/src/xrGame/WeaponGrenadeLauncher.cpp
+++ b/src/xrGame/WeaponGrenadeLauncher.cpp
@@ -1,0 +1,147 @@
+#include "StdAfx.h"
+#include <utility>
+
+#include "WeaponGrenadeLauncher.h"
+#include "../xrPhysics/MathUtils.h"
+#include "Actor.h"
+#include "Level.h"
+#include "Entity.h"
+#include "Inventory.h"
+#include "InventoryOwner.h"
+#include "Weapon.h"
+#include "WeaponMagazined.h"
+#include "RocketLauncher.h"
+#include "ExplosiveRocket.h"
+#include "xrDebug.h"
+
+BOOL g_launcher_dynamic_range = FALSE;
+BOOL g_launcher_dynamic_range_zoom = TRUE;
+BOOL g_launcher_dynamic_range_mode = FALSE;
+float g_launcher_dynamic_range_max = 300.0f;
+
+BOOL CWeaponGrenadeLauncher::use_dynamic_range(CWeapon* wpn)
+{
+    if (wpn->IsZoomed())
+    {
+        return g_launcher_dynamic_range_zoom;
+    }
+
+    return g_launcher_dynamic_range;
+}
+
+collide::rq_target CWeaponGrenadeLauncher::get_rq_target()
+{
+    if(g_launcher_dynamic_range_mode)
+        return collide::rqtBoth;
+    
+    return collide::rqtStatic;
+}
+
+void CWeaponGrenadeLauncher::LaunchGrenade(CWeapon* wpn)
+{
+    CWeaponMagazined* wm = smart_cast<CWeaponMagazined*>(wpn);
+    VERIFY(wm);
+
+    CRocketLauncher* rl = smart_cast<CRocketLauncher*>(wpn);
+    VERIFY(rl);
+    
+#ifdef CROCKETLAUNCHER_CHANGE
+    LPCSTR ammo_name = wm->m_ammoTypes[wm->m_ammoType].c_str();
+    float launch_speed = READ_IF_EXISTS(pSettings, r_float, ammo_name, "ammo_grenade_vel", rl->m_fLaunchSpeed);
+#endif
+    Fvector p1, d;
+    p1.set(wpn->get_LastFP2());
+    d.set(wpn->get_LastFD());
+    CEntity* E = smart_cast<CEntity*>(wpn->H_Parent());
+
+    if (E)
+    {
+        CInventoryOwner* io = smart_cast<CInventoryOwner*>(wpn->H_Parent());
+        if (NULL == io->inventory().ActiveItem())
+        {
+            Log("current_state", wpn->GetState());
+            Log("next_state", wpn->GetNextState());
+            Log("item_sect", wpn->cNameSect().c_str());
+            Log("H_Parent", wpn->H_Parent()->cNameSect().c_str());
+        }
+        E->g_fireParams(wpn, p1, d);
+    }
+    if (IsGameTypeSingle())
+        p1.set(wpn->get_LastFP2());
+
+    Fmatrix launch_matrix;
+    launch_matrix.identity();
+    launch_matrix.k.set(d);
+    Fvector::generate_orthonormal_basis(launch_matrix.k,
+                                        launch_matrix.j,
+                                        launch_matrix.i);
+
+    launch_matrix.c.set(p1);
+
+    if (IsGameTypeSingle() && use_dynamic_range(wpn) && smart_cast<CActor*>(wpn->H_Parent()))
+    {
+        wpn->H_Parent()->setEnabled(FALSE);
+        wpn->setEnabled(FALSE);
+
+        collide::rq_result RQ;
+        BOOL HasPick = Level().ObjectSpace.RayPick(p1, d, g_launcher_dynamic_range_max, get_rq_target(), RQ, wpn);
+
+        wpn->setEnabled(TRUE);
+        wpn->H_Parent()->setEnabled(TRUE);
+
+        if (HasPick)
+        {
+            Fvector Transference;
+            Transference.mul(d, RQ.range);
+            Fvector res[2];
+#ifdef		DEBUG
+            //.				DBG_OpenCashedDraw();
+            //.				DBG_DrawLine(p1,Fvector().add(p1,d),D3DCOLOR_XRGB(255,0,0));
+#endif
+#ifdef CROCKETLAUNCHER_CHANGE
+            u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, launch_speed, wpn->EffectiveGravity(), res);
+#else
+            u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference,
+                                                            rl->m_fLaunchSpeed,
+                                                            rl->EffectiveGravity(),
+                                                            res);
+#endif
+#ifdef DEBUG
+            //.				if(canfire0>0)DBG_DrawLine(p1,Fvector().add(p1,res[0]),D3DCOLOR_XRGB(0,255,0));
+            //.				if(canfire0>1)DBG_DrawLine(p1,Fvector().add(p1,res[1]),D3DCOLOR_XRGB(0,0,255));
+            //.				DBG_ClosedCashedDraw(30000);
+#endif
+
+            if (canfire0 != 0)
+            {
+                d = res[0];
+            };
+        }
+    };
+
+    d.normalize();
+#ifdef CROCKETLAUNCHER_CHANGE
+    d.mul(launch_speed);
+#else
+    d.mul(rl->m_fLaunchSpeed);
+#endif
+    VERIFY2(_valid(launch_matrix), "CWeaponMagazinedWGrenade::SwitchState. Invalid launch_matrix!");
+    rl->LaunchRocket(launch_matrix, d, zero_vel);
+
+    CExplosiveRocket* pGrenade = smart_cast<CExplosiveRocket*>(rl->getCurrentRocket());
+    VERIFY(pGrenade);
+    pGrenade->SetInitiator(wpn->H_Parent()->ID());
+
+    if (wpn->Local() && OnServer())
+    {
+        VERIFY(wm->m_magazine.size());
+        wm->m_magazine.pop_back();
+        --wm->iAmmoElapsed;
+        VERIFY((u32) wpn->iAmmoElapsed == wm->m_magazine.size());
+
+        NET_Packet P;
+        wpn->u_EventGen(P, GE_LAUNCH_ROCKET, wpn->ID());
+        P.w_u16(rl->getCurrentRocket()->ID());
+        wpn->u_EventSend(P);
+    };
+}

--- a/src/xrGame/WeaponGrenadeLauncher.h
+++ b/src/xrGame/WeaponGrenadeLauncher.h
@@ -1,0 +1,17 @@
+#ifndef _WEAPON_GRENADE_LAUNCHER_
+#define _WEAPON_GRENADE_LAUNCHER_
+
+#include "../xrCDB/xr_collide_defs.h"
+
+class CWeapon;
+
+class CWeaponGrenadeLauncher
+{
+private:
+    static BOOL use_dynamic_range(CWeapon* wpn);
+    static collide::rq_target get_rq_target();
+public:
+    static void LaunchGrenade(CWeapon* wpn);
+};
+
+#endif //_WEAPON_GRENADE_LAUNCHER

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -33,6 +33,8 @@ ENGINE_API extern float psHUD_FOV_def;
 float g_gunsnd_indoor = 0.f;
 float g_gunsnd_indoor_volume = 1.f;
 
+BOOL g_auto_reload = FALSE;
+
 CUIXml* pWpnScopeXml = NULL;
 
 void createWpnScopeXML()
@@ -308,11 +310,14 @@ void CWeaponMagazined::FireEnd()
 {
 	inherited::FireEnd();
 
-	/* Alundaio: Removed auto-reload since it's widely asked by just about everyone who is a gun whore
-    CActor	*actor = smart_cast<CActor*>(H_Parent());
-    if (m_pInventory && !iAmmoElapsed && actor && GetState() != eReload)
-        Reload();
-	*/
+	// Alundaio: Removed auto-reload since it's widely asked by just about everyone who is a gun whore
+	// Lander: Reinstated as a cvar
+	if (g_auto_reload)
+	{
+		CActor	*actor = smart_cast<CActor*>(H_Parent());
+		if (m_pInventory && !iAmmoElapsed && actor && GetState() != eReload)
+			Reload();
+	}
 }
 
 void CWeaponMagazined::Reload()

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -1,8 +1,13 @@
 #include "stdafx.h"
-#include "weaponmagazinedwgrenade.h"
+
+#include <build_config_defines.h>
+#include "../xrPhysics/MathUtils.h"
+
+#include "WeaponMagazinedWGrenade.h"
 #include "entity.h"
 #include "ParticlesObject.h"
 #include "GrenadeLauncher.h"
+#include "WeaponGrenadeLauncher.h"
 #include "xrserver_objects_alife_items.h"
 #include "ExplosiveRocket.h"
 #include "Actor.h"
@@ -10,13 +15,13 @@
 #include "level.h"
 #include "object_broker.h"
 #include "game_base_space.h"
-#include "../xrphysics/MathUtils.h"
 #include "player_hud.h"
-#include "../build_config_defines.h"
 
 #ifdef DEBUG
 #	include "phdebug.h"
 #endif
+
+BOOL g_fire_reloads_ubgl = TRUE;
 
 CWeaponMagazinedWGrenade::CWeaponMagazinedWGrenade(ESoundTypes eSoundType) : CWeaponMagazined(eSoundType)
 {
@@ -65,6 +70,11 @@ void CWeaponMagazinedWGrenade::Load(LPCSTR section)
 	iMagazineSize2 = iMagazineSize;
 }
 
+bool CWeaponMagazinedWGrenade::is_grenade(const char* sect)
+{
+	return pSettings->line_exist(sect, "fake_grenade_name");
+}
+
 void CWeaponMagazinedWGrenade::net_Destroy()
 {
 	inherited::net_Destroy();
@@ -91,11 +101,11 @@ BOOL CWeaponMagazinedWGrenade::net_Spawn(CSE_Abstract* DC)
 
 	if (!IsGameTypeSingle())
 	{
-		if (!m_bGrenadeMode && IsGrenadeLauncherAttached() && !getRocketCount() && iAmmoElapsed2)
+		shared_str grenade_name = m_DefaultCartridge2.m_ammoSect;
+		if (!m_bGrenadeMode && IsGrenadeLauncherAttached() && is_grenade(grenade_name.c_str()) && !getRocketCount() && iAmmoElapsed2)
 		{
 			m_magazine2.push_back(m_DefaultCartridge2);
 
-			shared_str grenade_name = m_DefaultCartridge2.m_ammoSect;
 			shared_str fake_grenade_name = pSettings->r_string(grenade_name, "fake_grenade_name");
 
 			CRocketLauncher::SpawnRocket(*fake_grenade_name, this);
@@ -114,9 +124,12 @@ BOOL CWeaponMagazinedWGrenade::net_Spawn(CSE_Abstract* DC)
 
 		if (b_if_grenade_mode || b_if_simple_mode)
 		{
-			shared_str fake_grenade_name = pSettings->r_string(pM->back().m_ammoSect, "fake_grenade_name");
-
-			CRocketLauncher::SpawnRocket(*fake_grenade_name, this);
+			shared_str grenade_name = pM->back().m_ammoSect;
+			if (is_grenade(grenade_name.c_str()))
+			{
+				shared_str fake_grenade_name = pSettings->r_string(grenade_name, "fake_grenade_name");
+				CRocketLauncher::SpawnRocket(*fake_grenade_name, this);
+			}
 		}
 	}
 	return l_res;
@@ -240,9 +253,10 @@ void CWeaponMagazinedWGrenade::PerformSwitchGL()
 	m_magazine.swap(m_magazine2);
 	iAmmoElapsed = (int)m_magazine.size();
 
-	if (m_bGrenadeMode && !getRocketCount())
+	shared_str grenade_name = m_ammoTypes[m_ammoType];
+	if (m_bGrenadeMode && is_grenade(grenade_name.c_str()) && !getRocketCount())
 	{
-		shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
+		shared_str fake_grenade_name = pSettings->r_string(grenade_name, "fake_grenade_name");
 
 		CRocketLauncher::SpawnRocket(*fake_grenade_name, this);
 	}
@@ -300,28 +314,23 @@ bool CWeaponMagazinedWGrenade::Action(u16 cmd, u32 flags)
 		if (flags & CMD_START)
 		{
 			if (iAmmoElapsed)
-				LaunchGrenade();
-			else
+			    if(is_grenade(m_ammoTypes[m_ammoType].c_str()))
+					LaunchGrenade();
+				else
+					FireStart();
+			else if(g_fire_reloads_ubgl)
 				Reload();
 
 			if (GetState() == eIdle)
 				OnEmptyClick();
 		}
-		return true;
-	}
-	if (inherited::Action(cmd, flags))
-		return true;
+		else
+			FireEnd();
 
-	/*switch (cmd)
-	{
-	case kWPN_FUNC:
-	{
-	    if (flags&CMD_START && !IsPending())
-	        SwitchState(eSwitch);
-	    return true;
+		return true;
 	}
-	}*/
-	return false;
+	
+	return inherited::Action(cmd, flags);
 }
 
 #include "inventory.h"
@@ -332,7 +341,7 @@ void CWeaponMagazinedWGrenade::state_Fire(float dt)
 	VERIFY(fOneShotTime > 0.f);
 
 	//режим стрельбы подствольника
-	if (m_bGrenadeMode)
+	if (m_bGrenadeMode && is_grenade(m_ammoTypes[m_ammoType].c_str()))
 	{
 		/*
 		fTime					-=dt;
@@ -395,117 +404,7 @@ void CWeaponMagazinedWGrenade::LaunchGrenade()
 {
 	if (!getRocketCount()) return;
 	R_ASSERT(m_bGrenadeMode);
-	{
-#ifdef CROCKETLAUNCHER_CHANGE
-		LPCSTR ammo_name = m_ammoTypes[m_ammoType].c_str();
-		float launch_speed = READ_IF_EXISTS(pSettings, r_float, ammo_name, "ammo_grenade_vel", CRocketLauncher::m_fLaunchSpeed);
-#endif
-		Fvector p1, d;
-		p1.set(get_LastFP2());
-		d.set(get_LastFD());
-		CEntity* E = smart_cast<CEntity*>(H_Parent());
-
-		if (E)
-		{
-			CInventoryOwner* io = smart_cast<CInventoryOwner*>(H_Parent());
-			if (NULL == io->inventory().ActiveItem())
-			{
-				Log("current_state", GetState());
-				Log("next_state", GetNextState());
-				Log("item_sect", cNameSect().c_str());
-				Log("H_Parent", H_Parent()->cNameSect().c_str());
-			}
-			E->g_fireParams(this, p1, d);
-		}
-		if (IsGameTypeSingle())
-			p1.set(get_LastFP2());
-
-		Fmatrix launch_matrix;
-		launch_matrix.identity();
-		launch_matrix.k.set(d);
-		Fvector::generate_orthonormal_basis(launch_matrix.k,
-		                                    launch_matrix.j,
-		                                    launch_matrix.i);
-
-		launch_matrix.c.set(p1);
-
-		if (IsGameTypeSingle() && IsZoomed() && smart_cast<CActor*>(H_Parent()))
-		{
-			H_Parent()->setEnabled(FALSE);
-			setEnabled(FALSE);
-
-			collide::rq_result RQ;
-			BOOL HasPick = Level().ObjectSpace.RayPick(p1, d, 300.0f, collide::rqtStatic, RQ, this);
-
-			setEnabled(TRUE);
-			H_Parent()->setEnabled(TRUE);
-
-			if (HasPick)
-			{
-				Fvector Transference;
-				Transference.mul(d, RQ.range);
-				Fvector res[2];
-#ifdef		DEBUG
-				//.				DBG_OpenCashedDraw();
-				//.				DBG_DrawLine(p1,Fvector().add(p1,d),D3DCOLOR_XRGB(255,0,0));
-#endif
-#ifdef CROCKETLAUNCHER_CHANGE
-				u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, launch_speed, EffectiveGravity(), res);
-#else
-				u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference,
-				                                                CRocketLauncher::m_fLaunchSpeed,
-				                                                EffectiveGravity(),
-				                                                res);
-#endif
-#ifdef DEBUG
-				//.				if(canfire0>0)DBG_DrawLine(p1,Fvector().add(p1,res[0]),D3DCOLOR_XRGB(0,255,0));
-				//.				if(canfire0>1)DBG_DrawLine(p1,Fvector().add(p1,res[1]),D3DCOLOR_XRGB(0,0,255));
-				//.				DBG_ClosedCashedDraw(30000);
-#endif
-
-				if (canfire0 != 0)
-				{
-					d = res[0];
-				};
-			}
-		};
-
-		d.normalize();
-#ifdef CROCKETLAUNCHER_CHANGE
-		d.mul(launch_speed);
-#else
-		d.mul(CRocketLauncher::m_fLaunchSpeed);
-#endif
-		VERIFY2(_valid(launch_matrix), "CWeaponMagazinedWGrenade::SwitchState. Invalid launch_matrix!");
-		CRocketLauncher::LaunchRocket(launch_matrix, d, zero_vel);
-
-		CExplosiveRocket* pGrenade = smart_cast<CExplosiveRocket*>(getCurrentRocket());
-		VERIFY(pGrenade);
-		pGrenade->SetInitiator(H_Parent()->ID());
-
-		if (Local() && OnServer())
-		{
-			VERIFY(m_magazine.size());
-			m_magazine.pop_back();
-			--iAmmoElapsed;
-			VERIFY((u32) iAmmoElapsed == m_magazine.size());
-
-			NET_Packet P;
-			u_EventGen(P, GE_LAUNCH_ROCKET, ID());
-			P.w_u16(getCurrentRocket()->ID());
-			u_EventSend(P);
-		};
-	}
-}
-
-void CWeaponMagazinedWGrenade::FireEnd()
-{
-	if (m_bGrenadeMode)
-	{
-		CWeapon::FireEnd();
-	}
-	else
-		inherited::FireEnd();
+	CWeaponGrenadeLauncher::LaunchGrenade(this);
 }
 
 void CWeaponMagazinedWGrenade::OnMagazineEmpty()
@@ -521,9 +420,10 @@ void CWeaponMagazinedWGrenade::ReloadMagazine()
 	inherited::ReloadMagazine();
 
 	//перезарядка подствольного гранатомета
-	if (iAmmoElapsed && !getRocketCount() && m_bGrenadeMode)
+	shared_str grenade_name = m_ammoTypes[m_ammoType];
+	if (is_grenade(grenade_name.c_str()) && iAmmoElapsed && !getRocketCount() && m_bGrenadeMode)
 	{
-		shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
+		shared_str fake_grenade_name = pSettings->r_string(grenade_name, "fake_grenade_name");
 
 		CRocketLauncher::SpawnRocket(*fake_grenade_name, this);
 	}
@@ -556,12 +456,6 @@ void CWeaponMagazinedWGrenade::OnAnimationEnd(u32 state)
 		{
 			SetPending(FALSE);
 			SwitchState(eIdle);
-		}
-		break;
-	case eFire:
-		{
-			if (m_bGrenadeMode)
-				Reload();
 		}
 		break;
 	}

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -405,6 +405,13 @@ void CWeaponMagazinedWGrenade::LaunchGrenade()
 	if (!getRocketCount()) return;
 	R_ASSERT(m_bGrenadeMode);
 	CWeaponGrenadeLauncher::LaunchGrenade(this);
+	if (Local() && OnServer())
+	{
+		VERIFY(m_magazine.size());
+		m_magazine.pop_back();
+		--iAmmoElapsed;
+		VERIFY((u32) iAmmoElapsed == m_magazine.size());
+	};
 }
 
 void CWeaponMagazinedWGrenade::OnMagazineEmpty()

--- a/src/xrGame/WeaponMagazinedWGrenade.h
+++ b/src/xrGame/WeaponMagazinedWGrenade.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "weaponmagazined.h"
 #include "rocketlauncher.h"
-
+#include "WeaponGrenadeLauncher.h"
 
 class CWeaponFakeGrenade;
 
@@ -10,6 +10,10 @@ class CWeaponMagazinedWGrenade : public CWeaponMagazined,
                                  public CRocketLauncher
 {
 	typedef CWeaponMagazined inherited;
+
+private:
+	virtual bool is_grenade(const char* sect);
+
 public:
 	CWeaponMagazinedWGrenade(ESoundTypes eSoundType = SOUND_TYPE_WEAPON_SUBMACHINEGUN);
 	virtual ~CWeaponMagazinedWGrenade();
@@ -35,7 +39,6 @@ public:
 	virtual bool UseScopeTexture();
 	virtual float CurrentZoomFactor();
 	virtual u8 GetCurrentHudOffsetIdx();
-	virtual void FireEnd();
 	void LaunchGrenade();
 
 	virtual void OnStateSwitch(u32 S, u32 oldState);

--- a/src/xrGame/WeaponRG6.cpp
+++ b/src/xrGame/WeaponRG6.cpp
@@ -1,10 +1,13 @@
 #include "stdafx.h"
+
+#include "../xrPhysics/MathUtils.h"
+
 #include "WeaponRG6.h"
 #include "entity.h"
-#include "explosiveRocket.h"
 #include "level.h"
-#include "../xrphysics/MathUtils.h"
 #include "actor.h"
+#include "ExplosiveRocket.h"
+#include "WeaponGrenadeLauncher.h"
 
 #ifdef DEBUG
 #	include "phdebug.h"
@@ -13,6 +16,11 @@
 
 CWeaponRG6::~CWeaponRG6()
 {
+}
+
+bool CWeaponRG6::is_grenade()
+{
+	return pSettings->line_exist(m_ammoTypes[m_ammoType], "fake_grenade_name");
 }
 
 BOOL CWeaponRG6::net_Spawn(CSE_Abstract* DC)
@@ -34,9 +42,7 @@ BOOL CWeaponRG6::net_Spawn(CSE_Abstract* DC)
 				inheritedRL::SpawnRocket(*fake_grenade_name, this);
 			}
 		}
-		//			inheritedRL::SpawnRocket(*fake_grenade_name, this);
 	}
-
 
 	return l_res;
 };
@@ -52,100 +58,13 @@ void CWeaponRG6::Load(LPCSTR section)
 
 void CWeaponRG6::FireStart()
 {
+	if (!is_grenade())
+		return inheritedSG::FireStart();
+
 	if (GetState() == eIdle && getRocketCount() && iAmmoElapsed)
 	{
 		inheritedSG::FireStart();
-#ifdef CROCKETLAUNCHER_CHANGE
-		LPCSTR ammo_name = m_ammoTypes[m_ammoType].c_str();
-		float launch_speed = READ_IF_EXISTS(pSettings, r_float, ammo_name, "ammo_grenade_vel", CRocketLauncher::m_fLaunchSpeed);
-#endif
-
-		Fvector p1, d;
-		p1.set(get_LastFP());
-		d.set(get_LastFD());
-
-		CEntity* E = smart_cast<CEntity*>(H_Parent());
-		if (E)
-		{
-			CInventoryOwner* io = smart_cast<CInventoryOwner*>(H_Parent());
-			if (NULL == io->inventory().ActiveItem())
-			{
-				Log("current_state", GetState());
-				Log("next_state", GetNextState());
-				Log("item_sect", cNameSect().c_str());
-				Log("H_Parent", H_Parent()->cNameSect().c_str());
-			}
-			E->g_fireParams(this, p1, d);
-		}
-
-		Fmatrix launch_matrix;
-		launch_matrix.identity();
-		launch_matrix.k.set(d);
-		Fvector::generate_orthonormal_basis(launch_matrix.k,
-		                                    launch_matrix.j, launch_matrix.i);
-		launch_matrix.c.set(p1);
-
-		if (IsGameTypeSingle() && IsZoomed() && smart_cast<CActor*>(H_Parent()))
-		{
-			H_Parent()->setEnabled(FALSE);
-			setEnabled(FALSE);
-
-			collide::rq_result RQ;
-			BOOL HasPick = Level().ObjectSpace.RayPick(p1, d, 300.0f, collide::rqtStatic, RQ, this);
-
-			setEnabled(TRUE);
-			H_Parent()->setEnabled(TRUE);
-
-			if (HasPick)
-			{
-				//			collide::rq_result& RQ = HUD().GetCurrentRayQuery();
-				Fvector Transference;
-				//Transference.add(p1, Fvector().mul(d, RQ.range));				
-				Transference.mul(d, RQ.range);
-				Fvector res[2];
-				/*#ifdef		DEBUG
-								DBG_OpenCashedDraw();
-								DBG_DrawLine(p1,Fvector().add(p1,d),D3DCOLOR_XRGB(255,0,0));
-				#endif*/
-#ifdef CROCKETLAUNCHER_CHANGE
-				u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, launch_speed, EffectiveGravity(), res);
-#else
-				u8 canfire0 = TransferenceAndThrowVelToThrowDir(Transference, CRocketLauncher::m_fLaunchSpeed,
-				                                                EffectiveGravity(), res);
-#endif
-				/*#ifdef DEBUG
-								if(canfire0>0)DBG_DrawLine(p1,Fvector().add(p1,res[0]),D3DCOLOR_XRGB(0,255,0));
-								if(canfire0>1)DBG_DrawLine(p1,Fvector().add(p1,res[1]),D3DCOLOR_XRGB(0,0,255));
-								DBG_ClosedCashedDraw(30000);
-				#endif*/
-				if (canfire0 != 0)
-				{
-					//					Msg ("d[%f,%f,%f] - res [%f,%f,%f]", d.x, d.y, d.z, res[0].x, res[0].y, res[0].z);
-					d = res[0];
-				};
-			}
-		};
-
-		d.normalize();
-#ifdef CROCKETLAUNCHER_CHANGE
-		d.mul(launch_speed);
-#else
-		d.mul(m_fLaunchSpeed);
-#endif
-		VERIFY2(_valid(launch_matrix), "CWeaponRG6::FireStart. Invalid launch_matrix");
-		CRocketLauncher::LaunchRocket(launch_matrix, d, zero_vel);
-
-		CExplosiveRocket* pGrenade = smart_cast<CExplosiveRocket*>(getCurrentRocket());
-		VERIFY(pGrenade);
-		pGrenade->SetInitiator(H_Parent()->ID());
-
-		if (OnServer())
-		{
-			NET_Packet P;
-			u_EventGen(P, GE_LAUNCH_ROCKET, ID());
-			P.w_u16(u16(getCurrentRocket()->ID()));
-			u_EventSend(P);
-		}
+		CWeaponGrenadeLauncher::LaunchGrenade(this);
 		dropCurrentRocket();
 	}
 }
@@ -153,19 +72,27 @@ void CWeaponRG6::FireStart()
 u8 CWeaponRG6::AddCartridge(u8 cnt)
 {
 	u8 t = inheritedSG::AddCartridge(cnt);
-	u8 k = cnt - t;
-	shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
-	while (k)
+
+	if (is_grenade())
 	{
-		--k;
-		inheritedRL::SpawnRocket(*fake_grenade_name, this);
+		u8 k = cnt - t;
+		shared_str fake_grenade_name = pSettings->r_string(m_ammoTypes[m_ammoType].c_str(), "fake_grenade_name");
+		while (k)
+		{
+			--k;
+			inheritedRL::SpawnRocket(*fake_grenade_name, this);
+		}
 	}
+
 	return t;
 }
 
 void CWeaponRG6::OnEvent(NET_Packet& P, u16 type)
 {
 	inheritedSG::OnEvent(P, type);
+
+	if(!is_grenade())
+		return;
 
 	u16 id;
 	switch (type)

--- a/src/xrGame/WeaponRG6.h
+++ b/src/xrGame/WeaponRG6.h
@@ -2,6 +2,7 @@
 
 #include "rocketlauncher.h"
 #include "weaponShotgun.h"
+#include "WeaponGrenadeLauncher.h"
 #include "script_export_space.h"
 
 class CWeaponRG6 : public CRocketLauncher,
@@ -9,6 +10,9 @@ class CWeaponRG6 : public CRocketLauncher,
 {
 	typedef CRocketLauncher inheritedRL;
 	typedef CWeaponShotgun inheritedSG;
+
+private:
+	virtual bool is_grenade();
 
 public:
 	virtual ~CWeaponRG6();

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -234,6 +234,13 @@ extern float wallmark_range_skeleton;
 
 ENGINE_API extern float g_console_sensitive;
 
+extern BOOL g_auto_reload;
+extern BOOL g_fire_reloads_ubgl;
+extern BOOL g_launcher_dynamic_range;
+extern BOOL g_launcher_dynamic_range_zoom;
+extern BOOL g_launcher_dynamic_range_mode;
+extern float g_launcher_dynamic_range_max;
+
 u32 g_dead_body_collision = 1;
 
 xr_token dead_body_collision_tokens[] =
@@ -2576,6 +2583,13 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask, "g_aimpos_zoom", &psActorFlags, AF_AIMPOS_ZOOM);
 	CMD4(CCC_Integer, "g_nearwall", &g_nearwall, 0, 2);
 	CMD4(CCC_Integer, "g_nearwall_trace", &g_nearwall_trace, 0, 1);
+
+	CMD4(CCC_Integer, "g_auto_reload", &g_auto_reload, 0, 1);
+	CMD4(CCC_Integer, "g_fire_reloads_ubgl", &g_fire_reloads_ubgl, 0, 1);
+	CMD4(CCC_Integer, "g_launcher_dynamic_range", &g_launcher_dynamic_range, 0, 1);
+	CMD4(CCC_Integer, "g_launcher_dynamic_range_zoom", &g_launcher_dynamic_range_zoom, 0, 1);
+	CMD4(CCC_Integer, "g_launcher_dynamic_range_mode", &g_launcher_dynamic_range_mode, 0, 1);
+	CMD4(CCC_Float, "g_launcher_dynamic_range_max", &g_launcher_dynamic_range_max, 0.f, 1000.f);
 
 	CMD3(CCC_Mask, "g_crosshair_show_always", &psCrosshair_Flags, CROSSHAIR_SHOW_ALWAYS);
 	CMD3(CCC_Mask, "g_crosshair_independent", &psCrosshair_Flags, CROSSHAIR_INDEPENDENT);

--- a/src/xrGame/xrGame.vcxproj
+++ b/src/xrGame/xrGame.vcxproj
@@ -1965,6 +1965,7 @@
     <ClInclude Include="WeaponCustomPistol.h" />
     <ClInclude Include="WeaponFN2000.h" />
     <ClInclude Include="WeaponFORT.h" />
+    <ClInclude Include="WeaponGrenadeLauncher.h" />
     <ClInclude Include="WeaponGroza.h" />
     <ClInclude Include="WeaponHPSA.h" />
     <ClInclude Include="WeaponKnife.h" />
@@ -4196,6 +4197,7 @@
       <PrecompiledHeaderFile>pch_script.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
+    <ClCompile Include="WeaponGrenadeLauncher.cpp" />
     <ClCompile Include="WeaponGroza.cpp">
       <PrecompiledHeaderFile>pch_script.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>

--- a/src/xrGame/xrGame.vcxproj.filters
+++ b/src/xrGame/xrGame.vcxproj.filters
@@ -2497,6 +2497,9 @@
     <Filter Include="UI\Common\ImGui">
       <UniqueIdentifier>{c14ffa0c-947d-49b9-8e01-269569b48371}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Core\Client\Objects\items &amp; weapons\Weapons\Various weapons\Weapon Grenade Launcher">
+      <UniqueIdentifier>{6750ea25-06ba-4a57-b46a-dd2be81676ad}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mt_config.h">
@@ -7392,8 +7395,12 @@
     <ClInclude Include="script_imgui_inline.h">
       <Filter>UI\Common\ImGui</Filter>
     </ClInclude>
+    <ClInclude Include="WeaponGrenadeLauncher.h">
+      <Filter>Core\Client\Objects\items &amp; weapons\Weapons\Various weapons\Weapon Grenade Launcher</Filter>
     <ClInclude Include="..\3rd party\fast_dynamic_cast\fast_dynamic_cast.hpp">
       <Filter>Core\Common\SmartCast</Filter>
+    <ClInclude Include="WeaponGrenadeLauncher.h">
+      <Filter>Core\Client\Objects\items &amp; weapons\Weapons\Various weapons\Weapon Grenade Launcher</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -11086,6 +11093,9 @@
     </ClCompile>
     <ClCompile Include="script_imgui_script.cpp">
       <Filter>UI\Common\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="WeaponGrenadeLauncher.cpp">
+      <Filter>Core\Client\Objects\items &amp; weapons\Weapons\Various weapons\Weapon Grenade Launcher</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes the M79 / RG6 bugs introduced in the original PR.

#### Summary of bug
- Inadvertently moved `CWeaponMagazinedWGrenade`'s ammo decrement into `CWeaponGrenadeLauncher`, causing it to apply to `CWeaponRG6`, which already defers to `CWeaponShotgun` for that functionality
- As a result, M79 was trying to decrement its ammo pool twice, causing the initial launch to work, but immediately canceling all followup actions (anim, sound)
- RG6 was doing the same, but succeeding when the ammo count was >=2; same behaviour as M79 when firing with 1 shell loaded