### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/3rd party/luajit-2/src/lj_debug.c
+++ b/src/3rd party/luajit-2/src/lj_debug.c
@@ -440,7 +440,8 @@ int lj_debug_getinfo(lua_State *L, const char *what, lj_Debug *ar, int ext)
   GCfunc *fn;
   if (*what == '>') {
     TValue *func = L->top - 1;
-    api_check(L, tvisfunc(func));
+    if (!tvisfunc(func))
+	  return 0;
     fn = funcV(func);
     L->top--;
     what++;

--- a/src/3rd party/luajit-2/src/lj_debug.c
+++ b/src/3rd party/luajit-2/src/lj_debug.c
@@ -441,7 +441,7 @@ int lj_debug_getinfo(lua_State *L, const char *what, lj_Debug *ar, int ext)
   if (*what == '>') {
     TValue *func = L->top - 1;
     if (!tvisfunc(func))
-	  return 0;
+      return 0;
     fn = funcV(func);
     L->top--;
     what++;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in lj_debug_getinfo() that was cloned from https://github.com/LuaJIT/LuaJIT/ but did not receive the security patch.

### Details:
Affected Function: lj_debug_getinfo() in src/3rd party/luajit-2/src/lj_debug.c
Original Fix: https://github.com/LuaJIT/LuaJIT/commit/c017b2bafc24f71620de7225c5fdcd4a71ff2593

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/LuaJIT/LuaJIT/commit/c017b2bafc24f71620de7225c5fdcd4a71ff2593
- https://nvd.nist.gov/vuln/detail/CVE-2019-19391

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
