### PR TITLE
Fix `CALifeMonsterBrain::process_task` segfault

### DIFF
--- a/gamedata/scripts/aaaa_script_fixes_mp.script
+++ b/gamedata/scripts/aaaa_script_fixes_mp.script
@@ -607,3 +607,11 @@ function trans_outfit.transparent_gg()
 		end 
 	end
 end
+
+-- Lander:
+-- Implement missing `CSE_ALifeSmartZone::task()` bind.
+-- Fixes segfault inside `CALifeMonsterBrain::process_task`,
+-- which was preventing offline monsters (+ stalkers) from pathfinding.
+function smart_terrain.se_smart_terrain:task()
+	return self.smart_alife_task
+end


### PR DESCRIPTION
Adds a working implementation of `se_smart_terrain:task()`, which fixes `CALifeMonsterBrain::process_task` segfaulting after attempting to dereference the null pointer returned when falling back to the default virtual implementation of `CSE_ALifeSmartZone::task`.

As a result, offline monsters (+ stalkers) attached to a smart zone will now pathfind toward it instead of getting stuck in a broken state.

Closes #363.