### PR TITLE
Export multiple `CWeaponKnife` related functions to Lua

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -390,6 +390,9 @@
     }
 
     class game_object {
+		// Class casting
+		function cast_Knife()
+
         // General
         Fmatrix xform(bool bHud)
         Fbox bounding_box(bool bHud)
@@ -627,6 +630,21 @@
         // Get and set the zoom_rotate_time (time in seconds to fully ADS) field for a given weapon
         function GetZoomRotateTime()
         function SetZoomRotateTime(float)
+    }
+
+    class CWeaponKnife : CWeapon {
+		function GetHit1Power()
+		function GetHit2Power()
+		function GetHit1PowerCritical()
+		function GetHit2PowerCritical()
+		function GetHit1Impulse()
+		function GetHit2Impulse()
+		function SetHit1Power(float power)
+		function SetHit2Power(float power)
+		function SetHit1PowerCritical(float power)
+		function SetHit2PowerCritical(float power)
+		function SetHit1Impulse(float impulse)
+		function SetHit2Impulse(float impulse)
     }
 	
     enum rq_target { (sum them up to target multiple types)

--- a/src/xrGame/WeaponKnife.cpp
+++ b/src/xrGame/WeaponKnife.cpp
@@ -107,51 +107,17 @@ void CWeaponKnife::OnStateSwitch(u32 S, u32 oldState)
 		break;
 	case eFire:
 		{
-			//-------------------------------------------
 			m_eHitType = m_eHitType_1;
-			//fHitPower		= fHitPower_1;
-			if (ParentIsActor())
-			{
-				if (GameID() == eGameIDSingle)
-				{
-					fCurrentHit = fvHitPower_1[g_SingleGameDifficulty];
-				}
-				else
-				{
-					fCurrentHit = fvHitPower_1[egdMaster];
-				}
-			}
-			else
-			{
-				fCurrentHit = fvHitPower_1[egdMaster];
-			}
-			fHitImpulse_cur = fHitImpulse_1;
-			//-------------------------------------------
+			fCurrentHit = GetHit1Power();
+			fHitImpulse_cur = GetHit1Impulse();
 			switch2_Attacking(S);
 		}
 		break;
 	case eFire2:
 		{
-			//-------------------------------------------
 			m_eHitType = m_eHitType_2;
-			//fHitPower		= fHitPower_2;
-			if (ParentIsActor())
-			{
-				if (GameID() == eGameIDSingle)
-				{
-					fCurrentHit = fvHitPower_2[g_SingleGameDifficulty];
-				}
-				else
-				{
-					fCurrentHit = fvHitPower_2[egdMaster];
-				}
-			}
-			else
-			{
-				fCurrentHit = fvHitPower_2[egdMaster];
-			}
-			fHitImpulse_cur = fHitImpulse_2;
-			//-------------------------------------------
+			fCurrentHit = GetHit2Power();
+			fHitImpulse_cur = GetHit2Impulse();
 			switch2_Attacking(S);
 		}
 		break;
@@ -382,65 +348,74 @@ void CWeaponKnife::LoadFireParams(LPCSTR section)
 {
 	inherited::LoadFireParams(section);
 
-	string32 buffer;
-	shared_str s_sHitPower_2;
-	shared_str s_sHitPowerCritical_2;
-
-	fvHitPower_1 = fvHitPower;
-	fvHitPowerCritical_1 = fvHitPowerCritical;
-	fHitImpulse_1 = fHitImpulse;
+	// Loading hit 1 params
+	SetHit1Power(fvHitPower[g_SingleGameDifficulty]);
+	SetHit1PowerCritical(fvHitPowerCritical[g_SingleGameDifficulty]);
+	SetHit1Impulse(fHitImpulse);
 	m_eHitType_1 = ALife::g_tfString2HitType(pSettings->r_string(section, "hit_type"));
 
-	//fHitPower_2			= pSettings->r_float	(section,strconcat(full_name, prefix, "hit_power_2"));
-	s_sHitPower_2 = pSettings->r_string_wb(section, "hit_power_2");
-	s_sHitPowerCritical_2 = pSettings->r_string_wb(section, "hit_power_critical_2");
+	// Loading hit 2 params
+	shared_str s_sHitPower_2 = pSettings->r_string_wb(section, "hit_power_2");
+	shared_str s_sHitPowerCritical_2 = pSettings->r_string_wb(section, "hit_power_critical_2");
 
-	fvHitPower_2[egdMaster] = (float)atof(_GetItem(*s_sHitPower_2, 0, buffer));
-	//первый параметр - это хит для уровня игры мастер
-	fvHitPowerCritical_2[egdMaster] = (float)atof(_GetItem(*s_sHitPowerCritical_2, 0, buffer));
-	//первый параметр - это хит для уровня игры мастер
+	string32 buffer;
 
-	fvHitPower_2[egdNovice] = fvHitPower_2[egdStalker] = fvHitPower_2[egdVeteran] = fvHitPower_2[egdMaster];
-	//изначально параметры для других уровней сложности такие же
-	fvHitPowerCritical_2[egdNovice] = fvHitPowerCritical_2[egdStalker] = fvHitPowerCritical_2[egdVeteran] =
-		fvHitPowerCritical_2[egdMaster]; //изначально параметры для других уровней сложности такие же
-
-	int num_game_diff_param = _GetItemCount(*s_sHitPower_2); //узнаём колличество параметров для хитов
-	if (num_game_diff_param > 1) //если задан второй параметр хита
-	{
-		fvHitPower_2[egdVeteran] = (float)atof(_GetItem(*s_sHitPower_2, 1, buffer));
-		//то вычитываем его для уровня ветерана
-	}
-	if (num_game_diff_param > 2) //если задан третий параметр хита
-	{
-		fvHitPower_2[egdStalker] = (float)atof(_GetItem(*s_sHitPower_2, 2, buffer));
-		//то вычитываем его для уровня сталкера
-	}
-	if (num_game_diff_param > 3) //если задан четвёртый параметр хита
-	{
-		fvHitPower_2[egdNovice] = (float)atof(_GetItem(*s_sHitPower_2, 3, buffer));
-		//то вычитываем его для уровня новичка
-	}
-
-	num_game_diff_param = _GetItemCount(*s_sHitPowerCritical_2); //узнаём колличество параметров
-	if (num_game_diff_param > 1) //если задан второй параметр хита
-	{
-		fvHitPowerCritical_2[egdVeteran] = (float)atof(_GetItem(*s_sHitPowerCritical_2, 1, buffer));
-		//то вычитываем его для уровня ветерана
-	}
-	if (num_game_diff_param > 2) //если задан третий параметр хита
-	{
-		fvHitPowerCritical_2[egdStalker] = (float)atof(_GetItem(*s_sHitPowerCritical_2, 2, buffer));
-		//то вычитываем его для уровня сталкера
-	}
-	if (num_game_diff_param > 3) //если задан четвёртый параметр хита
-	{
-		fvHitPowerCritical_2[egdNovice] = (float)atof(_GetItem(*s_sHitPowerCritical_2, 3, buffer));
-		//то вычитываем его для уровня новичка
-	}
-
-	fHitImpulse_2 = pSettings->r_float(section, "hit_impulse_2");
+	SetHit2Power((float) atof(_GetItem(*s_sHitPower_2, 0, buffer)));
+	SetHit2PowerCritical((float) atof(_GetItem(*s_sHitPowerCritical_2, 0, buffer)));
+	SetHit2Impulse(pSettings->r_float(section, "hit_impulse_2"));
 	m_eHitType_2 = ALife::g_tfString2HitType(pSettings->r_string(section, "hit_type_2"));
+}
+
+float CWeaponKnife::GetHit1Power() {
+	return fvHitPower_1[g_SingleGameDifficulty];
+}
+
+float CWeaponKnife::GetHit2Power() {
+	return fvHitPower_2[g_SingleGameDifficulty];
+}
+
+float CWeaponKnife::GetHit1PowerCritical() {
+	return fvHitPowerCritical_1[g_SingleGameDifficulty];
+}
+
+float CWeaponKnife::GetHit2PowerCritical() {
+	return fvHitPowerCritical_2[g_SingleGameDifficulty];
+}
+
+float CWeaponKnife::GetHit1Impulse() {
+	return fHitImpulse_1;
+}
+
+float CWeaponKnife::GetHit2Impulse() {
+	return fHitImpulse_2;
+}
+
+void CWeaponKnife::SetHit1Power(float power) {
+	fvHitPower_1[egdMaster] = power;
+	fvHitPower_1[egdNovice] = fvHitPower_1[egdStalker] = fvHitPower_1[egdVeteran] = fvHitPower_1[egdMaster];
+}
+
+void CWeaponKnife::SetHit2Power(float power) {
+	fvHitPower_2[egdMaster] = power;
+	fvHitPower_2[egdNovice] = fvHitPower_2[egdStalker] = fvHitPower_2[egdVeteran] = fvHitPower_2[egdMaster];
+}
+
+void CWeaponKnife::SetHit1PowerCritical(float power) {
+	fvHitPowerCritical_1[egdMaster] = power;
+	fvHitPowerCritical_1[egdNovice] = fvHitPowerCritical_1[egdStalker] = fvHitPowerCritical_1[egdVeteran] = fvHitPowerCritical_1[egdMaster];
+}
+
+void CWeaponKnife::SetHit2PowerCritical(float power) {
+	fvHitPowerCritical_2[egdMaster] = power;
+	fvHitPowerCritical_2[egdNovice] = fvHitPowerCritical_2[egdStalker] = fvHitPowerCritical_2[egdVeteran] = fvHitPowerCritical_2[egdMaster];
+}
+
+void CWeaponKnife::SetHit1Impulse(float impulse) {
+	fHitImpulse_1 = impulse;
+}
+
+void CWeaponKnife::SetHit2Impulse(float impulse) {
+	fHitImpulse_2 = impulse;
 }
 
 bool CWeaponKnife::GetBriefInfo(II_BriefInfo& info)

--- a/src/xrGame/WeaponKnife.h
+++ b/src/xrGame/WeaponKnife.h
@@ -43,7 +43,6 @@ protected:
 	float fHitImpulse_2;
 
 	float fCurrentHit;
-
 	float fHitImpulse_cur;
 
 	u32 dwUpdateSounds_Frame;
@@ -55,6 +54,20 @@ public:
 	virtual ~CWeaponKnife();
 
 	void Load(LPCSTR section);
+
+	float GetHit1Power();
+	float GetHit2Power();
+	float GetHit1PowerCritical();
+	float GetHit2PowerCritical();
+	float GetHit1Impulse();
+	float GetHit2Impulse();
+
+	void SetHit1Power(float power);
+	void SetHit2Power(float power);
+	void SetHit1PowerCritical(float power);
+	void SetHit2PowerCritical(float power);
+	void SetHit1Impulse(float impulse);
+	void SetHit2Impulse(float impulse);
 
 	virtual bool NeedBlendAnm();
 	virtual bool MovingAnimAllowedNow();

--- a/src/xrGame/WeaponKnife_script.cpp
+++ b/src/xrGame/WeaponKnife_script.cpp
@@ -10,5 +10,17 @@ void CWeaponKnife::script_register(lua_State* L)
 	[
 		class_<CWeaponKnife, CGameObject>("CWeaponKnife")
 		.def(constructor<>())
+		.def("GetHit1Power", &CWeaponKnife::GetHit1Power)
+		.def("GetHit2Power", &CWeaponKnife::GetHit2Power)
+		.def("GetHit1PowerCritical", &CWeaponKnife::GetHit1PowerCritical)
+		.def("GetHit2PowerCritical", &CWeaponKnife::GetHit2PowerCritical)
+		.def("GetHit1Impulse", &CWeaponKnife::GetHit1Impulse)
+		.def("GetHit2Impulse", &CWeaponKnife::GetHit2Impulse)
+		.def("SetHit1Power", &CWeaponKnife::SetHit1Power)
+		.def("SetHit2Power", &CWeaponKnife::SetHit2Power)
+		.def("SetHit1PowerCritical", &CWeaponKnife::SetHit1PowerCritical)
+		.def("SetHit2PowerCritical", &CWeaponKnife::SetHit2PowerCritical)
+		.def("SetHit1Impulse", &CWeaponKnife::SetHit1Impulse)
+		.def("SetHit2Impulse", &CWeaponKnife::SetHit2Impulse)
 	];
 }

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -37,6 +37,7 @@
 #include "antirad.h"
 #include "BottleItem.h"
 #include "Missile.h"
+#include "WeaponKnife.h"
 
 enum EPdaMsg;
 enum ESoundTypes;
@@ -940,6 +941,7 @@ public:
 	_DECLARE_FUNCTION14(cast_Artefact, CArtefact);
 	_DECLARE_FUNCTION14(cast_Ammo, CWeaponAmmo);
 	_DECLARE_FUNCTION14(cast_Weapon, CWeapon);
+	_DECLARE_FUNCTION14(cast_Knife, CWeaponKnife);
 	_DECLARE_FUNCTION14(cast_WeaponMagazined, CWeaponMagazined);
 	_DECLARE_FUNCTION14(cast_WeaponMagazinedWGrenade, CWeaponMagazinedWGrenade);
 	_DECLARE_FUNCTION14(cast_EatableItem, CEatableItem);

--- a/src/xrGame/script_game_object4.cpp
+++ b/src/xrGame/script_game_object4.cpp
@@ -50,6 +50,7 @@
 #include "medkit.h"
 #include "antirad.h"
 #include "BottleItem.h"
+#include "WeaponKnife.h"
 
 class CWeapon;
 
@@ -532,6 +533,7 @@ SPECIFIC_CAST(CScriptGameObject::cast_Helmet, CHelmet);
 SPECIFIC_CAST(CScriptGameObject::cast_Artefact, CArtefact);
 SPECIFIC_CAST(CScriptGameObject::cast_Ammo, CWeaponAmmo);
 SPECIFIC_CAST(CScriptGameObject::cast_Weapon, CWeapon);
+SPECIFIC_CAST(CScriptGameObject::cast_Knife, CWeaponKnife);
 SPECIFIC_CAST(CScriptGameObject::cast_WeaponMagazined, CWeaponMagazined);
 SPECIFIC_CAST(CScriptGameObject::cast_WeaponMagazinedWGrenade, CWeaponMagazinedWGrenade);
 SPECIFIC_CAST(CScriptGameObject::cast_Missile, CMissile);

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -521,6 +521,7 @@ class_<CScriptGameObject>& script_register_game_object2(class_<CScriptGameObject
 		.def("cast_Artefact", &CScriptGameObject::cast_Artefact)
 		.def("cast_Ammo", &CScriptGameObject::cast_Ammo)
 		.def("cast_Weapon", &CScriptGameObject::cast_Weapon)
+		.def("cast_Knife", &CScriptGameObject::cast_Knife)
 		.def("cast_WeaponMagazined", &CScriptGameObject::cast_WeaponMagazined)
 		.def("cast_WeaponMagazinedWGrenade", &CScriptGameObject::cast_WeaponMagazinedWGrenade)
 		.def("cast_EatableItem", &CScriptGameObject::cast_EatableItem)


### PR DESCRIPTION
Hello,

This PR brings the following changes :
- Added `CScriptGameObject::cast_Knife` to expose knife specific functions to Lua;
- Added getters and setters for `CWeaponKnife`'s internal hit 1/2 power/power critical/impulse values;
- Added script export for `CScriptGameObject::cast_Knife`, as well as the new getters and setters for `CWeaponKnife`;
- Simplified `CWeaponKnife::OnStateSwitch` given game difficulty and multiplayer are dead code;
- Simplified `CWeaponKnife::LoadFireParams` given difficulty is dead code;