### PR TITLE
Add string count to `stat_memory` and OOM handler

### DIFF
--- a/src/xrCore/xrDebugNew.cpp
+++ b/src/xrCore/xrDebugNew.cpp
@@ -508,10 +508,12 @@ int out_of_memory_handler(size_t size)
 	{
 		Memory.mem_compact();
 		size_t process_heap = Memory.mem_usage();
-		int eco_strings = (int)g_pStringContainer->stat_economy();
+        u32 eco_strings_count = 0;
+		int eco_strings = (int)g_pStringContainer->stat_economy(eco_strings_count);
 		int eco_smem = (int)g_pSharedMemoryContainer->stat_economy();
-		Msg("* [x-ray]: process heap[%llu K]", process_heap / 1024, process_heap / 1024);
-		Msg("* [x-ray]: economy: strings[%lld K], smem[%lld K]", eco_strings / 1024, eco_smem);
+		Msg("* [x-ray]: process heap[%llu K]", process_heap / 1024);
+		Msg("* [x-ray]: strings: memory[%ld K], count[%lu]", eco_strings / 1024, eco_strings_count);
+		Msg("* [x-ray]: shared: memory[%ld K]", eco_smem);
 	}
 
 	Debug.fatal(DEBUG_INFO, "Out of memory. Memory request: %lld K", size / 1024);

--- a/src/xrCore/xrstring.cpp
+++ b/src/xrCore/xrstring.cpp
@@ -119,7 +119,7 @@ struct str_container_impl
 		}
 	}
 
-	int stat_economy()
+	int stat_economy(u32& count)
 	{
 		int counter = 0;
 		for (u32 i = 0; i < buffer_size; ++i)
@@ -127,6 +127,7 @@ struct str_container_impl
 			str_value* value = buffer[i];
 			while (value)
 			{
+				count += 1;
 				counter -= sizeof(str_value);
 				counter += (value->dwReference - 1) * (value->dwLength + 1);
 				value = value->next;
@@ -237,12 +238,12 @@ void str_container::dump(IWriter* W)
 	cs.Leave();
 }
 
-u32 str_container::stat_economy()
+u32 str_container::stat_economy(u32& count)
 {
 	cs.Enter();
 	int counter = 0;
 	counter -= sizeof(*this);
-	counter += impl->stat_economy();
+	counter += impl->stat_economy(count);
 	cs.Leave();
 	return u32(counter);
 }

--- a/src/xrCore/xrstring.h
+++ b/src/xrCore/xrstring.h
@@ -49,7 +49,7 @@ public:
 	void dump();
 	void dump(IWriter* W);
 	void verify();
-	u32 stat_economy();
+	u32 stat_economy(u32& count);
 #ifdef PROFILE_CRITICAL_SECTIONS
     str_container ():cs(MUTEX_PROFILE_ID(str_container)) {}
 #endif // PROFILE_CRITICAL_SECTIONS

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -336,7 +336,7 @@ static void full_memory_stats()
 	Msg("* [x-ray]: process heap[%u K], game lua[%d K], render[%d K]", _process_heap / 1024, _game_lua / 1024, _render / 1024);
 #endif // SEVERAL_ALLOCATORS
 
-	Msg("* [x-ray]: strings: memory[%ld K], count[%lu]", _eco_strings / 1024, _eco_strings_count);
+	Msg("* [x-ray]: shared strings: memory[%ld K], count[%lu]", _eco_strings / 1024, _eco_strings_count);
 	Msg("* [x-ray]: shared memory: memory[%ld K]", _eco_smem);
 
 #ifdef FS_DEBUG

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -317,7 +317,8 @@ static void full_memory_stats()
 	u32		_game_lua = game_lua_memory_usage();
 	u32		_render = ::Render->memory_usage();
 #endif // SEVERAL_ALLOCATORS
-	int _eco_strings = (int)g_pStringContainer->stat_economy();
+    u32 _eco_strings_count = 0;
+	int _eco_strings = (int)g_pStringContainer->stat_economy(_eco_strings_count);
 	int _eco_smem = (int)g_pSharedMemoryContainer->stat_economy();
 	u32 m_base = 0, c_base = 0, m_lmaps = 0, c_lmaps = 0;
 
@@ -335,7 +336,8 @@ static void full_memory_stats()
 	Msg("* [x-ray]: process heap[%u K], game lua[%d K], render[%d K]", _process_heap / 1024, _game_lua / 1024, _render / 1024);
 #endif // SEVERAL_ALLOCATORS
 
-	Msg("* [x-ray]: economy: strings[%d K], smem[%d K]", _eco_strings / 1024, _eco_smem);
+	Msg("* [x-ray]: strings: memory[%ld K], count[%lu]", _eco_strings / 1024, _eco_strings_count);
+	Msg("* [x-ray]: shared memory: memory[%ld K]", _eco_smem);
 
 #ifdef FS_DEBUG
 	Msg("* [x-ray]: file mapping: memory[%d K], count[%d]", g_file_mapped_memory / 1024, g_file_mapped_count);


### PR DESCRIPTION
- Thread a `u32` reference through `stat_economy` to avoid adding a global
- Rearrange existing `Msg` calls to segment `string` and `shared`, add count to `string`