### PR TITLE
Fix for Random Music in Main Menu

### DIFF
--- a/src/xrGame/ui/MMSound.cpp
+++ b/src/xrGame/ui/MMSound.cpp
@@ -2,12 +2,11 @@
 
 #include "MMSound.h"
 #include "xrUIXmlParser.h"
-#include "time.h"
 
 CMMSound::CMMSound()
 {
 	// Ncenka - fix for not playing random Main Menu music
-	Random.seed((u32)time(NULL));
+	m_random.seed(u32(CPU::QPC() & 0xffffffff));
 }
 
 CMMSound::~CMMSound()
@@ -74,7 +73,7 @@ void CMMSound::music_Play()
 
 	int i = 0;
 	if (m_bRandom)
-		i = Random.randI(m_play_list.size());
+		i = m_random.randI(m_play_list.size());
 
 	string_path _path;
 	strconcat(sizeof(_path), _path, m_play_list[i].c_str(), ".ogg");

--- a/src/xrGame/ui/MMSound.cpp
+++ b/src/xrGame/ui/MMSound.cpp
@@ -2,9 +2,12 @@
 
 #include "MMSound.h"
 #include "xrUIXmlParser.h"
+#include "time.h"
 
 CMMSound::CMMSound()
 {
+	// Ncenka - fix for not playing random Main Menu music
+	Random.seed((u32)time(NULL));
 }
 
 CMMSound::~CMMSound()
@@ -69,7 +72,9 @@ void CMMSound::music_Play()
 	if (m_play_list.empty())
 		return;
 
-	int i = Random.randI(m_play_list.size());
+	int i = 0;
+	if (m_bRandom)
+		i = Random.randI(m_play_list.size());
 
 	string_path _path;
 	strconcat(sizeof(_path), _path, m_play_list[i].c_str(), ".ogg");

--- a/src/xrGame/ui/MMSound.h
+++ b/src/xrGame/ui/MMSound.h
@@ -28,4 +28,5 @@ protected:
 	ref_sound m_whell_click;
 	bool m_bRandom;
 	xr_vector<xr_string> m_play_list;
+	CRandom m_random;
 };


### PR DESCRIPTION
I found that setting `random="1"` in ui_mm_main\menu_sound actually did nothing and it always played the last listed track. By adding this lines it fixes the issue.