### PR TITLE
* UPD: [Render] r_ComputePass fix

### DIFF
--- a/src/Layers/xrRenderDX10/Blender_Recorder_R3.cpp
+++ b/src/Layers/xrRenderDX10/Blender_Recorder_R3.cpp
@@ -252,10 +252,7 @@ void CBlender_Compile::r_TessPass(LPCSTR vs, LPCSTR hs, LPCSTR ds, LPCSTR gs, LP
 
 void CBlender_Compile::r_ComputePass(LPCSTR cs)
 {
-	//LVutner: Sometimes CBuffers would be either empty or corrupted.
-	//That often happens with multipass CS setups. Needs more testing.
-	if(strstr(Core.Params, "-clear_cs_constants"))
-		ctable.clear();
+	ctable.clear();
 
 	dest.cs = DEV->_CreateCS(cs);
 


### PR DESCRIPTION
<img width="409" height="286" alt="image" src="https://github.com/user-attachments/assets/35256a39-91c4-4193-92db-c07e111c0b40" />

This is what you'll see after adding a compute pass that runs in the same render blender as your other pixel shaders.

https://github.com/themrdemonized/xray-monolith/pull/331 is not optional anymore.