### PR TITLE
fixed level.set_music_volume()

### DIFF
--- a/src/batch_build — копия.bat
+++ b/src/batch_build — копия.bat
@@ -1,9 +1,0 @@
-REM vswhere is required, install it via `choco install vswhere`
-@echo off
-setlocal enabledelayedexpansion
-
-for /f "usebackq tokens=*" %%i in (`vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
-  "%%i" engine-vs2022.sln /p:Configuration=DX11
-  pause
-  exit /b !errorlevel!
-)

--- a/src/batch_build — копия.bat
+++ b/src/batch_build — копия.bat
@@ -1,0 +1,9 @@
+REM vswhere is required, install it via `choco install vswhere`
+@echo off
+setlocal enabledelayedexpansion
+
+for /f "usebackq tokens=*" %%i in (`vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+  "%%i" engine-vs2022.sln /p:Configuration=DX11
+  pause
+  exit /b !errorlevel!
+)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -362,7 +362,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		volume_att = (p_source.max_distance - dist) / min_max;
 		clamp(volume_att, 0.f, p_source.volume);
 
-		float fade_scale = bStopping || (p_source.base_volume * p_source.volume * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic * psSoundVMusicFactor) < psSoundCull) ? -1.f : 1.f;
+		float fade_scale = bStopping || (p_source.base_volume * p_source.volume * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) < psSoundCull) ? -1.f : 1.f;
 		fade_volume += dt * 10.f * fade_scale;
 		//LostAlphaRus out
 
@@ -380,7 +380,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 	// Update smoothing
 	//LostAlphaRus in
-	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic * psSoundVMusicFactor) * occluder_volume * fade_volume);
+	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
 	//LostAlphaRus out
 
 	if (smooth_volume < psSoundCull)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -362,7 +362,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		volume_att = (p_source.max_distance - dist) / min_max;
 		clamp(volume_att, 0.f, p_source.volume);
 
-		float fade_scale = bStopping || (p_source.base_volume * p_source.volume * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) < psSoundCull) ? -1.f : 1.f;
+		float fade_scale = bStopping || (p_source.base_volume * p_source.volume * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic * psSoundVMusicFactor) < psSoundCull) ? -1.f : 1.f;
 		fade_volume += dt * 10.f * fade_scale;
 		//LostAlphaRus out
 
@@ -380,7 +380,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 	// Update smoothing
 	//LostAlphaRus in
-	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
+	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic * psSoundVMusicFactor) * occluder_volume * fade_volume);
 	//LostAlphaRus out
 
 	if (smooth_volume < psSoundCull)


### PR DESCRIPTION
level.set_music_volume didn't affect music volume during certain phases of sound (idk what are they), so music was just 100% regardless of level.get_music_volume. I changed script so it affects volume always. Tested in-game.