### PR TITLE
Smart covers now have fixed enter min/max distances

### DIFF
--- a/src/xrGame/smart_cover_object.cpp
+++ b/src/xrGame/smart_cover_object.cpp
@@ -20,14 +20,6 @@
 #include "../xrengine/xr_collide_form.h"
 using smart_cover::object;
 
-void object::Load(LPCSTR section)
-{
-	inherited::Load(section);
-
-	m_enter_min_enemy_distance = pSettings->r_float(section, "enter_min_enemy_distance");
-	m_exit_min_enemy_distance = pSettings->r_float(section, "exit_min_enemy_distance");
-}
-
 BOOL object::net_Spawn(CSE_Abstract* server_entity)
 {
 	CSE_SmartCover* smart_cover = smart_cast<CSE_SmartCover*>(server_entity);
@@ -65,6 +57,9 @@ BOOL object::net_Spawn(CSE_Abstract* server_entity)
 		return (FALSE);
 
 	spatial.type &= ~STYPE_VISIBLEFORAI;
+
+	m_enter_min_enemy_distance = smart_cover->m_enter_min_enemy_distance;
+    m_exit_min_enemy_distance = smart_cover->m_exit_min_enemy_distance;
 
 	if (ai().get_alife() && smart_cover->m_description.size())
 		m_cover = ai().cover_manager().add_smart_cover(smart_cover->m_description.c_str(), *this,

--- a/src/xrGame/smart_cover_object.h
+++ b/src/xrGame/smart_cover_object.h
@@ -25,12 +25,11 @@ namespace smart_cover
 		typedef CGameObject inherited;
 
 	private:
-		cover const* m_cover;
+		cover const* m_cover{};
 		float m_enter_min_enemy_distance;
 		float m_exit_min_enemy_distance;
 
 	public:
-		virtual void Load(LPCSTR section);
 		virtual bool feel_touch_on_contact(CObject*) { return FALSE; }
 		virtual bool use(CGameObject* who_use) { return false; }
 		virtual BOOL net_Spawn(CSE_Abstract* DC);


### PR DESCRIPTION
This pull request fixes a bug where the game would only load min/max enter distances from smart_cover.ltx and ignore the ones set in the SDK.

Original commit:
[https://github.com/OpenXRay/xray-16/commit/87eb137123eb80679d56b255ef72a5d8fb78120d](url)

All credits go to @Xottab-DUTY