### PR TITLE
Possible fix for corrupted CBuffers [r_ComputePass]

### DIFF
--- a/src/Layers/xrRenderDX10/Blender_Recorder_R3.cpp
+++ b/src/Layers/xrRenderDX10/Blender_Recorder_R3.cpp
@@ -252,6 +252,11 @@ void CBlender_Compile::r_TessPass(LPCSTR vs, LPCSTR hs, LPCSTR ds, LPCSTR gs, LP
 
 void CBlender_Compile::r_ComputePass(LPCSTR cs)
 {
+	//LVutner: Sometimes CBuffers would be either empty or corrupted.
+	//That often happens with multipass CS setups. Needs more testing.
+	if(strstr(Core.Params, "-clear_cs_constants"))
+		ctable.clear();
+
 	dest.cs = DEV->_CreateCS(cs);
 
 	ctable.merge(&dest.cs->constants);


### PR DESCRIPTION
That should fix corrupted CBuffers:
<img width="418" height="433" alt="image" src="https://github.com/user-attachments/assets/9bd79dd8-7d4d-4fb9-9588-dca6a2f73254" />

It's optional, so it doesn't affect current CS setups (original HDAO & other).