### PR TITLE
Fix lua function to get/set shaders and textures of models

### DIFF
--- a/src/Include/xrRender/RenderVisual.h
+++ b/src/Include/xrRender/RenderVisual.h
@@ -30,6 +30,7 @@ public:
 #ifdef DEBUG
 	virtual shared_str	_BCL	getDebugName() = 0;
 #endif
+	virtual u32 _BCL getID() { return 1; }
 	virtual LPCSTR _BCL getDebugShader() { return nullptr; }
 	virtual LPCSTR _BCL getDebugTexture() { return nullptr; }
 	
@@ -37,6 +38,7 @@ public:
 	virtual LPCSTR _BCL getDebugTextureDef() { return nullptr; }
 
 	virtual xr_vector<IRenderVisual*>* get_children() { return nullptr; };
+	virtual xr_vector<IRenderVisual*>* get_children_invisible() { return nullptr; };
 
 	virtual void SetShaderTexture(LPCSTR shader, LPCSTR texture) {};
 	virtual void ResetShaderTexture() {};

--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -43,6 +43,7 @@ void dxRender_Visual::Release()
 void dxRender_Visual::Load(const char* N, IReader* data, u32)
 {
 	dbg_name = N;
+	dbg_id = 1;
 	skinning = ::Render->m_skinning;
 
 	// header
@@ -164,6 +165,7 @@ void dxRender_Visual::Copy(dxRender_Visual* pFrom)
 	PCOPY(desc);
 #endif
 	PCOPY(flags);
+	PCOPY(dbg_id);
 	PCOPY(dbg_name);
 	PCOPY(dbg_shader);
 	PCOPY(dbg_shader_def);

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -48,11 +48,14 @@ public:
 #ifdef _EDITOR
     ogf_desc					desc		;
 #endif
+	u32							dbg_id		;
 	shared_str					dbg_name	;
 	shared_str					dbg_shader	;
 	shared_str					dbg_texture	;
 	shared_str					dbg_shader_def	;
 	shared_str					dbg_texture_def	;
+	virtual void				setID(u32 id) { dbg_id = id; }
+	virtual u32 _BCL			getID() { return dbg_id; }
 	virtual shared_str	_BCL	getDebugName() { return dbg_name; }
 	virtual LPCSTR _BCL			getDebugShader() { return *dbg_shader; }
 	virtual LPCSTR _BCL			getDebugTexture() { return *dbg_texture; }

--- a/src/Layers/xrRender/FHierrarhyVisual.cpp
+++ b/src/Layers/xrRender/FHierrarhyVisual.cpp
@@ -56,6 +56,7 @@ void FHierrarhyVisual::Load(const char* N, IReader* data, u32 dwFlags)
 #else
 			u32 ID = data->r_u32();
 			children[i] = ::Render->getVisual(ID);
+			((dxRender_Visual*)children[i])->setID(i + 1);
 #endif
 		}
 		bDontDelete = TRUE;
@@ -76,6 +77,7 @@ void FHierrarhyVisual::Load(const char* N, IReader* data, u32 dwFlags)
 					if (strext(short_name)) *strext(short_name) = 0;
 					strconcat(sizeof(name_load), name_load, short_name, ":", itoa(count, num, 10));
 					children.push_back(::Render->model_CreateChild(name_load, O));
+					((dxRender_Visual*)children.back())->setID(count);
 					O->close();
 					O = OBJ->open_chunk(count);
 				}
@@ -96,6 +98,8 @@ void FHierrarhyVisual::MarkAsHot(bool is_hot)
 	dxRender_Visual::MarkAsHot(is_hot);
 	for (u32 i = 0; i < children.size(); i++)
 		children[i]->MarkAsHot(is_hot);
+	for (u32 i = 0; i < children_invisible.size(); i++)
+		children_invisible[i]->MarkAsHot(is_hot);
 }
 //--DSR-- HeatVision_end
 

--- a/src/Layers/xrRender/FHierrarhyVisual.h
+++ b/src/Layers/xrRender/FHierrarhyVisual.h
@@ -13,6 +13,7 @@ class FHierrarhyVisual : public dxRender_Visual
 {
 public:
 	xr_vector<IRenderVisual*> children;
+	xr_vector<IRenderVisual*> children_invisible;
 	BOOL bDontDelete;
 public:
 	FHierrarhyVisual();
@@ -27,6 +28,7 @@ public:
 	//--DSR-- HeatVision_end
 
 	virtual xr_vector<IRenderVisual*>* get_children() { return &children; };
+	virtual xr_vector<IRenderVisual*>* get_children_invisible() { return &children_invisible; };
 };
 
 #endif //FHierrarhyVisualH

--- a/src/Layers/xrRender/SkeletonCustom.h
+++ b/src/Layers/xrRender/SkeletonCustom.h
@@ -128,7 +128,6 @@ protected:
 	u32 CurrentFrame;
 	Fmatrix	Matrix_Prev;
 	Fmatrix Matrix_Temp;
-	xr_vector<dxRender_Visual*> children_invisible;
 
 	// Globals
 	CInifile* pUserData;

--- a/src/xrGame/script_attachment_manager.cpp
+++ b/src/xrGame/script_attachment_manager.cpp
@@ -913,8 +913,9 @@ Fvector script_attachment::GetCenter()
 	}
 
 	xr_vector<IRenderVisual*>* children = m_model->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = m_model->getDebugShader();
@@ -923,15 +924,20 @@ Fvector script_attachment::GetCenter()
 		return table;
 	}
 
-	int i = 1;
-
 	for (auto* child : *children)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = child->getDebugShader();
 		subtable["texture"] = child->getDebugTexture();
-		table[i] = subtable;
-		++i;
+		table[child->getID()] = subtable;
+	}
+
+	for (auto* child : *children_invisible)
+	{
+		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShader();
+		subtable["texture"] = child->getDebugTexture();
+		table[child->getID()] = subtable;
 	}
 
 	return table;
@@ -948,8 +954,9 @@ Fvector script_attachment::GetCenter()
 	}
 
 	xr_vector<IRenderVisual*>* children = m_model->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = m_model->getDebugShaderDef();
@@ -958,15 +965,20 @@ Fvector script_attachment::GetCenter()
 		return table;
 	}
 
-	int i = 1;
-
 	for (auto* child : *children)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = child->getDebugShaderDef();
 		subtable["texture"] = child->getDebugTextureDef();
-		table[i] = subtable;
-		++i;
+		table[child->getID()] = subtable;
+	}
+
+	for (auto* child : *children_invisible)
+	{
+		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShaderDef();
+		subtable["texture"] = child->getDebugTextureDef();
+		table[child->getID()] = subtable;
 	}
 
 	return table;
@@ -976,50 +988,76 @@ void script_attachment::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture)
 {
 	if (!m_model) return;
 	xr_vector<IRenderVisual*>* children = m_model->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		m_model->SetShaderTexture(shader, texture);
 		return;
 	}
 
-	if (id == -1)
+	if (id < 1)
 	{
 		for (auto* child : *children)
+		{
+			child->SetShaderTexture(shader, texture);
+		}
+		for (auto* child : *children_invisible)
 		{
 			child->SetShaderTexture(shader, texture);
 		}
 		return;
 	}
 
-	id--;
-
-	if (id >= 0 && children->size() > id)
-		children->at(id)->SetShaderTexture(shader, texture);
+	for (auto* child : *children)
+	{
+		if (child->getID() != id) continue;
+		child->SetShaderTexture(shader, texture);
+		return;
+	}
+	for (auto* child : *children_invisible)
+	{
+		if (child->getID() != id) continue;
+		child->SetShaderTexture(shader, texture);
+		return;
+	}
 }
 
 void script_attachment::ResetShaderTexture(int id)
 {
 	if (!m_model) return;
 	xr_vector<IRenderVisual*>* children = m_model->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		m_model->ResetShaderTexture();
 		return;
 	}
 
-	if (id == -1)
+	if (id < 1)
 	{
 		for (auto* child : *children)
+		{
+			child->ResetShaderTexture();
+		}
+		for (auto* child : *children_invisible)
 		{
 			child->ResetShaderTexture();
 		}
 		return;
 	}
 
-	id--;
-
-	if (id >= 0 && children->size() > id)
-		children->at(id)->ResetShaderTexture();
+	for (auto* child : *children)
+	{
+		if (child->getID() != id) continue;
+		child->ResetShaderTexture();
+		return;
+	}
+	for (auto* child : *children_invisible)
+	{
+		if (child->getID() != id) continue;
+		child->ResetShaderTexture();
+		return;
+	}
 }

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -1169,8 +1169,9 @@ CGameObject& CScriptGameObject::object() const
 
 	IRenderVisual* vis = k->dcast_RenderVisual();
 	xr_vector<IRenderVisual*>* children = vis->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = vis->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = vis->getDebugShader();
@@ -1179,15 +1180,20 @@ CGameObject& CScriptGameObject::object() const
 		return table;
 	}
 
-	int i = 1;
-
 	for (auto* child : *children)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = child->getDebugShader();
 		subtable["texture"] = child->getDebugTexture();
-		table[i] = subtable;
-		++i;
+		table[child->getID()] = subtable;
+	}
+
+	for (auto* child : *children_invisible)
+	{
+		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShader();
+		subtable["texture"] = child->getDebugTexture();
+		table[child->getID()] = subtable;
 	}
 
 	return table;
@@ -1220,8 +1226,9 @@ CGameObject& CScriptGameObject::object() const
 
 	IRenderVisual* vis = k->dcast_RenderVisual();
 	xr_vector<IRenderVisual*>* children = vis->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = vis->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = vis->getDebugShaderDef();
@@ -1230,15 +1237,20 @@ CGameObject& CScriptGameObject::object() const
 		return table;
 	}
 
-	int i = 1;
-
 	for (auto* child : *children)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
 		subtable["shader"] = child->getDebugShaderDef();
 		subtable["texture"] = child->getDebugTextureDef();
-		table[i] = subtable;
-		++i;
+		table[child->getID()] = subtable;
+	}
+
+	for (auto* child : *children_invisible)
+	{
+		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
+		subtable["shader"] = child->getDebugShaderDef();
+		subtable["texture"] = child->getDebugTextureDef();
+		table[child->getID()] = subtable;
 	}
 
 	return table;
@@ -1247,51 +1259,77 @@ CGameObject& CScriptGameObject::object() const
 void set_shader_tex(IRenderVisual* vis, int id, LPCSTR shader, LPCSTR texture)
 {
 	xr_vector<IRenderVisual*>* children = vis->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = vis->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		vis->SetShaderTexture(shader, texture);
 		return;
 	}
 
-	if (id == -1)
+	if (id < 1)
 	{
 		for (auto* child : *children)
+		{
+			child->SetShaderTexture(shader, texture);
+		}
+		for (auto* child : *children_invisible)
 		{
 			child->SetShaderTexture(shader, texture);
 		}
 		return;
 	}
 
-	id--;
-
-	if (id >= 0 && children->size() > id)
-		children->at(id)->SetShaderTexture(shader, texture);
+	for (auto* child : *children)
+	{
+		if (child->getID() != id) continue;
+		child->SetShaderTexture(shader, texture);
+		return;
+	}
+	for (auto* child : *children_invisible)
+	{
+		if (child->getID() != id) continue;
+		child->SetShaderTexture(shader, texture);
+		return;
+	}
 }
 
 void reset_shader_tex(IRenderVisual* vis, int id)
 {
 	xr_vector<IRenderVisual*>* children = vis->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = vis->get_children_invisible();
 
-	if (!children)
+	if (!children && !children_invisible)
 	{
 		vis->ResetShaderTexture();
 		return;
 	}
 
-	if (id == -1)
+	if (id < 1)
 	{
 		for (auto* child : *children)
+		{
+			child->ResetShaderTexture();
+		}
+		for (auto* child : *children_invisible)
 		{
 			child->ResetShaderTexture();
 		}
 		return;
 	}
 
-	id--;
-
-	if (id >= 0 && children->size() > id)
-		children->at(id)->ResetShaderTexture();
+	for (auto* child : *children)
+	{
+		if (child->getID() != id) continue;
+		child->ResetShaderTexture();
+		return;
+	}
+	for (auto* child : *children_invisible)
+	{
+		if (child->getID() != id) continue;
+		child->ResetShaderTexture();
+		return;
+	}
 }
 
 void CScriptGameObject::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture, bool bHud)


### PR DESCRIPTION
They now also apply to hidden parts of the model and their order is no longer mixed up when visibility of submeshes changes.
Fixes https://github.com/themrdemonized/xray-monolith/issues/286