### PR TITLE
fix inertia offset movement when using canted aim

### DIFF
--- a/src/xrCore/_color.h
+++ b/src/xrCore/_color.h
@@ -23,7 +23,11 @@ ICF u32 color_get_R(u32 rgba) { return (((rgba) >> 16) & 0xff); }
 ICF u32 color_get_G(u32 rgba) { return (((rgba) >> 8) & 0xff); }
 ICF u32 color_get_B(u32 rgba) { return ((rgba) & 0xff); }
 ICF u32 color_get_A(u32 rgba) { return ((rgba) >> 24); }
-ICF u32 subst_alpha(u32 rgba, u32 a) { return rgba & ~color_rgba(0, 0, 0, 0xff) | color_rgba(0, 0, 0, a); }
+ICF u32 subst_red(u32 rgba, u32 r) { return (rgba & 0xFF00FFFF) | ((r & 0xff) << 16); }
+ICF u32 subst_green(u32 rgba, u32 g) { return (rgba & 0xFFFF00FF) | ((g & 0xff) << 8); }
+ICF u32 subst_blue(u32 rgba, u32 b) { return (rgba & 0xFFFFFF00) | (b & 0xff); }
+ICF u32 subst_alpha(u32 rgba, u32 a) { return (rgba & 0x00FFFFFF) | ((a & 0xff) << 24); }
+//ICF u32 subst_alpha(u32 rgba, u32 a) { return rgba & ~color_rgba(0, 0, 0, 0xff) | color_rgba(0, 0, 0, a); }
 ICF u32 bgr2rgb(u32 bgr) { return color_rgba(color_get_B(bgr), color_get_G(bgr), color_get_R(bgr), 0); }
 ICF u32 rgb2bgr(u32 rgb) { return bgr2rgb(rgb); }
 

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -2855,6 +2855,11 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 	Fvector curr_offs;
 	curr_offs = {fLR_lim * -1.f * m_fLR_InertiaFactor, fUD_lim * m_fUD_InertiaFactor, 0.0f};
 
+	// PrivatePirate: rotate inertia offset around Z axis to compensate roll
+	Fmatrix R;
+	R.rotateZ(-m_hud_offset[1].z);
+	R.transform_dir(curr_offs);
+
 	Fmatrix hud_rotation;
 	hud_rotation.identity();
 	hud_rotation.translate_over(curr_offs);

--- a/src/xrGame/ui/UIWindow_script.cpp
+++ b/src/xrGame/ui/UIWindow_script.cpp
@@ -76,6 +76,46 @@ int GetARGB(u16 a, u16 r, u16 g, u16 b)
 	return color_argb(a, r, g, b);
 }
 
+int ClrGetA(u32 argb)
+{
+	return color_get_A(argb);
+}
+
+int ClrGetR(u32 argb)
+{
+	return color_get_R(argb);
+}
+
+int ClrGetG(u32 argb)
+{
+	return color_get_G(argb);
+}
+
+int ClrGetB(u32 argb)
+{
+	return color_get_B(argb);
+}
+
+int ClrSetA(u32 argb, u16 a)
+{
+	return subst_alpha(argb, a);
+};
+
+int ClrSetR(u32 argb, u16 r)
+{
+	return subst_red(argb, r);
+};
+
+int ClrSetG(u32 argb, u16 g)
+{
+	return subst_green(argb, g);
+};
+
+int ClrSetB(u32 argb, u16 b)
+{
+	return subst_blue(argb, b);
+};
+
 const Fvector2* get_wnd_pos(CUIWindow* w)
 {
 	return &w->GetWndPos();
@@ -98,6 +138,15 @@ void CUIWindow::script_register(lua_State* L)
 	module(L)
 	[
 		def("GetARGB", &GetARGB),
+		def("ClrGetA", &ClrGetA),
+		def("ClrGetR", &ClrGetR),
+		def("ClrGetG", &ClrGetG),
+		def("ClrGetB", &ClrGetB),
+		def("ClrSetA", &ClrSetA),
+		def("ClrSetR", &ClrSetR),
+		def("ClrSetG", &ClrSetG),
+		def("ClrSetB", &ClrSetB),
+
 		def("GetFontSmall", &GetFontSmall),
 		def("GetFontMedium", &GetFontMedium),
 		def("GetFontDI", &GetFontDI),


### PR DESCRIPTION
Usually the inertia offset movement direction is always fixed relative to weapon rotation around barrel axis which leads to weird movement when using canted aim (weapon z rotation =/= 0). This edit simply counterrotates the inertia offset position vector to compensate the rotation. Now the offsert inertia movement direction is always the same no matter how much the weapon is rotated around the barrel axis.

Preview:
<img width="384" height="216" alt="before scaled 2" src="https://github.com/user-attachments/assets/9b17e07d-09b6-4950-bef7-68006116775d" /> <img width="384" height="216" alt="after scaled 2" src="https://github.com/user-attachments/assets/9d239a2e-d095-45ff-91d1-cbb13654b34f" />


