### PR TITLE
Development work for level_graph, CExplosive, CGrenade, CWeaponStatMgun, CWeapon, script mutant movement. Export CGrenade functions.

### DIFF
--- a/gamedata/scripts/bind_monster.script
+++ b/gamedata/scripts/bind_monster.script
@@ -523,6 +523,8 @@ function server_entity_on_register(se,flag)
 end
 
 MONSTER_MOVE_ACCEPTED_VALUES = {
+	[move.walk_fwd] = true,
+	[move.run_fwd] = true,
 	[move.walk_with_leader] = true,
 	[move.run_with_leader] = true,
 }

--- a/gamedata/scripts/xr_combat_ignore.script
+++ b/gamedata/scripts/xr_combat_ignore.script
@@ -1,0 +1,493 @@
+--[[
+	scheme_type: generic
+	author: Stohe
+	modified_by: Alundaio
+--]]
+
+fighting_with_actor_npcs = {}
+safe_zone_npcs = {}
+
+local ignored_zone = {}
+local ignored_zone_list = {
+	--"bar_mutant_exile_zone",
+	--"esc_smart_terrain_2_12_sr_no_assault",
+	--"esc_lager_guard_kill_zone",
+	"zat_a2_sr_no_assault",
+	"jup_a6_sr_no_assault",
+	"jup_b41_sr_no_assault"
+}
+
+------------------------------------------
+-- Localized Functions
+------------------------------------------
+local function npc_on_hit_callback(npc,amount,local_direction,who,bone_index)
+	if (amount > 0) then
+		db.storage[npc:id()].hitted_by = who and who:id()
+	end
+	
+	-- xr_bribe
+	if who:id() == AC_ID then
+		xr_bribe.npc_on_hit_callback(character_community(npc))
+	end
+end
+
+local function npc_on_death_callback(npc,who)
+	safe_zone_npcs[npc:id()] = nil
+end
+
+local function squad_on_npc_death(squad,npc)
+	if (squad:npc_count() == 0) then
+		safe_zone_npcs[squad.id] = nil
+	end
+end
+
+local function on_game_load()
+	if (not alife_storage_manager.get_state().enable_warfare_mode) then
+		for i=1,#ignored_zone_list do
+			--ignored_zone[#ignored_zone+1] = ignored_zone_list[i] --Test
+		end
+	end
+end
+
+--[[ #if MODED_EXE
+Reset enemy_id to nil when enemy_id is no longer valid.
+Dead, run away, hasn't been seen for long enough, on_enemy_eval returns false, etc.
+-- #endif]]
+
+---[[ #if MODED_EXE
+function on_update_enemy_id(npc)
+	local st = db.storage[npc:id()]
+	if not (st and st.enemy_id) then
+		return
+	end
+	local ene = db.storage[st.enemy_id] and db.storage[st.enemy_id].object or level.object_by_id(st.enemy_id)
+	if not (ene and is_enemy(npc,ene,nil,true)) then
+		st.enemy_id = nil
+		--printf("%s on_update_enemy_id(%s) ene:%s = nil",debug.getinfo(1,"S").source,npc:name(),ene and ene:name())
+	end
+end
+-- #endif ]]
+
+--------------------------------
+-- Callback Register
+--------------------------------
+function on_game_start()
+	RegisterScriptCallback("npc_on_hit_callback",npc_on_hit_callback)
+	RegisterScriptCallback("npc_on_death_callback",npc_on_death_callback)
+	RegisterScriptCallback("squad_on_npc_death",squad_on_npc_death)
+	RegisterScriptCallback("on_game_load",on_game_load)
+
+---[[ #if MODED_EXE
+	RegisterScriptCallback("npc_on_update",on_update_enemy_id)
+	RegisterScriptCallback("monster_on_update",on_update_enemy_id)
+-- #endif ]]
+end
+
+---[[ #if MODED_EXE
+function is_enemy(obj,enemy,no_memory,check_st_enemy_id)
+--[[ #else
+function is_enemy(obj,enemy,no_memory)
+-- #endif ]]
+	--utils_data.debug_write("eval_is_enemy")
+	if(device().precache_frame > 1) then
+		return false -- fix actor dying before game loads from enemies. Also fixes strange crash on game load when in combat sometimes.
+	end
+	
+	if (obj:clsid() == clsid.crow) or (enemy:clsid() == clsid.crow) then -- freakin crows!
+		return false 
+	end
+	
+	if not (obj:alive()) then 
+		return false 
+	end
+	
+	if not (enemy:alive()) then 
+		return false 
+	end
+	
+	if (obj:critically_wounded()) then 
+		return true 
+	end
+	
+	local flags = {override = false, result = false}
+	SendScriptCallback("on_enemy_eval",obj,enemy,flags)
+	
+	if flags.override then return flags.result end
+	
+	local ene_id = enemy:id()
+	local id = obj:id()
+	local st = db.storage[id]
+	
+	if (DEV_DEBUG) then
+		if (xrs_debug_tools and xrs_debug_tools.debug_invis and ene_id == AC_ID) then
+			return false
+		end
+	end
+	
+	-- xr_bribe							   
+	if xr_bribe and ene_id == AC_ID then
+		if xr_bribe.at_peace(character_community(obj),character_community(enemy),enemy:position():distance_to_sqr(obj:position())) then				 
+			return false
+		end
+	end
+	
+	local obj_is_stalker = IsStalker(obj)
+	-- Ignore long unseen/unheard enemies
+	if (obj_is_stalker) then
+		if (no_memory ~= true) then
+			local tg = time_global()
+			local time_in_memory = tg - obj:memory_time(enemy)
+			if (time_in_memory < 0) then
+				--obj:enable_memory_object(enemy,false)
+				--time_in_memory = time_in_memory + load_var(obj,"mem_time_offset",0)
+				if (ene_id == 0 and time_in_memory < -120000 or time_in_memory < -60000) then 
+					return false 
+				end
+			else 
+				if (ene_id == AC_ID and time_in_memory > 120000 or time_in_memory > 60000) then
+					--obj:enable_memory_object(enemy,false)
+					--save_var(obj,"mem_time_offset",tg)
+					return false
+				end
+			end
+		end
+	end
+
+	-- NPC was hit by actor always return true. It's for keep_when_attacked condition
+	if (ene_id == AC_ID and load_var(obj,"xr_combat_ignore_enabled",true) == false) then
+		st.enemy_id = ene_id
+		return true
+	end
+
+	if (obj:has_info("npcx_is_companion") or enemy:has_info("npcx_is_companion")) then
+		-- If companion is in stealth mode then ignore combat greater than 30m unless enemy is in combat with actor
+		if (obj:has_info("npcx_beh_substate_stealth") or enemy:has_info("npcx_beh_substate_stealth")) then 
+			if not (fighting_with_actor_npcs[id] or fighting_with_actor_npcs[ene_id]) then 
+				if (enemy:position():distance_to_sqr(obj:position()) < 900) then 
+					return false
+				end
+			end
+		end
+	else
+		
+		local is_actor = (ene_id == AC_ID)
+		
+		-- Ignore enemies during surge, only if npc has a surge job at a smart_terrain and the enemy is greater then 25m (actor 100m) away from the npc's surge job's alife_task position
+		if (xr_conditions.surge_started) then 
+			local smart = xr_gulag.get_npc_smart(obj)
+			local npc_info = smart and smart.npc_info and smart.npc_info[id]
+			if (npc_info) then
+				local npc_job = npc_info.job
+				if (npc_job and npc_job.job_type_id == 2) then
+					local alife_task = npc_job.alife_task
+					if (alife_task) then 
+						if (is_actor and enemy:position():distance_to_sqr(alife_task:position()) > 10000) then 
+							return false 
+						elseif (enemy:position():distance_to_sqr(alife_task:position()) > 625) then
+							return false
+						end
+					end
+				end
+			end
+		end
+		
+		local sim = alife()
+		local is_monster = character_community(enemy) == "zombied" or IsMonster(enemy)
+		
+		-- Ignore enemies with the safe_zone flag
+		if (is_actor ~= true) then
+		
+			-- ignore hostages
+			if (axr_task_manager.hostages_by_id[ene_id]) then
+				return true 
+			end
+			
+			if (obj_is_stalker and not is_monster) then
+				local se_obj = sim:object(id)
+				if not (se_obj) then 
+					return false
+				end
+				
+				local cid = se_obj.group_id and se_obj.group_id ~= 65535 and se_obj.group_id or id
+				local tg = time_global()
+				
+				if (safe_zone_npcs[cid]) then
+					db.storage[id].heli_enemy_flag = nil
+					if (tg < safe_zone_npcs[cid] + 8000) then
+						return false
+					end
+					safe_zone_npcs[cid] = nil
+				else
+					for i,v in ipairs(ignored_zone) do
+						if (utils_obj.npc_in_zone(obj, v)) then
+							safe_zone_npcs[cid] = tg
+							return false
+						end
+					end
+				end
+			
+				local ene_squad = get_object_squad(enemy)
+				local bid = ene_squad and ene_squad.id or ene_id
+				if (safe_zone_npcs[bid]) then
+					return false
+				else 
+					for i,v in ipairs(ignored_zone) do
+						if (utils_obj.npc_in_zone(enemy, v)) then
+							safe_zone_npcs[bid] = tg
+							return false
+						end
+					end
+				end
+			end
+		end
+
+		--Ignore by distance; mainly unrestricted for all non-story stalker vs. stalker combat
+		local pos1 = obj:position()
+		local pos2 = enemy:position()
+		
+		local comm = character_community(obj)
+		local ene_comm = character_community(enemy)
+		if (comm == "army" and ene_comm == "stalker") or (comm == "stalker" and comm == "army") then 
+			-- In Cordon prevent stalker v military combat with distances greater than 60m
+			if (level.name() == "l01_escape" and pos1:distance_to_sqr(pos2) >= 3600) then
+				return false
+			end
+		end
+
+		if (is_actor) then
+			if (level.get_time_hours() < 4 or level.get_time_hours() > 19 or level.rain_factor() >= 0.4) and (pos1:distance_to_sqr(pos2) > 10000) then 
+				-- limit combat range to 100m during night hours or heavy rain for stalker v actor
+				return false
+			end
+		elseif (is_monster) then
+			if (math.abs(pos1.y-pos2.y) > 30) then
+				-- prevent stalker from attack mutants under ground or above ground
+				return false 
+			end
+			if (pos1:distance_to_sqr(pos2) > 4900) then
+				-- ignore monsters 70m or greater
+				return false
+			end
+		else
+			local dist = pos1:distance_to_sqr(pos2)
+			if (dist > 10000) then -- 100m max combat range for stalker v stalker
+				return false
+			end
+			if (dist > 5625) and (level.rain_factor() > 0 or level.get_time_hours() < 4 or level.get_time_hours() > 19) then 
+				-- limit combat range to 75m during night hours for stalker v stalker or rain
+				return false
+			end
+			if (dist > 3600) then
+				-- limit combat range to 60m during heavy rain, surges or if they are story related
+				if (xr_conditions.surge_started() or level.rain_factor() >= 0.5 or get_object_story_id(id) or get_object_story_id(ene_id)) then 
+					return false
+				end
+				
+				local squad = get_object_squad(obj)
+				local ene_squad = get_object_squad(enemy)
+				
+				if (squad and get_object_story_id(squad.id) or ene_squad and get_object_story_id(ene_squad.id)) then 
+					return false
+				end
+			end
+		end
+	end
+
+	-- Store Pure enemy (Enemy without overrides)
+	if (obj:relation(enemy) >= game_object.enemy) then
+		st.enemy_id = ene_id
+	end
+	
+---[[ #if MODED_EXE
+	if (check_st_enemy_id) then
+		-- Check if the current enemy_id is still legit. Don't check ignore_enemy_by_overrides.
+		return true
+	end
+-- #endif ]]
+	
+	-- Ignore enemies by overrides
+	if (ignore_enemy_by_overrides(obj,enemy)) then
+		return false
+	end
+
+	return true
+end
+
+function ignore_enemy_by_overrides(obj,enemy,no_check_job)
+	if not (enemy) then
+		return true
+	end
+	
+	if (IsStalker(obj)) then
+		if (enemy:section() == "mar_smart_terrain_doc_dog" or enemy:section() == "mar_smart_terrain_base_dog_doctor") then 
+			return true 
+		end
+	end
+
+	local id = obj:id()
+	local ene_id = enemy:id()
+
+	local st = db.storage[id] and db.storage[id].overrides
+	if (st) then
+	
+		-- combat_ignore_cond from custom data logic
+		local ignore = st and st.combat_ignore and xr_logic.pick_section_from_condlist(enemy, obj, st.combat_ignore.condlist)
+		if (ignore == "true") then
+			--obj:enable_memory_object(enemy,false)
+			return true
+			
+		-- Ignore enemies because of no_combat_job
+		elseif (no_check_job ~= true) and (st and st.no_combat_job and xr_logic.pick_section_from_condlist(enemy, obj, st.no_combat_job.condlist) == "true") then
+			return true
+		end
+	end
+	
+	-- enemy_ignore_cond override from custom data logic
+	-- if this is true then npc will IGNORE combat with this specific enemy
+	local ene_st = db.storage[ene_id] and db.storage[ene_id].overrides
+	if (ene_st) then
+		ignore = ene_st.enemy_ignore and xr_logic.pick_section_from_condlist(enemy, obj, ene_st.enemy_ignore.condlist)
+		if (ignore == "true") then
+			--obj:enable_memory_object(enemy,false)
+			return true
+		end
+	end
+
+	return false
+end
+
+function npc_in_safe_zone(npc)
+	if (npc:id() == AC_ID) then
+		return false
+	end
+	local squad = get_object_squad(npc)
+	if (squad and safe_zone_npcs[squad.id]) or (safe_zone_npcs[id]) then
+		return true
+	end
+	return false
+end
+----------------------------------------------------------------------------------------------------------------------
+
+class "action_process_enemy"
+function action_process_enemy:__init( obj, storage )
+	--printf("action_process_enemy init: %s", obj:name())
+	self.object = obj
+	self.st = storage
+end
+
+function action_process_enemy:trader_enemy_callback(obj,enemy)
+	return false
+end
+
+function action_process_enemy:enemy_callback(npc, enemy)
+	--utils_data.debug_write(strformat("action_process_enemy:enemy_callback"))
+	local id = npc:id()
+	local ene_id = enemy:id()
+	
+	--printf("action_process_enemy enemy_callback: %s, %s", npc:name(), enemy:name())
+	if (is_enemy(npc,enemy)) then
+		--printf("!action_process_enemy enemy_callback: enemy detected")
+		--utils_data.debug_write(strformat("action_process_enemy:enemy_callback is_enemy true"))
+		-- keep track of actor enemies
+		if (ene_id == AC_ID and not fighting_with_actor_npcs[id]) then
+			fighting_with_actor_npcs[id] = true
+			SendScriptCallback("npc_on_fighting_actor",npc)
+		end
+
+		-- Set smart alarm (unused in coc)
+		--[[
+		local sim = alife()
+		local se_obj = sim:object(id)
+		if (se_obj and se_obj.m_smart_terrain_id ~= 65535) then
+			local smart = sim:object(se_obj.m_smart_terrain_id)
+			if (smart) then
+				smart:set_alarm()
+			end
+		end
+		--]]
+		return true
+	end
+	
+---[[ #if MODED_EXE
+	--[[
+	It's incorrect to set nil enemy_id here.
+	enemy_callback() check for everyone this npc can see or hear.
+	Problems:
+		enemy_id is a legit enemy from the previous check can be reset if the current enemy check fails.
+		enemy_id might not be reset if there is no more enemy around to fire this callback.
+	--]]
+--[[ #else
+	db.storage[id].enemy_id = nil
+-- #endif ]]
+
+	if (ene_id == AC_ID) then
+		fighting_with_actor_npcs[id] = nil
+		save_var(npc,"xr_combat_ignore_enabled",nil)
+	end
+	
+	--utils_data.debug_write(strformat("action_process_enemy:enemy_callback is_enemy false"))
+	--printf("-action_process_enemy enemy_callback: no enemy")
+	return false	
+end
+
+function action_process_enemy:hit_callback(obj, amount, local_direction, who, bone_index)
+	if (load_var(obj,"xr_combat_ignore_enabled") == false) then 
+		return 
+	end
+	if (amount > 0 and who and who:id() == AC_ID) then
+		local sim = alife()
+		local se_obj = sim:object(obj:id())
+		if (se_obj) then 
+			local squad = se_obj.group_id and se_obj.group_id ~= 65535 and sim:object(se_obj.group_id)
+			if (squad) then
+				-- disable combat ignore for entire squad if attacked by actor
+				for k in squad:squad_members() do 
+					local st = db.storage[k.id]
+					if (st) then
+						if (st.overrides == nil or st.overrides.combat_ignore_keep_when_attacked ~= true) then
+							--st.combat_ignore.enabled = false
+							save_var(st.object,"xr_combat_ignore_enabled",false)
+						end
+					end
+				end
+			else 
+				local overrides = db.storage[obj:id()] and db.storage[obj:id()].overrides
+				if not overrides or not overrides.combat_ignore_keep_when_attacked then
+					--self.st.enabled = false
+					save_var(obj,"xr_combat_ignore_enabled",false)
+				end
+			end
+		end
+	end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- binder
+----------------------------------------------------------------------------------------------------------------------
+function setup_generic_scheme(npc,ini,scheme,section,stype,temp)
+	local st = xr_logic.assign_storage_and_bind(npc,ini,"combat_ignore",section,temp)
+end
+
+function add_to_binder(npc,ini,scheme,section,st,temp)
+	st.action = action_process_enemy(npc,st)
+end
+
+function reset_generic_scheme(npc,scheme,section,stype,st)
+	local storage = st.combat_ignore
+	if not (storage) then 
+		printf("xr_combat_ignore: reset_generic_scheme storage is nil! npc=%s scheme=%s section=%s",npc and npc:name(),scheme,section)
+		return
+	end
+	npc:set_enemy_callback(storage.action.enemy_callback,storage.action)
+	xr_logic.subscribe_action_for_events(npc, storage, storage.action)
+	--storage.enabled = true
+end
+
+function disable_generic_scheme(npc,scheme,stype)
+	npc:set_enemy_callback()
+
+	local st = db.storage[npc:id()][scheme]
+	if st then
+		xr_logic.unsubscribe_action_from_events(npc, st, st.action)
+	end
+end

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1574,12 +1574,21 @@ void CActor::detach_Vehicle(bool bForce)
 		CCar *car = smart_cast<CCar *>(m_holder);
 #ifdef CAR_NEW
 		if (car && car->IsRemoteControl() == false)
-#endif
 		{
 			character_physics_support()->movement()->SetPosition(m_holder->ExitPosition());
 			character_physics_support()->movement()->SetVelocity(m_holder->ExitVelocity());
 			cam_Active()->Direction().set(Fvector().setHP(GO->Direction().getH(), 0.0F));
 		}
+#endif
+#ifdef STATIONARYMGUN_NEW
+		CWeaponStatMgun *stm = smart_cast<CWeaponStatMgun *>(m_holder);
+		if (stm)
+		{
+			character_physics_support()->movement()->SetPosition(m_holder->ExitPosition());
+			character_physics_support()->movement()->SetVelocity(m_holder->ExitVelocity());
+			cam_Active()->Direction().set(Fvector().setHP(GO->Direction().getH(), 0.0F));
+		}
+#endif
 
 		m_holder->detach_Actor();
 		m_holder = NULL;

--- a/src/xrGame/Explosive.cpp
+++ b/src/xrGame/Explosive.cpp
@@ -76,7 +76,7 @@ CExplosive::CExplosive(void)
 	m_bDynamicParticles = FALSE;
 	m_pExpParticle = NULL;
 
-#ifdef CEXPLOSIVE_CHANGE
+#ifdef EXPLOSIVE_CHANGE
 	m_on_explode_callback._set("");
 #endif
 }
@@ -168,7 +168,7 @@ void CExplosive::Load(CInifile const* ini, LPCSTR section)
 	if (ini->line_exist(section, "dynamic_explosion_particles"))
 		m_bDynamicParticles = ini->r_bool(section, "dynamic_explosion_particles");
 
-#ifdef CEXPLOSIVE_CHANGE
+#ifdef EXPLOSIVE_CHANGE
 	m_on_explode_callback._set(READ_IF_EXISTS(ini, r_string, section, "on_explode", ""));
 #endif
 }
@@ -585,7 +585,7 @@ void CExplosive::OnAfterExplosion()
 
 void CExplosive::OnBeforeExplosion()
 {
-#ifdef CEXPLOSIVE_CHANGE
+#ifdef EXPLOSIVE_CHANGE
 	if (m_on_explode_callback.size())
 	{
 		::luabind::functor<void> lua_function;
@@ -867,7 +867,7 @@ bool CExplosive::Useful() const
 	return m_explosion_flags.flags == 0;
 }
 
-#ifdef CEXPLOSIVE_CHANGE
+#ifdef EXPLOSIVE_CHANGE
 void CExplosive::LoadExplosiveSection(LPCSTR section)
 {
 	CExplosive::Load(pSettings, section);

--- a/src/xrGame/Explosive.h
+++ b/src/xrGame/Explosive.h
@@ -14,11 +14,6 @@
 #include "ParticlesObject.h"
 #include "hudsound.h"
 
-// GhenTuong: on_explode callback
-#ifndef CEXPLOSIVE_CHANGE
-#define CEXPLOSIVE_CHANGE
-#endif
-
 class IRender_Light;
 DEFINE_VECTOR(CPhysicsShellHolder*, BLASTED_OBJECTS_V, BLASTED_OBJECTS_I);
 
@@ -188,7 +183,7 @@ protected:
 		shared_str effect_sect_name;
 	} effector;
 
-#ifdef CEXPLOSIVE_CHANGE
+#ifdef EXPLOSIVE_CHANGE
 	shared_str m_on_explode_callback;
 	void LoadExplosiveSection(LPCSTR section);
 	void LoadExplosiveSection(CInifile *ini, LPCSTR section);

--- a/src/xrGame/Grenade.cpp
+++ b/src/xrGame/Grenade.cpp
@@ -13,12 +13,22 @@
 #include "xrserver_objects_alife.h"
 #include "script_game_object.h"
 
+#ifdef EXPLOSIVE_CHANGE
+#include "../xrEngine/GameMtlLib.h"
+#include "../xrphysics/ExtendedGeom.h"
+#include "../xrphysics/CalculateTriangle.h"
+#include "../xrphysics/tri-colliderknoopc/dctriangle.h"
+#endif
+
 #define GRENADE_REMOVE_TIME		30000
 const float default_grenade_detonation_threshold_hit = 100;
 
 CGrenade::CGrenade(void)
 {
 	m_destroy_callback.clear();
+#ifdef EXPLOSIVE_CHANGE
+	m_on_grenade_explode_callback._set("");
+#endif
 }
 
 CGrenade::~CGrenade(void)
@@ -38,6 +48,11 @@ void CGrenade::Load(LPCSTR section)
 		m_dwGrenadeRemoveTime = GRENADE_REMOVE_TIME;
 	m_grenade_detonation_threshold_hit = READ_IF_EXISTS(pSettings, r_float, section, "detonation_threshold_hit",
 	                                                    default_grenade_detonation_threshold_hit);
+
+#ifdef EXPLOSIVE_CHANGE
+	m_on_grenade_explode_callback._set(READ_IF_EXISTS(pSettings, r_string, section, "on_grenade_explode", ""));
+	m_contact.enabled = !!READ_IF_EXISTS(pSettings, r_bool, section, "explode_on_contact", FALSE);
+#endif
 }
 
 void CGrenade::Hit(SHit* pHDS)
@@ -285,6 +300,10 @@ void CGrenade::UpdateCL()
 	CExplosive::UpdateCL();
 
 	if (!IsGameTypeSingle()) make_Interpolation();
+
+#ifdef EXPLOSIVE_CHANGE
+	ContactUpdateCL();
+#endif
 }
 
 
@@ -385,3 +404,156 @@ bool CGrenade::GetBriefInfo(II_BriefInfo& info)
 	info.cur_ammo._set(stmp);
 	return true;
 }
+
+#ifdef EXPLOSIVE_CHANGE
+void CGrenade::activate_physic_shell()
+{
+	inherited::activate_physic_shell();
+	if (PPhysicsShell())
+	{
+		PPhysicsShell()->add_ObjectContactCallback(GrenadeContactCallback);
+	}
+}
+
+void CGrenade::Contact(const Fvector &pos, const Fvector &vel, const LPCSTR mtl)
+{
+	m_contact.contact = true;
+	m_contact.position.set(pos);
+	m_contact.velocity.set(vel);
+	m_contact.material._set(mtl ? mtl : "");
+}
+
+void CGrenade::ContactUpdateCL()
+{
+	if (!m_contact.contact)
+	{
+		return;
+	}
+	m_contact.contact = false;
+	m_contact.explode = true;
+
+	if (PPhysicsShell())
+	{
+		PPhysicsShell()->set_LinearVel(zero_vel);
+		PPhysicsShell()->set_AngularVel(zero_vel);
+		PPhysicsShell()->remove_ObjectContactCallback(GrenadeContactCallback);
+		PPhysicsShell()->Disable();
+	}
+	Position().set(m_contact.position);
+	Destroy();
+}
+
+void CGrenade::GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SGameMtl *material_1, SGameMtl *material_2)
+{
+	dxGeomUserData *gd1 = PHRetrieveGeomUserData(c.geom.g1);
+	dxGeomUserData *gd2 = PHRetrieveGeomUserData(c.geom.g2);
+
+	SGameMtl *material = nullptr;
+	Fvector normal;
+	CGrenade *gnd = gd1 ? smart_cast<CGrenade *>(gd1->ph_ref_object) : nullptr;
+	if (!gnd)
+	{
+		gnd = gd2 ? smart_cast<CGrenade *>(gd2->ph_ref_object) : nullptr;
+		normal.invert(*(Fvector *)&c.geom.normal);
+		material = material_1;
+	}
+	else
+	{
+		normal.set(*(Fvector *)&c.geom.normal);
+		material = material_2;
+	}
+	VERIFY(material);
+
+	if (material->Flags.is(SGameMtl::flPassable))
+		return;
+
+	if (gnd == nullptr || gnd->m_contact.enabled != true || gnd->m_contact.contact == true)
+		return;
+
+	CGameObject *who = gd1 ? smart_cast<CGameObject *>(gd1->ph_ref_object) : NULL;
+	if (!who || who == (CGameObject *)gnd)
+	{
+		who = gd2 ? smart_cast<CGameObject *>(gd2->ph_ref_object) : NULL;
+	}
+
+	if (!who || who->ID() != gnd->CurrentParentID())
+	{
+		Fvector pos;
+		pos.set(gnd->Position());
+		dxGeomUserData *l_pMYU = bo1 ? gd1 : gd2;
+		VERIFY(l_pMYU);
+		if (l_pMYU->last_pos[0] != -dInfinity)
+		{
+			pos = cast_fv(l_pMYU->last_pos);
+		}
+		if (!gd1 || !gd2)
+		{
+			dGeomID GID = (gd1) ? c.geom.g1 : c.geom.g2;
+			dxGeomUserData *&GUD = gd1 ? gd1 : gd2;
+
+			if (GUD->pushing_neg)
+			{
+				Fvector velocity;
+				gnd->PHGetLinearVell(velocity);
+				if (velocity.square_magnitude() > EPS)
+				{
+					velocity.normalize();
+					Triangle neg_tri;
+					CalculateTriangle(GUD->neg_tri, GID, neg_tri, Level().ObjectSpace.GetStaticVerts());
+					float cosinus = velocity.dotproduct(*((Fvector *)neg_tri.norm));
+					VERIFY(_valid(neg_tri.dist));
+					float dist = neg_tri.dist / cosinus;
+					velocity.mul(dist * 1.1f);
+					pos.sub(velocity);
+				}
+			}
+		}
+		Fvector vel;
+		gnd->PHGetLinearVell(vel);
+		gnd->Contact(pos, vel, material->m_Name.c_str());
+		R_ASSERT(gnd->m_pPhysicsShell);
+		gnd->m_pPhysicsShell->DisableCollision();
+		gnd->m_pPhysicsShell->set_LinearVel(zero_vel);
+		gnd->m_pPhysicsShell->set_AngularVel(zero_vel);
+		gnd->m_pPhysicsShell->setForce(zero_vel);
+		gnd->m_pPhysicsShell->setTorque(zero_vel);
+		gnd->m_pPhysicsShell->set_ApplyByGravity(false);
+		gnd->setEnabled(FALSE);
+
+		do_colide = false;
+	}
+}
+
+void CGrenade::OnBeforeExplosion()
+{
+	CExplosive::OnBeforeExplosion();
+	if (m_on_grenade_explode_callback.size())
+	{
+		::luabind::functor<void> lua_function;
+		if (ai().script_engine().functor(m_on_grenade_explode_callback.c_str(), lua_function))
+		{
+			Fvector pos;
+			Fvector vel;
+			LPCSTR mtl = "";
+			if (m_contact.explode)
+			{
+				pos.set(m_contact.position);
+				vel.set(m_contact.velocity);
+				mtl = m_contact.material.c_str();
+			}
+			else
+			{
+				pos.set(Position());
+				PHGetLinearVell(vel);
+				mtl = "";
+			}
+			::luabind::object lua_table = ::luabind::newtable(ai().script_engine().lua());
+			lua_table["flag"] = m_contact.explode;
+			lua_table["position"] = pos;
+			lua_table["velocity"] = vel;
+			lua_table["material"] = mtl;
+			lua_function(lua_game_object(), lua_table);
+		}
+	}
+}
+#endif

--- a/src/xrGame/Grenade.cpp
+++ b/src/xrGame/Grenade.cpp
@@ -415,11 +415,12 @@ void CGrenade::activate_physic_shell()
 	}
 }
 
-void CGrenade::Contact(const Fvector &pos, const Fvector &vel, const LPCSTR mtl)
+void CGrenade::Contact(const Fvector &pos, const Fvector &vel, const Fvector &nor, const LPCSTR mtl)
 {
 	m_contact.contact = true;
 	m_contact.position.set(pos);
 	m_contact.velocity.set(vel);
+	m_contact.normal.set(nor);
 	m_contact.material._set(mtl ? mtl : "");
 }
 
@@ -448,23 +449,25 @@ void CGrenade::GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SG
 	dxGeomUserData *gd1 = PHRetrieveGeomUserData(c.geom.g1);
 	dxGeomUserData *gd2 = PHRetrieveGeomUserData(c.geom.g2);
 
-	SGameMtl *material = nullptr;
-	Fvector normal;
+	SGameMtl *mtl = nullptr;
+	Fvector pos;
+	Fvector nor;
+	pos.set(*(Fvector *)&c.geom.pos);
 	CGrenade *gnd = gd1 ? smart_cast<CGrenade *>(gd1->ph_ref_object) : nullptr;
 	if (!gnd)
 	{
 		gnd = gd2 ? smart_cast<CGrenade *>(gd2->ph_ref_object) : nullptr;
-		normal.invert(*(Fvector *)&c.geom.normal);
-		material = material_1;
+		nor.invert(*(Fvector *)&c.geom.normal);
+		mtl = material_1;
 	}
 	else
 	{
-		normal.set(*(Fvector *)&c.geom.normal);
-		material = material_2;
+		nor.set(*(Fvector *)&c.geom.normal);
+		mtl = material_2;
 	}
-	VERIFY(material);
+	VERIFY(mtl);
 
-	if (material->Flags.is(SGameMtl::flPassable))
+	if (mtl->Flags.is(SGameMtl::flPassable))
 		return;
 
 	if (gnd == nullptr || gnd->m_contact.enabled != true || gnd->m_contact.contact == true)
@@ -478,8 +481,7 @@ void CGrenade::GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SG
 
 	if (!who || who->ID() != gnd->CurrentParentID())
 	{
-		Fvector pos;
-		pos.set(gnd->Position());
+#if 0 /* Copy from CCustomRocket. No idea what these do. Don't seem to work. */
 		dxGeomUserData *l_pMYU = bo1 ? gd1 : gd2;
 		VERIFY(l_pMYU);
 		if (l_pMYU->last_pos[0] != -dInfinity)
@@ -508,9 +510,10 @@ void CGrenade::GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SG
 				}
 			}
 		}
+#endif
 		Fvector vel;
 		gnd->PHGetLinearVell(vel);
-		gnd->Contact(pos, vel, material->m_Name.c_str());
+		gnd->Contact(pos, vel, nor, mtl->m_Name.c_str());
 		R_ASSERT(gnd->m_pPhysicsShell);
 		gnd->m_pPhysicsShell->DisableCollision();
 		gnd->m_pPhysicsShell->set_LinearVel(zero_vel);
@@ -534,23 +537,27 @@ void CGrenade::OnBeforeExplosion()
 		{
 			Fvector pos;
 			Fvector vel;
+			Fvector nor;
 			LPCSTR mtl = "";
 			if (m_contact.explode)
 			{
 				pos.set(m_contact.position);
 				vel.set(m_contact.velocity);
+				nor.set(m_contact.normal);
 				mtl = m_contact.material.c_str();
 			}
 			else
 			{
 				pos.set(Position());
 				PHGetLinearVell(vel);
+				nor.set(0.0F, 1.0F, 0.0F);
 				mtl = "";
 			}
 			::luabind::object lua_table = ::luabind::newtable(ai().script_engine().lua());
 			lua_table["flag"] = m_contact.explode;
 			lua_table["position"] = pos;
 			lua_table["velocity"] = vel;
+			lua_table["normal"] = nor;
 			lua_table["material"] = mtl;
 			lua_function(lua_game_object(), lua_table);
 		}

--- a/src/xrGame/Grenade.h
+++ b/src/xrGame/Grenade.h
@@ -3,6 +3,27 @@
 #include "explosive.h"
 #include "../xrEngine/feel_touch.h"
 
+#ifdef EXPLOSIVE_CHANGE
+struct SGrenadeContact
+{
+	bool enabled; /* Enable explode by contact. */
+	bool contact; /* Set true on grenade contact callback, used for ContactUpdateCL. */
+	bool explode; /* Grenade explode by contact. (not by time out) */
+	Fvector position;
+	Fvector velocity;
+	shared_str material;
+	SGrenadeContact()
+	{
+		enabled = false;
+		contact = false;
+		explode = false;
+		position.set(0.0F, 0.0F, 0.0F);
+		velocity.set(0.0F, 0.0F, 0.0F);
+		material._set("");
+	}
+};
+#endif
+
 class CGrenade :
 	public CMissile,
 	public CExplosive
@@ -75,6 +96,17 @@ public:
 	{
 		m_destroy_callback = callback;
 	}
+
+#ifdef EXPLOSIVE_CHANGE
+	SGrenadeContact m_contact;
+	virtual void activate_physic_shell();
+	void Contact(const Fvector &pos, const Fvector &vel, const LPCSTR mtl);
+	void ContactUpdateCL();
+	static void GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SGameMtl *mtl_1, SGameMtl *mtl_2);
+
+	shared_str m_on_grenade_explode_callback;
+	void OnBeforeExplosion();
+#endif
 
 private:
 	destroy_callback m_destroy_callback;

--- a/src/xrGame/Grenade.h
+++ b/src/xrGame/Grenade.h
@@ -11,6 +11,7 @@ struct SGrenadeContact
 	bool explode; /* Grenade explode by contact. (not by time out) */
 	Fvector position;
 	Fvector velocity;
+	Fvector normal;
 	shared_str material;
 	SGrenadeContact()
 	{
@@ -19,6 +20,7 @@ struct SGrenadeContact
 		explode = false;
 		position.set(0.0F, 0.0F, 0.0F);
 		velocity.set(0.0F, 0.0F, 0.0F);
+		normal.set(0.0F, 1.0F, 0.0F);
 		material._set("");
 	}
 };
@@ -100,7 +102,7 @@ public:
 #ifdef EXPLOSIVE_CHANGE
 	SGrenadeContact m_contact;
 	virtual void activate_physic_shell();
-	void Contact(const Fvector &pos, const Fvector &vel, const LPCSTR mtl);
+	void Contact(const Fvector &pos, const Fvector &vel, const Fvector &nor, const LPCSTR mtl);
 	void ContactUpdateCL();
 	static void GrenadeContactCallback(bool &do_colide, bool bo1, dContact &c, SGameMtl *mtl_1, SGameMtl *mtl_2);
 

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -141,6 +141,8 @@ public:
 	void set_mFirePoint(Fvector &fire_point);
 	void set_mFirePoint2(Fvector &fire_point);
 	void set_mShellPoint(Fvector &fire_point);
+	Fmatrix get_mOffset() { return m_Offset; };
+	Fmatrix get_mStrapOffset() { return m_StrapOffset; };
 
 	virtual void create_physic_shell();
 	virtual void activate_physic_shell();

--- a/src/xrGame/WeaponAK74.cpp
+++ b/src/xrGame/WeaponAK74.cpp
@@ -140,6 +140,13 @@ void CWeaponAK74::script_register	(lua_State *L)
 			.def("Set_mFirePoint2", &CWeapon::set_mFirePoint2)
 			.def("Set_mShellPoint", &CWeapon::set_mShellPoint)
 
+			.def("Get_mOffset", &CWeapon::get_mOffset)
+			.def("Get_mStrapOffset", &CWeapon::get_mStrapOffset)
+			.def("Get_strap_bone0", &CWeapon::strap_bone0)
+			.def("Get_strap_bone1", &CWeapon::strap_bone1)
+			.def("Get_strapped_mode", (bool (CWeapon::*)() const)&CWeapon::strapped_mode)
+			.def("HandDependence", &CWeapon::HandDependence)
+
 			// Cam Recoil
 			// Getters
 			.def("GetCamRelaxSpeed", &CWeapon::GetCamRelaxSpeed)

--- a/src/xrGame/level_graph.h
+++ b/src/xrGame/level_graph.h
@@ -248,6 +248,7 @@ public:
 	IC Fvector2 v2d(const Fvector& vector3d) const;
 	IC bool valid_vertex_position(const Fvector& position) const;
 	bool neighbour_in_direction(const Fvector& direction, u32 start_vertex_id) const;
+	void nearby_vertices(const Fvector &position, float radius, xr_vector<CVertex *> &res) const;
 
 	IC CVertex* vertices() { return m_nodes; }
 

--- a/src/xrGame/level_graph_vertex.cpp
+++ b/src/xrGame/level_graph_vertex.cpp
@@ -577,3 +577,18 @@ bool CLevelGraph::neighbour_in_direction(const Fvector& direction, u32 start_ver
 	}
 	return (false);
 }
+
+void CLevelGraph::nearby_vertices(const Fvector &position, float radius, xr_vector<CVertex *> &res) const
+{
+	float radius_sqr = _sqr(radius);
+	for (u32 i = 0; i < header().vertex_count(); ++i)
+	{
+		CVertex *ver = m_nodes + i;
+		Fvector vec;
+		vertex_position(vec, ver->position());
+		if (vec.distance_to_xz_sqr(position) < radius_sqr)
+		{
+			res.push_back(ver);
+		}
+	}
+}

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -58,6 +58,8 @@
 #include "ui\UILogsWnd.h"
 #include "game_news.h"
 #include "alife_registry_wrappers.h"
+#include "cover_manager.h"
+#include "cover_point.h"
 
 using namespace luabind;
 
@@ -290,6 +292,28 @@ void change_game_time(u32 days, u32 hours, u32 mins)
 		g_pGamePersistent->Environment().ChangeGameTime(fValue);
 		tpGame->alife().time_manager().change_game_time(value);
 	}
+}
+
+::luabind::object get_nearby_covers(const Fvector &pos, float radius)
+{
+	xr_vector<CCoverPoint *> nearby_covers;
+	nearby_covers.clear();
+	ai().cover_manager().covers().nearest(pos, radius, nearby_covers);
+	::luabind::object lua_table = ::luabind::newtable(ai().script_engine().lua());
+	for (auto &I : nearby_covers)
+	{
+		lua_table[I->level_vertex_id()] = true;
+	}
+	return lua_table;
+}
+
+u32 vertex_link(u32 level_vertex_id, int index)
+{
+	if (!ai().level_graph().valid_vertex_id(level_vertex_id))
+	{
+		return u32(-1);
+	}
+	return ai().level_graph().vertex(level_vertex_id)->link(index);
 }
 
 float high_cover_in_direction(u32 level_vertex_id, const Fvector& direction)
@@ -2390,6 +2414,8 @@ void CLevel::script_register(lua_State* L)
 			def("get_time_minutes", get_time_minutes),
 			def("change_game_time", change_game_time),
 
+			def("get_nearby_covers", get_nearby_covers),
+			def("vertex_link", vertex_link),
 			def("high_cover_in_direction", high_cover_in_direction),
 			def("low_cover_in_direction", low_cover_in_direction),
 			def("vertex_in_direction", vertex_in_direction),

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1111,6 +1111,19 @@ u32 vertex_id(Fvector position)
 	return (ai().level_graph().vertex_id(position));
 }
 
+::luabind::object get_nearby_vertices(const Fvector &pos, float radius)
+{
+	xr_vector<CLevelGraph::CVertex *> nearby_vertices;
+	nearby_vertices.clear();
+	ai().level_graph().nearby_vertices(pos, radius, nearby_vertices);
+	::luabind::object lua_table = ::luabind::newtable(ai().script_engine().lua());
+	for (auto &I : nearby_vertices)
+	{
+		lua_table[ai().level_graph().vertex_id(I)] = true;
+	}
+	return lua_table;
+}
+
 u32 render_get_dx_level()
 {
 	return ::Render->get_dx_level();
@@ -2500,6 +2513,7 @@ void CLevel::script_register(lua_State* L)
 			def("remove_complex_effector", &remove_complex_effector),
 
 			def("vertex_id", &vertex_id),
+			def("get_nearby_vertices", &get_nearby_vertices),
 
 			def("game_id", &GameID),
 			def("ray_pick", &ray_pick),

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -957,6 +957,7 @@ public:
 	_DECLARE_FUNCTION14(cast_FoodItem, CFoodItem);
 	_DECLARE_FUNCTION14(cast_BottleItem, CBottleItem);
 	_DECLARE_FUNCTION14(cast_Missile, CMissile);
+	_DECLARE_FUNCTION14(cast_Explosive, CExplosive);
 
 	void SetHealthEx(float hp); //AVO
 	float GetLuminocityHemi();

--- a/src/xrGame/script_game_object4.cpp
+++ b/src/xrGame/script_game_object4.cpp
@@ -537,6 +537,7 @@ SPECIFIC_CAST(CScriptGameObject::cast_Knife, CWeaponKnife);
 SPECIFIC_CAST(CScriptGameObject::cast_WeaponMagazined, CWeaponMagazined);
 SPECIFIC_CAST(CScriptGameObject::cast_WeaponMagazinedWGrenade, CWeaponMagazinedWGrenade);
 SPECIFIC_CAST(CScriptGameObject::cast_Missile, CMissile);
+SPECIFIC_CAST(CScriptGameObject::cast_Explosive, CExplosive);
 CMedkit* CScriptGameObject::cast_Medkit()
 {
 	CInventoryItem* ii = object().cast_inventory_item();

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -530,6 +530,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("cast_FoodItem", &CScriptGameObject::cast_FoodItem)
 		.def("cast_BottleItem", &CScriptGameObject::cast_BottleItem)
 		.def("cast_Missile", &CScriptGameObject::cast_Missile)
+		.def("cast_Explosive", &CScriptGameObject::cast_Explosive)
 		//Alundaio: END
 
 		//Torch


### PR DESCRIPTION
level_graph:
	LUA: level.get_nearby_vertices(...) can be used to collect nearby vertices.
	LUA: level.vertex_link(...) can be used to get the vertices that is connected to the current vertex.
	LUA: level.get_nearby_covers(...) can be used to collect nearby vertices that are covers.

CExplosive, CGrenade:
	Unify changes under #define EXPLOSIVE_CHANGE.
	"on_grenade_explode" can be added to grenade configuration section to fire a callback when the grenade explode.
	"explode_on_contact" can be added to grenade configuration section to make the grenade explode when it lands on a solid surface.
	Export explosive object and grenade get/set functions.

CWeaponStatMgun:
	Set Actor position when leaving machine gun turret.

CWeapon:
	Export:
        Get_mOffset
        Get_mStrapOffset
        Get_strap_bone0
        Get_strap_bone1
        Get_strapped_mode
        HandDependence

Script mutant movement:
	Allow the use of move.walk_fwd and move.run_fwd since they're also legit movement flags.

scripts\xr_combat_ignore.script
	Add a fix to properly set enemy_id to nil when the enemy is no longer valid.