### PR TITLE
Level Script Attachments

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -295,6 +295,13 @@
         //        air_resistance = 0.2,
         //    }
         //    level.add_bullet(t)
+
+         // Script Attachments
+        function add_attachment(string, string)
+        function get_attachment(string)
+        function remove_attachment(string)
+        function remove_attachment(script_attachment)
+        function iterate_attachments(function)
     }
 
     // obj:get_physics_shell()
@@ -757,6 +764,7 @@
         -- Parent
         function set_parent(ScriptAttachment*);
         function set_parent(game_object*);
+        function set_parent_level();
         function get_parent();
 
         -- Child

--- a/src/xrGame/Level.cpp
+++ b/src/xrGame/Level.cpp
@@ -56,6 +56,8 @@
 #include "UICursor.h"
 #include "debug_renderer.h"
 #include "LevelDebugScript.h"
+#include "script_attachment_manager.h"
+#include "script_light_inline.h"
 
 #include "alife_simulator.h"
 #include "alife_object_registry.h"
@@ -271,6 +273,7 @@ CLevel::~CLevel()
 {
 	//crash_saving::save_impl = nullptr; // CLevel not available, disable crash save
 	xr_delete(g_player_hud);
+	delete_data(m_script_attachments);
 	delete_data(hud_zones_list);
 	hud_zones_list = nullptr;
 	Msg("- Destroying level");
@@ -1070,6 +1073,7 @@ void CLevel::OnFrame()
 		else
 			m_level_sound_manager->Update();
 	}
+
 	// defer LUA-GC-STEP
 	if (!g_dedicated_server)
 	{
@@ -1085,6 +1089,9 @@ void CLevel::OnFrame()
 		pStatGraphR->AppendItem(float(m_dwRPC) * fRPC_Mult, 0xffff0000, 1);
 		pStatGraphR->AppendItem(float(m_dwRPS) * fRPS_Mult, 0xff00ff00, 0);
 	}
+
+	for (auto& pair : m_script_attachments)
+		pair.second->Update();
 }
 
 int psLUA_GCSTEP = 300;
@@ -1312,6 +1319,61 @@ void CLevel::ScriptDebugRender()
 	// demonized: fix of showing console window when there are no visible gizmos 
 	if (hasVisibleObj)
 		DRender->OnFrameEnd();
+}
+
+script_attachment* CLevel::add_attachment(LPCSTR name, script_attachment* att)
+{
+	R_ASSERT(att);
+	remove_child(name, true);
+	m_script_attachments.emplace(mk_pair(name, att));
+	return att;
+}
+
+script_attachment* CLevel::get_attachment(LPCSTR name)
+{
+	if (m_script_attachments.size())
+	{
+		auto& att = m_script_attachments.find(name);
+		if (att != m_script_attachments.end())
+			return att->second;
+	}
+
+	return nullptr;
+}
+
+void CLevel::remove_child(LPCSTR name, bool destroy)
+{
+	script_attachment* attachment = get_attachment(name);
+	if (!attachment)
+		return;
+
+	if (destroy)
+		xr_delete(attachment);
+
+	m_script_attachments.erase(name);
+}
+
+void CLevel::remove_attachment(script_attachment* child)
+{
+	if (!child) return;
+	if (m_script_attachments.size())
+	{
+		script_attachment* attachment = get_attachment(child->GetName());
+		if (!attachment || attachment != child)
+			return;
+
+		remove_child(child->GetName(), true);
+	}
+}
+
+void CLevel::iterate_attachments(::luabind::functor<bool> functor)
+{
+	if (!m_script_attachments.size())
+		return;
+
+	for (auto& pair : m_script_attachments)
+		if (functor(pair.first.c_str(), pair.second) == true)
+			return;
 }
 
 void CLevel::OnEvent(EVENT E, u64 P1, u64 /**P2/**/)

--- a/src/xrGame/Level.h
+++ b/src/xrGame/Level.h
@@ -36,6 +36,7 @@ class demoplay_control;
 class demo_info;
 class CDebugRenderer;
 class DBG_ScriptObject;
+class script_attachment;
 
 extern float g_fov;
 
@@ -239,6 +240,14 @@ public:
 	void cl_Process_Event(u16 dest, u16 type, NET_Packet& P);
 	void cl_Process_Spawn(NET_Packet& P);
 
+	script_attachment* add_attachment(LPCSTR name, script_attachment* att);
+	script_attachment* get_attachment(LPCSTR name);
+	void remove_child(LPCSTR name, bool destroy = false);
+	void remove_attachment(LPCSTR name) { remove_child(name, true); }
+	void remove_attachment(script_attachment* child);
+	void iterate_attachments(::luabind::functor<bool> functor);
+	xr_map<shared_str, script_attachment*>* GetAttachments() { return &m_script_attachments; }
+
 //AVO: used by SPAWN_ANTIFREEZE (by alpet)
 #ifdef SPAWN_ANTIFREEZE
 public:
@@ -335,6 +344,7 @@ public:
 
 protected:
 	CBulletManager* m_pBulletManager;
+	xr_map<shared_str, script_attachment*> m_script_attachments;
 
 public:
 	IC CBulletManager& BulletManager() { return *m_pBulletManager; }

--- a/src/xrGame/script_attachment_manager.cpp
+++ b/src/xrGame/script_attachment_manager.cpp
@@ -52,13 +52,13 @@ static void update_visbox_attachment(IKinematics* k)
 #endif
 }
 
-script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
+script_attachment::script_attachment(LPCSTR name, LPCSTR model_name): ISpatial(g_SpatialSpace)
 {
 	m_name = name;
-	m_model = nullptr;
 	m_kinematics = nullptr;
 	m_parent_attachment = nullptr;
 	m_parent_object = nullptr;
+	m_parent_level = false;
 	m_script_ui = nullptr;
 	m_script_ui_func = 0;
 	m_script_ui_mat = Fidentity;
@@ -72,7 +72,8 @@ script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 	m_script_light_bone = 0;
 	m_parent_bone = 0;
 	m_offset = Fidentity;
-	m_transform = Fidentity;
+	renderable.visual = nullptr;
+	renderable.xform = Fidentity;
 	m_attachment_offset[0].set(0, 0, 0);
 	m_attachment_offset[1].set(0, 0, 0);
 	m_attachment_offset[2].set(1, 1, 1);
@@ -84,6 +85,7 @@ script_attachment::script_attachment(LPCSTR name, LPCSTR model_name)
 	m_current_motion = "idle";
 	m_model_name = "";
 	m_userdata = nullptr;
+	spatial.type |= STYPE_RENDERABLE;
 	LoadModel(model_name);
 	PlayMotion("idle", false);
 }
@@ -103,14 +105,31 @@ void script_attachment::RemoveAttachment(script_attachment* child)
 	RemoveAttachment(child->GetName());
 }
 
-void script_attachment::Render(IKinematics* model, Fmatrix* mat)
+void script_attachment::spatial_register()
 {
-	if (!model || (m_bone_callbacks[0] && m_bone_callbacks[0]->m_bone_id != BI_NONE))
-		m_transform = *mat;
-	else
-		m_transform.mul_43(*mat, BoneTransform(model));
+	renderable.xform.transform_tiny(spatial.sphere.P, renderable.visual ? renderable.visual->getVisData().sphere.P : Fvector{ 0,0,0 });
+	Fvector& scale = m_attachment_offset[2];
+	spatial.sphere.R = renderable.visual ? renderable.visual->getVisData().sphere.R * max(scale.x, max(scale.y, scale.z)) : 0.f;
+	ISpatial::spatial_register();
+}
 
-	m_transform.mulB_43(m_offset);
+void script_attachment::spatial_unregister()
+{
+	ISpatial::spatial_unregister();
+}
+
+void script_attachment::spatial_move()
+{
+	if (!spatial.node_ptr) return;
+	renderable.xform.transform_tiny(spatial.sphere.P, renderable.visual->getVisData().sphere.P);
+	Fvector& scale = m_attachment_offset[2];
+	spatial.sphere.R = renderable.visual->getVisData().sphere.R * max(scale.x, max(scale.y, scale.z));
+	ISpatial::spatial_move();
+}
+
+void script_attachment::renderable_Render()
+{
+	if (GetType() != eSA_World) return;
 
 	if (m_script_light)
 	{
@@ -121,11 +140,55 @@ void script_attachment::Render(IKinematics* model, Fmatrix* mat)
 		else
 			light_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
 
-		LM.mul(m_transform, light_bone);
+		LM.mul(renderable.xform, light_bone);
 		m_script_light->SetXFORM(LM);
 	}
 
-	IKinematicsAnimated* ka = m_model->dcast_PKinematicsAnimated();
+	if (::Render->get_generation() == ::Render->GENERATION_R1)
+		g_pGamePersistent->AttachmentUIsToRender.push_back(this);
+	else
+		RenderUI();
+
+	IKinematicsAnimated* ka = renderable.visual->dcast_PKinematicsAnimated();
+	if (ka) ka->UpdateTracks();
+	m_kinematics->CalculateBones_Invalidate();
+	m_kinematics->CalculateBones(TRUE);
+
+	::Render->set_Transform(&renderable.xform);
+	::Render->add_Visual(renderable.visual);
+
+	if (m_children.size())
+	{
+		for (auto& pair : m_children)
+		{
+			pair.second->Render(m_kinematics, &renderable.xform);
+		}
+	}
+}
+
+void script_attachment::Render(IKinematics* model, Fmatrix* mat)
+{
+	if (!model || (m_bone_callbacks[0] && m_bone_callbacks[0]->m_bone_id != BI_NONE))
+		renderable.xform = *mat;
+	else
+		renderable.xform.mul_43(*mat, BoneTransform(model));
+
+	renderable.xform.mulB_43(m_offset);
+
+	if (m_script_light)
+	{
+		Fmatrix LM;
+		Fmatrix light_bone;
+		if (m_kinematics->LL_BoneCount() > m_script_light_bone)
+			light_bone = m_kinematics->LL_GetTransform(m_script_light_bone);
+		else
+			light_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
+
+		LM.mul(renderable.xform, light_bone);
+		m_script_light->SetXFORM(LM);
+	}
+
+	IKinematicsAnimated* ka = renderable.visual->dcast_PKinematicsAnimated();
 	if (ka || GetType() == eSA_CamAttached)
 	{
 		if (ka) ka->UpdateTracks();
@@ -133,14 +196,14 @@ void script_attachment::Render(IKinematics* model, Fmatrix* mat)
 		m_kinematics->CalculateBones(TRUE);
 	}
 
-	::Render->set_Transform(&m_transform);
-	::Render->add_Visual(m_model);
+	::Render->set_Transform(&renderable.xform);
+	::Render->add_Visual(renderable.visual);
 
 	if (m_children.size())
 	{
 		for (auto& pair : m_children)
 		{
-			pair.second->Render(m_kinematics, &m_transform);
+			pair.second->Render(m_kinematics, &renderable.xform);
 		}
 	}
 }
@@ -251,7 +314,7 @@ void script_attachment::RenderUI()
 		else
 			ui_bone = m_kinematics->LL_GetTransform(m_kinematics->LL_GetBoneRoot());
 
-		LM.mul(m_transform, ui_bone);
+		LM.mul(renderable.xform, ui_bone);
 		LM.mulB_43(m_script_ui_mat);
 		UIRender->CacheSetXformWorld(LM);
 		m_script_ui->Draw();
@@ -311,6 +374,12 @@ void script_attachment::RecalcOffset()
 		m_offset.translate_over(position);
 		m_offset.mulB_43(Fmatrix().scale(scale));
 	}
+
+	if (m_parent_level)
+	{
+		renderable.xform = m_offset;
+		spatial_move();
+	}
 }
 
 void script_attachment::SetPosition(float x, float y, float z)
@@ -353,6 +422,11 @@ void script_attachment::SetParent(script_attachment* att)
 	if (m_parent_object)
 		m_parent_object->remove_child(GetName());
 
+	if (m_parent_level)
+		Level().remove_child(GetName());
+
+	spatial_unregister();
+	m_parent_level = false;
 	m_parent_object = nullptr;
 	m_parent_attachment = att;
 	m_parent_attachment->AddChild(GetName(), this);
@@ -373,8 +447,12 @@ void script_attachment::SetParent(CGameObject* obj)
 
 		m_parent_object->remove_child(GetName());
 	}
-		
+	
+	if (m_parent_level)
+		Level().remove_child(GetName());
 
+	spatial_unregister();
+	m_parent_level = false;
 	m_parent_object = obj;
 	m_parent_attachment = nullptr;
 	m_parent_object->add_attachment(GetName(), this);
@@ -396,10 +474,33 @@ void script_attachment::SetParent(CScriptGameObject* obj)
 		m_parent_object->remove_child(GetName());
 	}
 
+	if (m_parent_level)
+		Level().remove_child(GetName());
 
+	spatial_unregister();
+	m_parent_level = false;
 	m_parent_object = &obj->object();
 	m_parent_attachment = nullptr;
 	m_parent_object->add_attachment(GetName(), this);
+}
+
+void script_attachment::SetParentLevel()
+{
+	if (m_parent_level)
+		return;
+
+	if (m_parent_attachment)
+		m_parent_attachment->RemoveChild(GetName());
+
+	if (m_parent_object)
+		m_parent_object->remove_child(GetName());
+
+	m_parent_level = true;
+	m_parent_object = nullptr;
+	m_parent_attachment = nullptr;
+	Level().add_attachment(GetName(), this);
+	spatial_register();
+	spatial_move();
 }
 
 ::luabind::object script_attachment::GetParent()
@@ -407,6 +508,7 @@ void script_attachment::SetParent(CScriptGameObject* obj)
 	::luabind::object table = ::luabind::newtable(ai().script_engine().lua());
 	table["object"] = m_parent_object ? m_parent_object->lua_game_object() : nullptr;
 	table["attachment"] = m_parent_attachment ? m_parent_attachment : nullptr;
+	table["level"] = m_parent_level;
 	return table;
 }
 
@@ -464,7 +566,7 @@ Fmatrix& script_attachment::BoneTransform(IKinematics* model)
 
 u32 script_attachment::PlayMotion(LPCSTR name, bool mixin, float speed)
 {
-	IKinematicsAnimated* k = m_model->dcast_PKinematicsAnimated();
+	IKinematicsAnimated* k = renderable.visual->dcast_PKinematicsAnimated();
 
 	if (!k)
 		return 0;
@@ -502,7 +604,7 @@ u32 script_attachment::PlayMotion(LPCSTR name, bool mixin, float speed)
 
 u32 script_attachment::motion_length(const MotionID& M, const CMotionDef*& md, float speed)
 {
-	IKinematicsAnimated* k = m_model->dcast_PKinematicsAnimated();
+	IKinematicsAnimated* k = renderable.visual->dcast_PKinematicsAnimated();
 
 	if (!k)
 		return 0;
@@ -577,7 +679,7 @@ Fmatrix script_attachment::bone_transform(u16 bone_id)
 	}
 
 	Fmatrix matrix;
-	matrix.mul_43(m_transform, m_kinematics->LL_GetTransform(bone_id));
+	matrix.mul_43(renderable.xform, m_kinematics->LL_GetTransform(bone_id));
 	return matrix;
 }
 
@@ -630,16 +732,18 @@ void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
 
 	u16 count_prev = 0;
 
-	if (m_model)
+	if (renderable.visual)
 	{
 		count_prev = m_kinematics->LL_BoneCount();
-		::Render->model_Delete(m_model);
+		::Render->model_Delete(renderable.visual);
 	}
 	
-	m_model = ::Render->model_Create(*m_model_name);
-	R_ASSERT(m_model);
-	m_kinematics = m_model->dcast_PKinematics();
+	renderable.visual = ::Render->model_Create(*m_model_name);
+	R_ASSERT(renderable.visual);
+	m_kinematics = renderable.visual->dcast_PKinematics();
 	R_ASSERT(m_kinematics);
+
+	spatial_move();
 
 	// Bone Callbacks
 	if (keep_bc && m_bone_callbacks.size() && count_prev <= m_kinematics->LL_BoneCount())
@@ -659,7 +763,25 @@ void script_attachment::LoadModel(LPCSTR model_name, bool keep_bc)
 
 void script_attachment::SetName(LPCSTR name)
 {
-	if (m_parent_object)
+	if (m_parent_level)
+	{
+		// Remove old instance from parent (without destroying it)
+		Level().remove_child(GetName(), false);
+
+		auto& pair = Level().GetAttachments()->find(name);
+		if (pair != Level().GetAttachments()->end())
+		{
+			// Attachment with name exists, replace it
+			xr_delete(pair->second);
+			pair->second = this;
+		}
+		else
+		{
+			// Attachment with name does not exist, add it
+			Level().add_attachment(name, this);
+		}
+	}
+	else if (m_parent_object)
 	{
 		// Remove old instance from parent (without destroying it)
 		m_parent_object->remove_child(GetName(), false);
@@ -891,13 +1013,13 @@ void script_attachment::RemoveBoneCallback(u16 bone_id)
 
 const Fbox& script_attachment::Box()
 {
-	return m_model->dcast_PKinematics()->GetBox();
+	return renderable.visual->dcast_PKinematics()->GetBox();
 }
 
 Fvector script_attachment::GetCenter()
 {
-	if (m_model)
-		return m_model->getVisData().sphere.P;
+	if (renderable.visual)
+		return renderable.visual->getVisData().sphere.P;
 
 	return { 0,0,0 };
 }
@@ -906,20 +1028,20 @@ Fvector script_attachment::GetCenter()
 {
 	::luabind::object table = ::luabind::newtable(ai().script_engine().lua());
 
-	if (!m_model)
+	if (!renderable.visual)
 	{
 		table["error"] = true;
 		return table;
 	}
 
-	xr_vector<IRenderVisual*>* children = m_model->get_children();
-	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = renderable.visual->get_children_invisible();
 
 	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
-		subtable["shader"] = m_model->getDebugShader();
-		subtable["texture"] = m_model->getDebugTexture();
+		subtable["shader"] = renderable.visual->getDebugShader();
+		subtable["texture"] = renderable.visual->getDebugTexture();
 		table[1] = subtable;
 		return table;
 	}
@@ -947,20 +1069,20 @@ Fvector script_attachment::GetCenter()
 {
 	::luabind::object table = ::luabind::newtable(ai().script_engine().lua());
 
-	if (!m_model)
+	if (!renderable.visual)
 	{
 		table["error"] = true;
 		return table;
 	}
 
-	xr_vector<IRenderVisual*>* children = m_model->get_children();
-	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = renderable.visual->get_children_invisible();
 
 	if (!children && !children_invisible)
 	{
 		::luabind::object subtable = ::luabind::newtable(ai().script_engine().lua());
-		subtable["shader"] = m_model->getDebugShaderDef();
-		subtable["texture"] = m_model->getDebugTextureDef();
+		subtable["shader"] = renderable.visual->getDebugShaderDef();
+		subtable["texture"] = renderable.visual->getDebugTextureDef();
 		table[1] = subtable;
 		return table;
 	}
@@ -986,13 +1108,13 @@ Fvector script_attachment::GetCenter()
 
 void script_attachment::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture)
 {
-	if (!m_model) return;
-	xr_vector<IRenderVisual*>* children = m_model->get_children();
-	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
+	if (!renderable.visual) return;
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = renderable.visual->get_children_invisible();
 
 	if (!children && !children_invisible)
 	{
-		m_model->SetShaderTexture(shader, texture);
+		renderable.visual->SetShaderTexture(shader, texture);
 		return;
 	}
 
@@ -1025,13 +1147,13 @@ void script_attachment::SetShaderTexture(int id, LPCSTR shader, LPCSTR texture)
 
 void script_attachment::ResetShaderTexture(int id)
 {
-	if (!m_model) return;
-	xr_vector<IRenderVisual*>* children = m_model->get_children();
-	xr_vector<IRenderVisual*>* children_invisible = m_model->get_children_invisible();
+	if (!renderable.visual) return;
+	xr_vector<IRenderVisual*>* children = renderable.visual->get_children();
+	xr_vector<IRenderVisual*>* children_invisible = renderable.visual->get_children_invisible();
 
 	if (!children && !children_invisible)
 	{
-		m_model->ResetShaderTexture();
+		renderable.visual->ResetShaderTexture();
 		return;
 	}
 

--- a/src/xrGame/script_attachment_manager.h
+++ b/src/xrGame/script_attachment_manager.h
@@ -3,6 +3,9 @@
 #include "script_game_object.h"
 #include "script_light_inline.h"
 
+#include "../xrcdb/ispatial.h"
+#include "../xrEngine/IRenderable.h"
+
 enum script_attachment_type
 {
 	eSA_HUD = 0,
@@ -42,15 +45,16 @@ struct script_attachment_bone_cb
 	~script_attachment_bone_cb() {}
 };
 
-class script_attachment
+class script_attachment :
+	public IRenderable,
+	public ISpatial
 {
 private:
 	shared_str m_name;
 
-	Fmatrix m_offset, m_transform;
+	Fmatrix m_offset;
 	Fvector m_attachment_offset[4];
 
-	IRenderVisual* m_model;
 	IKinematics* m_kinematics;
 	shared_str m_model_name;
 	shared_str m_current_motion;
@@ -72,6 +76,7 @@ private:
 	u16 m_type;
 	script_attachment* m_parent_attachment;
 	CGameObject* m_parent_object;
+	bool m_parent_level;
 	xr_map<shared_str, script_attachment*> m_children;
 	xr_map<u16, script_attachment_bone_cb*> m_bone_callbacks;
 
@@ -83,12 +88,20 @@ public:
 	script_attachment(LPCSTR name, LPCSTR model_name);
 	~script_attachment()
 	{
-		::Render->model_Delete(m_model);
-		m_model = nullptr;
+		spatial_unregister();
+		::Render->model_Delete(renderable.visual);
+		renderable.visual = nullptr;
 		delete_data(m_children);
 		delete_data(m_bone_callbacks);
 		xr_delete(m_userdata);
 	}
+
+	virtual void spatial_register();
+	virtual void spatial_unregister();
+	virtual void spatial_move();
+	virtual IRenderable* dcast_Renderable() { return this; }
+
+	virtual void renderable_Render();
 
 	void Render(IKinematics* model, Fmatrix* mat);
 	void Update();
@@ -123,6 +136,7 @@ public:
 	void SetParent(script_attachment* att);
 	void SetParent(CGameObject* obj);
 	void SetParent(CScriptGameObject* obj);
+	void SetParentLevel();
 	::luabind::object GetParent();
 
 	void SetParentBone(u16 bone_id) { m_parent_bone = bone_id; }
@@ -212,7 +226,7 @@ public:
 	void RemoveBoneCallback(u16 bone_id);
 	void RemoveBoneCallback(LPCSTR bone) { RemoveBoneCallback(bone_id(bone)); }
 
-	Fmatrix GetTransform() { return m_transform; }
+	Fmatrix GetTransform() { return renderable.xform; }
 	Fmatrix GetOffset() { return m_offset; }
 	Fvector GetCenter();
 	const Fbox& Box();

--- a/src/xrGame/script_attachment_script.cpp
+++ b/src/xrGame/script_attachment_script.cpp
@@ -23,6 +23,7 @@ void script_attachment::script_register(lua_State* L)
 		//Parent
 		.def("set_parent", (void (script_attachment::*)(script_attachment*)) &script_attachment::SetParent)
 		.def("set_parent", (void (script_attachment::*)(CScriptGameObject*)) &script_attachment::SetParent)
+		.def("set_parent_level", &script_attachment::SetParentLevel)
 		.def("get_parent", &script_attachment::GetParent)
 
 		//Child


### PR DESCRIPTION
Added support for level script attachments (same function calls as with objects, just level.x instead of obj:x)
For example:
```lua
local latt = level.add_attachment("gubu", "dynamics\\scene_objects\\pripyat\\pri_a25_antenna_destroyable_barrier")
```

To attach an existing attachment to the level use
```lua
attachment:set_parent_level()
```