### PR TITLE
decoupled horz recoil, non-linear inertia movement, additions to lua_help_ex.script

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -90,6 +90,16 @@
         int get_modded_exes_version() // Returns modded exes version in integer format
         table get_string_table() // Returns all translated strings in [string id] = string text format 
         player_hud* get_player_hud()
+
+        -- color getters / setters
+        ClrGetA(number argb)
+        ClrGetR(number argb)
+        ClrGetG(number argb)
+        ClrGetB(number argb)
+        ClrSetA(number argb, number a)
+        ClrSetR(number argb, number r)
+        ClrSetG(number argb, number g)
+        ClrSetB(number argb, number b)
     }
 
     get_console() {

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -60,6 +60,9 @@
 
         poltergeist_spawn_corpse_on_death // Poltergeists spawn corpses on death
         g_firepos_zoom // Make firepos work while aiming
+
+        g_use_non_linear_inertia // enable non linear weapon inertia movement
+
     }
 
     lua extensions {

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -61,6 +61,7 @@
         poltergeist_spawn_corpse_on_death // Poltergeists spawn corpses on death
         g_firepos_zoom // Make firepos work while aiming
 
+        g_decouple_horz_recoil // calculate horz recoil independently of vert recoil
         g_use_non_linear_inertia // enable non linear weapon inertia movement
 
     }

--- a/src/xrGame/EffectorShot.cpp
+++ b/src/xrGame/EffectorShot.cpp
@@ -9,6 +9,10 @@
 //-----------------------------------------------------------------------------
 // Weapon shot effector
 //-----------------------------------------------------------------------------
+
+// calculate horz recoil independently of vert recoil
+BOOL g_decouple_horz_recoil = FALSE;
+
 CWeaponShotEffector::CWeaponShotEffector()
 {
 	Reset();
@@ -83,7 +87,15 @@ void CWeaponShotEffector::Shot2(float angle)
 	}
 
 	float rdm = m_Random.randF(-1.0f, 1.0f);
-	m_angle_horz += (m_angle_vert / m_cam_recoil.MaxAngleVert) * rdm * m_cam_recoil.StepAngleHorz;
+
+	if (g_decouple_horz_recoil)
+	{
+		m_angle_horz += rdm * m_cam_recoil.StepAngleHorz;
+	}
+	else
+	{
+		m_angle_horz += (m_angle_vert / m_cam_recoil.MaxAngleVert) * rdm * m_cam_recoil.StepAngleHorz;
+	}
 
 	clamp(m_angle_horz, -m_cam_recoil.MaxAngleHorz, m_cam_recoil.MaxAngleHorz);
 

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -55,6 +55,8 @@ float hud_fov_aim_multiplier = 1.0f;
 
 extern int g_nearwall;
 
+BOOL g_use_non_linear_inertia = FALSE;
+
 float CWeapon::SDS_Radius(bool alt) {
 	// hack for GL to always return 0, fix later
 	if (m_zoomtype == 2)
@@ -2681,12 +2683,26 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		// Двигаемся в любом другом направлении - плавно убираем наклон
 		if (m_fLR_MovingFactor < 0.0f)
 		{
-			m_fLR_MovingFactor += fStepPerUpd;
+			if (g_use_non_linear_inertia)
+			{
+				m_fLR_MovingFactor += fStepPerUpd * (0.1f - 2.f * m_fLR_MovingFactor);
+			}
+			else
+			{
+				m_fLR_MovingFactor += fStepPerUpd;
+			}
 			clamp(m_fLR_MovingFactor, -1.0f, 0.0f);
 		}
 		else
 		{
-			m_fLR_MovingFactor -= fStepPerUpd;
+			if (g_use_non_linear_inertia)
+			{
+				m_fLR_MovingFactor -= fStepPerUpd * (0.1f + 2.f * m_fLR_MovingFactor);
+			}
+			else
+			{
+				m_fLR_MovingFactor -= fStepPerUpd;
+			}
 			clamp(m_fLR_MovingFactor, 0.0f, 1.0f);
 		}
 	}
@@ -2822,12 +2838,26 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		float fRetSpeedMod = (fYMag == 0.0f ? 1.0f : 0.75f) * (fInertiaReturnSpeedMod * 0.075f);
 		if (m_fLR_InertiaFactor < 0.0f)
 		{
-			m_fLR_InertiaFactor += fAvgTimeDelta * fRetSpeedMod;
+			if (g_use_non_linear_inertia)
+			{
+				m_fLR_InertiaFactor += (0.3f - m_fLR_InertiaFactor) * fAvgTimeDelta * fRetSpeedMod;
+			}
+			else
+			{
+				m_fLR_InertiaFactor += fAvgTimeDelta * fRetSpeedMod;
+			}
 			clamp(m_fLR_InertiaFactor, -1.0f, 0.0f);
 		}
 		else
 		{
-			m_fLR_InertiaFactor -= fAvgTimeDelta * fRetSpeedMod;
+			if (g_use_non_linear_inertia)
+			{
+				m_fLR_InertiaFactor -= (0.3f + m_fLR_InertiaFactor) * fAvgTimeDelta * fRetSpeedMod;
+			}
+			else
+			{
+				m_fLR_InertiaFactor -= fAvgTimeDelta * fRetSpeedMod;
+			}
 			clamp(m_fLR_InertiaFactor, 0.0f, 1.0f);
 		}
 	}
@@ -2838,12 +2868,26 @@ void CWeapon::UpdateHudAdditional(Fmatrix& trans)
 		float fRetSpeedMod = (fPMag == 0.0f ? 1.0f : 0.75f) * (fInertiaReturnSpeedMod * 0.075f);
 		if (m_fUD_InertiaFactor < 0.0f)
 		{
-			m_fUD_InertiaFactor += fAvgTimeDelta * fRetSpeedMod;
+			if (g_use_non_linear_inertia)
+			{
+				m_fUD_InertiaFactor += (0.3f - m_fUD_InertiaFactor) * fAvgTimeDelta * fRetSpeedMod;
+			}
+			else
+			{
+				m_fUD_InertiaFactor += fAvgTimeDelta * fRetSpeedMod;
+			}
 			clamp(m_fUD_InertiaFactor, -1.0f, 0.0f);
 		}
 		else
 		{
-			m_fUD_InertiaFactor -= fAvgTimeDelta * fRetSpeedMod;
+			if (g_use_non_linear_inertia)
+			{
+				m_fUD_InertiaFactor -= (0.3f + m_fUD_InertiaFactor) * fAvgTimeDelta * fRetSpeedMod;
+			}
+			else
+			{
+				m_fUD_InertiaFactor -= fAvgTimeDelta * fRetSpeedMod;
+			}
 			clamp(m_fUD_InertiaFactor, 0.0f, 1.0f);
 		}
 	}

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -223,6 +223,8 @@ extern CrosshairSettings g_crosshair_device_far;
 	CrosshairOpacityCommands(crosshair, suffix); \
 	CrosshairLineCommands(crosshair, suffix)
 
+extern BOOL g_use_non_linear_inertia;
+
 extern float recon_show_speed;
 extern float recon_hide_speed;
 extern float recon_mindist;
@@ -2594,6 +2596,8 @@ void CCC_RegisterCommands()
 	CrosshairFarCommands(g_crosshair_weapon_far, "weapon_far");
 	CrosshairNearCommands(g_crosshair_device_near, "device_near");
 	CrosshairFarCommands(g_crosshair_device_far, "device_far");
+
+	CMD4(CCC_Integer, "g_use_non_linear_inertia", &g_use_non_linear_inertia, 0, 1);
 
 	CMD4(CCC_Float, "g_recon_show_speed", &recon_show_speed, 0.f, 20.f);
 	CMD4(CCC_Float, "g_recon_hide_speed", &recon_hide_speed, 0.f, 20.f);

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -223,6 +223,7 @@ extern CrosshairSettings g_crosshair_device_far;
 	CrosshairOpacityCommands(crosshair, suffix); \
 	CrosshairLineCommands(crosshair, suffix)
 
+extern BOOL g_decouple_horz_recoil;
 extern BOOL g_use_non_linear_inertia;
 
 extern float recon_show_speed;
@@ -2597,6 +2598,7 @@ void CCC_RegisterCommands()
 	CrosshairNearCommands(g_crosshair_device_near, "device_near");
 	CrosshairFarCommands(g_crosshair_device_far, "device_far");
 
+	CMD4(CCC_Integer, "g_decouple_horz_recoil", &g_decouple_horz_recoil, 0, 1);
 	CMD4(CCC_Integer, "g_use_non_linear_inertia", &g_use_non_linear_inertia, 0, 1);
 
 	CMD4(CCC_Float, "g_recon_show_speed", &recon_show_speed, 0.f, 20.f);


### PR DESCRIPTION
**1. Decoupled Horizontal Recoil**
Usually horz recoil offset angle is coupled with and therefore dependent on vert recoil offset angle. This causes horz recoil to be practically zero when starting to shoot and slowly increasing with higher vert offset angle. This approach removes this dependency, horz recoil has full effect on first shot. Attention: unlike vert recoil, horz recoil does NOT increase with amout of bullets fire. The magnitude of the offset is random with each shot.
This approach makes more sense imo and also makes gunplay a little more challenging. Can be toggled with the cvar 'g_decouple_horz_recoil', disabled by default. Should this get an option in modded exes settings, e.g. in General/Aim? If yes then I'll add it to the PR.

**2. Non-linear Inertia**
Currently inertia movement uses linear functions to calculate any offsets which makes movement look quiet robotic. This adds non-linear offset calculation functions for offset return movement (after changing view direction) and weapon tilt back movement (after walking sideways) to make the movement feel/look more organic, difference is subtle though. Can be toggled with the cvar 'g_use_non_linear_inertia', disabled by default.

**3. Additions to lua_help_ex.script**
Added new color exports that I forgot to add in my last PR. Also added the cvars from 1. and 2.