### PR TITLE
super early luajit init

### DIFF
--- a/src/3rd party/luajit-2/src/xr_alloc.c
+++ b/src/3rd party/luajit-2/src/xr_alloc.c
@@ -119,6 +119,13 @@ char* find_free(int size)
 	return NULL;
 }
 
+void XR_EARLY_INIT()
+{
+	ntavm = (PNTAVM)GetProcAddress(GetModuleHandleA("ntdll.dll"),
+	                               "NtAllocateVirtualMemory");
+	XR_INIT();
+}
+
 static 	char temp[1025];
 void dump_map(void* ptr, size_t size, char c)
 {

--- a/src/3rd party/luajit-2/src/xr_alloc.h
+++ b/src/3rd party/luajit-2/src/xr_alloc.h
@@ -9,4 +9,6 @@ void XR_INIT();
 void* XR_MMAP(size_t size);
 void XR_DESTROY(void* p, size_t size);
 
+void XR_EARLY_INIT();
+
 #endif

--- a/src/xrEngine/x_ray.cpp
+++ b/src/xrEngine/x_ray.cpp
@@ -32,6 +32,8 @@
 
 #include "xrSash.h"
 
+extern "C" void XR_EARLY_INIT();
+
 //#include "securom_api.h"
 
 
@@ -1172,6 +1174,10 @@ int APIENTRY WinMain(HINSTANCE hInstance,
                      char* lpCmdLine,
                      int nCmdShow)
 {
+	// Initialize LuaJIT low-memory pool FIRST, before any DLLs load and fragment
+	// the lower 2GB address space.
+	XR_EARLY_INIT();
+
 	//DllMainOpenAL32(NULL, DLL_PROCESS_ATTACH, NULL);
 	DllMainXrCore(NULL, DLL_PROCESS_ATTACH, NULL);
 	DllMainXrPhysics(NULL, DLL_PROCESS_ATTACH, NULL);


### PR DESCRIPTION
dx10 was crashing for me in lj_alloc_create because tbase was NULL. most likely because prior to this loaded dlls allocated in low 2gb space an there were no space left for jit.