### PR TITLE
fix race in refcount

### DIFF
--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -446,7 +446,7 @@ void CResourceManager::_DumpMemoryUsage()
 		{
 			u32 m = I->second->flags.MemoryUsage;
 			shared_str n = I->second->cName;
-			mtex.insert(mk_pair(m, mk_pair(I->second->dwReference, n)));
+			mtex.insert(mk_pair(m, mk_pair(I->second->dwReference.load(std::memory_order_relaxed), n)));
 		}
 	}
 

--- a/src/Layers/xrRender/ResourceManager_Loader.cpp
+++ b/src/Layers/xrRender/ResourceManager_Loader.cpp
@@ -13,7 +13,7 @@ void CResourceManager::OnDeviceDestroy(BOOL)
 	// Matrices
 	for (map_Matrix::iterator m = m_matrices.begin(); m != m_matrices.end(); m++)
 	{
-		R_ASSERT(1==m->second->dwReference);
+		R_ASSERT(1==m->second->dwReference.load(std::memory_order_relaxed));
 		xr_delete(m->second);
 	}
 	m_matrices.clear();
@@ -21,7 +21,7 @@ void CResourceManager::OnDeviceDestroy(BOOL)
 	// Constants
 	for (map_Constant::iterator c = m_constants.begin(); c != m_constants.end(); c++)
 	{
-		R_ASSERT(1==c->second->dwReference);
+		R_ASSERT(1==c->second->dwReference.load(std::memory_order_relaxed));
 		xr_delete(c->second);
 	}
 	m_constants.clear();

--- a/src/Layers/xrRender/ResourceManager_Reset.cpp
+++ b/src/Layers/xrRender/ResourceManager_Reset.cpp
@@ -103,7 +103,7 @@ void mdump(C c)
 {
 	if (0 == c.size()) return;
 	for (C::iterator I = c.begin(); I != c.end(); I++)
-		Msg("*        : %3d: %s", I->second->dwReference, I->second->cName.c_str());
+		Msg("*        : %3d: %s", I->second->dwReference.load(std::memory_order_relaxed), I->second->cName.c_str());
 }
 
 CResourceManager::~CResourceManager()

--- a/src/Layers/xrRender/ResourceManager_Resources.cpp
+++ b/src/Layers/xrRender/ResourceManager_Resources.cpp
@@ -533,7 +533,7 @@ CMatrix* CResourceManager::_CreateMatrix(LPCSTR Name)
 	{
 		CMatrix* M = xr_new<CMatrix>();
 		M->dwFlags |= xr_resource_flagged::RF_REGISTERED;
-		M->dwReference = 1;
+		M->dwReference.store(1, std::memory_order_relaxed);
 		m_matrices.insert(mk_pair(M->set_name(Name), M));
 		return M;
 	}
@@ -571,7 +571,7 @@ CConstant* CResourceManager::_CreateConstant(LPCSTR Name)
 	{
 		CConstant* C = xr_new<CConstant>();
 		C->dwFlags |= xr_resource_flagged::RF_REGISTERED;
-		C->dwReference = 1;
+		C->dwReference.store(1, std::memory_order_relaxed);
 		m_constants.insert(mk_pair(C->set_name(Name), C));
 		return C;
 	}

--- a/src/Layers/xrRenderDX10/dx10ResourceManager_Resources.cpp
+++ b/src/Layers/xrRenderDX10/dx10ResourceManager_Resources.cpp
@@ -690,7 +690,7 @@ CMatrix* CResourceManager::_CreateMatrix(LPCSTR Name)
 	{
 		CMatrix* M = xr_new<CMatrix>();
 		M->dwFlags |= xr_resource_flagged::RF_REGISTERED;
-		M->dwReference = 1;
+		M->dwReference.store(1, std::memory_order_relaxed);
 		m_matrices.insert(mk_pair(M->set_name(Name), M));
 		return M;
 	}
@@ -728,7 +728,7 @@ CConstant* CResourceManager::_CreateConstant(LPCSTR Name)
 	{
 		CConstant* C = xr_new<CConstant>();
 		C->dwFlags |= xr_resource_flagged::RF_REGISTERED;
-		C->dwReference = 1;
+		C->dwReference.store(1, std::memory_order_relaxed);
 		m_constants.insert(mk_pair(C->set_name(Name), C));
 		return C;
 	}

--- a/src/xrCore/Xr_ini.cpp
+++ b/src/xrCore/Xr_ini.cpp
@@ -1513,7 +1513,7 @@ void CInifile::save_as(IWriter& writer, bool bcheck) const
 		if (bcheck)
 		{
 			xr_sprintf(temp, sizeof(temp), "; %d %d %d", (*r_it)->Name._get()->dwCRC,
-			           (*r_it)->Name._get()->dwReference,
+			           (*r_it)->Name._get()->dwReference.load(std::memory_order_relaxed),
 			           (*r_it)->Name._get()->dwLength);
 			writer.w_string(temp);
 		}

--- a/src/xrCore/xr_resource.h
+++ b/src/xrCore/xr_resource.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fast_dynamic_cast/fast_dynamic_cast.hpp>
+#include <atomic>
 
 // resource itself, the base class for all derived resources
 class XRCORE_API xr_resource
@@ -8,11 +9,11 @@ public:
 	enum { RF_REGISTERED = 1 << 0 };
 
 public:
-	u32 dwReference;
+	std::atomic<u32> dwReference;
 
-	xr_resource() : dwReference(0)
-	{
-	}
+	xr_resource() : dwReference(0) {}
+	xr_resource(const xr_resource&) : dwReference(0) {}
+	xr_resource& operator=(const xr_resource&) { return *this; }
 };
 
 class XRCORE_API xr_resource_flagged : public xr_resource
@@ -61,20 +62,19 @@ protected:
 	void _inc()
 	{
 		if (0 == p_) return;
-		p_->dwReference++;
+		p_->dwReference.fetch_add(1, std::memory_order_relaxed);
 	}
 
 	void _dec()
 	{
 		if (0 == p_) return;
-		p_->dwReference--;
-		if (0 == p_->dwReference) xr_delete(p_);
+		if (p_->dwReference.fetch_sub(1, std::memory_order_acq_rel) == 1) xr_delete(p_);
 	}
 
 public:
 	ICF void _set(T* rhs)
 	{
-		if (0 != rhs) rhs->dwReference++;
+		if (0 != rhs) rhs->dwReference.fetch_add(1, std::memory_order_relaxed);
 		_dec();
 		p_ = rhs;
 	}

--- a/src/xrCore/xrsharedmem.cpp
+++ b/src/xrCore/xrsharedmem.cpp
@@ -15,7 +15,7 @@ smem_value* smem_container::dock(u32 dwCRC, u32 dwLength, void* ptr)
 	// search a place to insert
 	u8 storage[4 * sizeof(u32)];
 	smem_value* value = (smem_value*)storage;
-	value->dwReference = 0;
+	value->dwReference.store(0, std::memory_order_relaxed);
 	value->dwCRC = dwCRC;
 	value->dwLength = dwLength;
 	cdb::iterator it = std::lower_bound(container.begin(), container.end(), value, smem_search);
@@ -45,7 +45,7 @@ smem_value* smem_container::dock(u32 dwCRC, u32 dwLength, void* ptr)
                                                , "storage: smem"
 #endif // DEBUG_MEMORY_NAME
 		);
-		result->dwReference = 0;
+		result->dwReference.store(0, std::memory_order_relaxed);
 		result->dwCRC = dwCRC;
 		result->dwLength = dwLength;
 		CopyMemory(result->value, ptr, dwLength);
@@ -62,7 +62,7 @@ void smem_container::clean()
 	cs.Enter();
 	cdb::iterator it = container.begin();
 	cdb::iterator end = container.end();
-	for (; it != end; it++) if (0 == (*it)->dwReference) xr_free(*it);
+	for (; it != end; it++) if (0 == (*it)->dwReference.load(std::memory_order_relaxed)) xr_free(*it);
 	container.erase(remove(container.begin(), container.end(), (smem_value*)0), container.end());
 	if (container.empty()) container.clear();
 	cs.Leave();
@@ -75,7 +75,7 @@ void smem_container::dump()
 	cdb::iterator end = container.end();
 	FILE* F = fopen("x:\\$smem_dump$.txt", "w");
 	for (; it != end; it++)
-		fprintf(F, "%4u : crc[%6x], %u bytes\n", (*it)->dwReference, (*it)->dwCRC, (*it)->dwLength);
+		fprintf(F, "%4u : crc[%6x], %u bytes\n", (*it)->dwReference.load(std::memory_order_relaxed), (*it)->dwCRC, (*it)->dwLength);
 	fclose(F);
 	cs.Leave();
 }
@@ -93,7 +93,7 @@ u32 smem_container::stat_economy()
 	{
 		counter -= 16;
 		counter -= node_size;
-		counter += s64((s64((*it)->dwReference) - 1) * s64((*it)->dwLength));
+		counter += s64((s64((*it)->dwReference.load(std::memory_order_relaxed)) - 1) * s64((*it)->dwLength));
 	}
 	cs.Leave();
 

--- a/src/xrCore/xrsharedmem.h
+++ b/src/xrCore/xrsharedmem.h
@@ -2,13 +2,14 @@
 #define xrsharedmemH
 #pragma once
 
+#include <atomic>
 #pragma pack(push,4)
 //////////////////////////////////////////////////////////////////////////
 #pragma warning(push)
 #pragma warning(disable : 4200)
 struct XRCORE_API smem_value
 {
-	u32 dwReference;
+	std::atomic<u32> dwReference;
 	u32 dwCRC;
 	u32 dwLength;
 	u32 _align_16;
@@ -73,15 +74,14 @@ protected:
 	void _dec()
 	{
 		if (0 == p_) return;
-		p_->dwReference--;
-		if (0 == p_->dwReference) p_ = 0;
+		if (p_->dwReference.fetch_sub(1, std::memory_order_acq_rel) == 1) p_ = 0;
 	}
 
 public:
 	void _set(ref_smem const& rhs)
 	{
 		smem_value* v = rhs.p_;
-		if (0 != v) v->dwReference++;
+		if (0 != v) v->dwReference.fetch_add(1, std::memory_order_relaxed);
 		_dec();
 		p_ = v;
 	}
@@ -102,7 +102,7 @@ public:
 	void create(u32 dwCRC, u32 dwLength, T* ptr)
 	{
 		smem_value* v = g_pSharedMemoryContainer->dock(dwCRC, dwLength * sizeof(T), ptr);
-		if (0 != v) v->dwReference++;
+		if (0 != v) v->dwReference.fetch_add(1, std::memory_order_relaxed);
 		_dec();
 		p_ = v;
 	}
@@ -137,7 +137,7 @@ public:
 	u32 ref_count()
 	{
 		if (0 == p_) return 0;
-		else return p_->dwReference;
+		else return p_->dwReference.load(std::memory_order_relaxed);
 	}
 };
 

--- a/src/xrCore/xrstring.cpp
+++ b/src/xrCore/xrstring.cpp
@@ -56,7 +56,7 @@ struct str_container_impl
 			while (*current != NULL)
 			{
 				str_value* value = *current;
-				if (!value->dwReference)
+				if (!value->dwReference.load(std::memory_order_relaxed))
 				{
 					*current = value->next;
 					xr_free(value);
@@ -96,7 +96,7 @@ struct str_container_impl
 			str_value* value = buffer[i];
 			while (value)
 			{
-				fprintf(f, "ref[%4u]-len[%3u]-crc[%8X] : %s\n", value->dwReference, value->dwLength, value->dwCRC,
+				fprintf(f, "ref[%4u]-len[%3u]-crc[%8X] : %s\n", value->dwReference.load(std::memory_order_relaxed), value->dwLength, value->dwCRC,
 				        value->value);
 				value = value->next;
 			}
@@ -111,7 +111,7 @@ struct str_container_impl
 			string4096 temp;
 			while (value)
 			{
-				xr_sprintf(temp, sizeof(temp), "ref[%4u]-len[%3u]-crc[%8X] : %s\n", value->dwReference, value->dwLength,
+				xr_sprintf(temp, sizeof(temp), "ref[%4u]-len[%3u]-crc[%8X] : %s\n", value->dwReference.load(std::memory_order_relaxed), value->dwLength,
 				           value->dwCRC, value->value);
 				f->w_string(temp);
 				value = value->next;
@@ -129,7 +129,7 @@ struct str_container_impl
 			{
 				count += 1;
 				counter -= sizeof(str_value);
-				counter += (value->dwReference - 1) * (value->dwLength + 1);
+				counter += (value->dwReference.load(std::memory_order_relaxed) - 1) * (value->dwLength + 1);
 				value = value->next;
 			}
 		}
@@ -163,7 +163,7 @@ str_value* str_container::dock(str_c value)
 	// setup find structure
 	char header[sizeof(str_value)];
 	str_value* sv = (str_value*)header;
-	sv->dwReference = 0;
+	sv->dwReference.store(0, std::memory_order_relaxed);
 	sv->dwLength = s_len;
 	sv->dwCRC = crc32(value, s_len);
 
@@ -196,7 +196,7 @@ str_value* str_container::dock(str_c value)
         }
 #endif // DEBUG
 
-		result->dwReference = 0;
+		result->dwReference.store(0, std::memory_order_relaxed);
 		result->dwLength = sv->dwLength;
 		result->dwCRC = sv->dwCRC;
 		CopyMemory(result->value, value, s_len_with_zero);
@@ -303,7 +303,7 @@ str_value* str_container::dock(str_c value)
     // setup find structure
     char header[sizeof(str_value)];
     str_value* sv = (str_value*)header;
-    sv->dwReference = 0;
+    sv->dwReference.store(0, std::memory_order_relaxed);
     sv->dwLength = s_len;
     sv->dwCRC = crc32(value, s_len);
     sv->next = NULL;
@@ -348,7 +348,7 @@ str_value* str_container::dock(str_c value)
 
         // DUMP_PHASE;
 
-        result->dwReference = 0;
+        result->dwReference.store(0, std::memory_order_relaxed);
         result->dwLength = sv->dwLength;
         result->dwCRC = sv->dwCRC;
         result->next = NULL;
@@ -371,7 +371,7 @@ void str_container::clean()
     for (; it != end;)
     {
         str_value* sv = *it;
-        if (0 == sv->dwReference)
+        if (0 == sv->dwReference.load(std::memory_order_relaxed))
         {
             str_container_impl::cdb::iterator i_current = it;
             str_container_impl::cdb::iterator i_next = ++it;
@@ -411,7 +411,7 @@ void str_container::dump()
     str_container_impl::cdb::iterator end = impl->container.end();
     FILE* F = fopen("d:\\$str_dump$.txt", "w");
     for (; it != end; it++)
-        fprintf(F, "ref[%4d]-len[%3d]-crc[%8X] : %s\n", (*it)->dwReference, (*it)->dwLength, (*it)->dwCRC, (*it)->value);
+        fprintf(F, "ref[%4d]-len[%3d]-crc[%8X] : %s\n", (*it)->dwReference.load(std::memory_order_relaxed), (*it)->dwLength, (*it)->dwCRC, (*it)->value);
     fclose(F);
     cs.Leave();
 }
@@ -429,7 +429,7 @@ u32 str_container::stat_economy()
     {
         counter -= HEADER;
         counter -= node_size;
-        counter += int((int((*it)->dwReference) - 1)*int((*it)->dwLength + 1));
+        counter += int((int((*it)->dwReference.load(std::memory_order_relaxed)) - 1)*int((*it)->dwLength + 1));
     }
     cs.Leave();
 

--- a/src/xrCore/xrstring.h
+++ b/src/xrCore/xrstring.h
@@ -2,6 +2,7 @@
 #define xrstringH
 #pragma once
 
+#include <atomic>
 #pragma pack(push,4)
 //////////////////////////////////////////////////////////////////////////
 typedef const char* str_c;
@@ -11,7 +12,7 @@ typedef const char* str_c;
 #pragma warning(disable : 4200)
 struct XRCORE_API str_value
 {
-	u32 dwReference;
+	std::atomic<u32> dwReference;
 	u32 dwLength;
 	u32 dwCRC;
 	str_value* next;
@@ -67,15 +68,14 @@ protected:
 	void _dec()
 	{
 		if (0 == p_) return;
-		p_->dwReference--;
-		if (0 == p_->dwReference) p_ = 0;
+		if (p_->dwReference.fetch_sub(1, std::memory_order_acq_rel) == 1) p_ = 0;
 	}
 
 public:
 	void _set(str_c rhs)
 	{
 		str_value* v = g_pStringContainer->dock(rhs);
-		if (0 != v) v->dwReference++;
+		if (0 != v) v->dwReference.fetch_add(1, std::memory_order_relaxed);
 		_dec();
 		p_ = v;
 	}
@@ -83,7 +83,7 @@ public:
 	void _set(shared_str const& rhs)
 	{
 		str_value* v = rhs.p_;
-		if (0 != v) v->dwReference++;
+		if (0 != v) v->dwReference.fetch_add(1, std::memory_order_relaxed);
 		_dec();
 		p_ = v;
 	}


### PR DESCRIPTION
render thread and lua calls (map_add_object_spot for example) can access same refcounters which in case of a race gives crash when counter is decremented more than incremented. 

main change is in xr_resource, two other were changed just in case because they use same pattern.