### PR TITLE
Easing and correct scaling for .anms, custom pivot points

### DIFF
--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -854,7 +854,7 @@ void CWeaponMagazinedWGrenade::PlayAnimIdle()
 
 			if (m_bGrenadeMode)
 			{
-				if (act_state == 0)
+				if (act_state == 0 || psDeviceFlags2.test(rsBlendMoveAnims))
 					iAmmoElapsed == 0 && HudAnimationExist("anm_idle_empty_g")
 					? PlayHUDMotion("anm_idle_empty_g", TRUE, NULL, GetState())
 					: PlayHUDMotion("anm_idle_g", TRUE, NULL, GetState());
@@ -879,7 +879,7 @@ void CWeaponMagazinedWGrenade::PlayAnimIdle()
 			}
 			else
 			{
-				if (act_state == 0)
+				if (act_state == 0 || psDeviceFlags2.test(rsBlendMoveAnims))
 					iAmmoElapsed == 0 && HudAnimationExist("anm_idle_empty_w_gl")
 						? PlayHUDMotion("anm_idle_empty_w_gl", TRUE, NULL, GetState())
 						: PlayHUDMotion("anm_idle_w_gl", TRUE, NULL, GetState());

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1546,9 +1546,9 @@ bool AllowHudMotion()
 	return g_player_hud->allow_script_anim();
 }
 
-void PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bool bLooped, bool no_restart)
+void PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bool bLooped, bool no_restart, LPCSTR pivot_bone)
 {
-	g_player_hud->PlayBlendAnm(name, part, speed, power, bLooped, no_restart);
+	g_player_hud->PlayBlendAnm(name, part, speed, power, bLooped, no_restart, pivot_bone);
 }
 
 void StopBlendAnm(LPCSTR name, bool bForce)

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -1224,10 +1224,36 @@ void player_hud::update(const Fmatrix& cam_trans)
 		Fmatrix blend = anm->XFORM();
 
 		if (anm->m_part == 0 || anm->m_part == 2)
-			m_transform.mulB_43(blend);
+        {
+			IKinematics* K = m_model->dcast_PKinematics();
+			u16 bone_id = K ? K->LL_BoneID(anm->m_pivot_bone) : u16(-1);
+			if (bone_id != u16(-1))
+			{
+				Fmatrix B = K->LL_GetTransform(bone_id);
+				Fmatrix invB; invB.invert(B);
+				Fmatrix tmp; tmp.mul_43(B, blend);
+				tmp.mulB_43(invB);
+				m_transform.mulB_43(tmp);
+			}
+			else
+				m_transform.mulB_43(blend);
+        }
 
 		if (anm->m_part == 1 || anm->m_part == 2)
-			m_transform_2.mulB_43(blend);
+        {
+			IKinematics* K = m_model_2->dcast_PKinematics();
+			u16 bone_id = K ? K->LL_BoneID(anm->m_pivot_bone) : u16(-1);
+			if (bone_id != u16(-1))
+			{
+				Fmatrix B = K->LL_GetTransform(bone_id);
+				Fmatrix invB; invB.invert(B);
+				Fmatrix tmp; tmp.mul_43(B, blend);
+				tmp.mulB_43(invB);
+				m_transform_2.mulB_43(tmp);
+			}
+			else
+				m_transform_2.mulB_43(blend);
+        }
 	}
 
 	bool need_blend[2];
@@ -1371,7 +1397,7 @@ void player_hud::updateMovementLayerState()
 	}
 }
 
-void player_hud::PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bool bLooped, bool no_restart)
+void player_hud::PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bool bLooped, bool no_restart, LPCSTR pivot_bone)
 {
 	for (script_layer* anm : m_script_layers)
 	{
@@ -1392,11 +1418,12 @@ void player_hud::PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bo
 			anm->anm->Speed() = speed;
 			anm->m_power = power;
 			anm->active = true;
+            anm->m_pivot_bone = pivot_bone;
 			return;
 		}
 	}
 
-	script_layer* anm = xr_new<script_layer>(name, part, speed, power, bLooped);
+	script_layer* anm = xr_new<script_layer>(name, part, speed, power, bLooped, pivot_bone);
 	m_script_layers.push_back(anm);
 }
 

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -150,12 +150,14 @@ struct script_layer
 	bool active;
 	Fmatrix blend;
 	u8 m_part;
+    shared_str m_pivot_bone;
 
-	script_layer(LPCSTR name, u8 part, float speed = 1.f, float power = 1.f, bool looped = true)
+	script_layer(LPCSTR name, u8 part, float speed = 1.f, float power = 1.f, bool looped = true, LPCSTR pivot_bone = nullptr)
 	{
 		m_name = name;
 		m_part = part;
 		m_power = power;
+		m_pivot_bone = pivot_bone;
 		blend.identity();
 		anm = xr_new<CObjectAnimator>();
 		anm->Load(name);
@@ -359,7 +361,7 @@ public:
 	void update(const Fmatrix& trans);
 	void updateMovementLayerState();
 	void StopScriptAnim();
-	void PlayBlendAnm(LPCSTR name, u8 part = 0, float speed = 1.f, float power = 1.f, bool bLooped = true, bool no_restart = false);
+	void PlayBlendAnm(LPCSTR name, u8 part = 0, float speed = 1.f, float power = 1.f, bool bLooped = true, bool no_restart = false, LPCSTR pivot_bone = nullptr);
 	void StopBlendAnm(LPCSTR name, bool bForce = false);
 	void StopAllBlendAnms(bool bForce);
 	float SetBlendAnmTime(LPCSTR name, float time);

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -112,12 +112,31 @@ struct movement_layer
 
 	const Fmatrix& XFORM(u8 part)
 	{
-		blend.set(anm->XFORM());
-		blend.mul(blend_amount[part] * m_power);
-		blend.m[0][0] = 1.f;
-		blend.m[1][1] = 1.f;
-		blend.m[2][2] = 1.f;
+		auto cubic_bezier = [](float t) {
+			return 10 * t * t * t - 15 * t * t * t * t + 6 * t * t * t * t * t;
+		};
 
+		float eased = cubic_bezier(blend_amount[part]);
+
+		// Rotation interpolation
+		Fquaternion qA; qA.identity();
+		Fquaternion qB; qB.set(anm->XFORM());
+		{
+			// Take m_power into account
+			Fvector axis;
+			float angle;
+			if (qB.get_axis_angle(axis, angle)) {
+				angle *= m_power;
+				qB.rotation(axis, angle);
+			}
+		}
+		Fquaternion q; q.slerp(qA, qB, eased);
+
+		// Translation interpolation
+		Fvector t = anm->XFORM().c;
+		t.mul(m_power * eased);
+
+		blend.mk_xform(q, t);
 		return blend;
 	}
 };

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -112,11 +112,11 @@ struct movement_layer
 
 	const Fmatrix& XFORM(u8 part)
 	{
-		auto cubic_bezier = [](float t) {
-			return 10 * t * t * t - 15 * t * t * t * t + 6 * t * t * t * t * t;
+		auto min_jerk_interp = [](float t) {
+			return 10*t*t*t - 15*t*t*t*t + 6*t*t*t*t*t;
 		};
 
-		float eased = cubic_bezier(blend_amount[part]);
+		float eased = min_jerk_interp(blend_amount[part]);
 
 		// Rotation interpolation
 		Fquaternion qA; qA.identity();
@@ -184,12 +184,31 @@ struct script_layer
 
 	const Fmatrix& XFORM()
 	{
-		blend.set(anm->XFORM());
-		blend.mul(blend_amount * m_power);
-		blend.m[0][0] = 1.f;
-		blend.m[1][1] = 1.f;
-		blend.m[2][2] = 1.f;
+		auto min_jerk_interp = [](float t) {
+			return 10*t*t*t - 15*t*t*t*t + 6*t*t*t*t*t;
+		};
 
+		float eased = min_jerk_interp(blend_amount);
+
+		// Rotation interpolation
+		Fquaternion qA; qA.identity();
+		Fquaternion qB; qB.set(anm->XFORM());
+		{
+			// Take m_power into account
+			Fvector axis;
+			float angle;
+			if (qB.get_axis_angle(axis, angle)) {
+				angle *= m_power;
+				qB.rotation(axis, angle);
+			}
+		}
+		Fquaternion q; q.slerp(qA, qB, eased);
+
+		// Translation interpolation
+		Fvector t = anm->XFORM().c;
+		t.mul(m_power * eased);
+
+		blend.mk_xform(q, t);
 		return blend;
 	}
 };


### PR DESCRIPTION
The default blending code just multiplies the entire .anm transform matrix by `blending * power`, and sets the diagonal to one. This has several issues:

1. The transform becomes non-orthonormal, because rotation vectors are not normalized. That means, with some .anms the weapon is going to stretch in a weird way
2. Practically the rotation amount is limited. For example, .anm can't rotate the weapon 90 degree to the side
3. The blending is applied to rotation vectors directly, meaning the rotation speed isn't linear
4. The blending itself is linear parameter so it doesn't feel natural

To fix those, I convert rotation transform to a quaternion and apply slerp to ensure constant spherical speed of blended rotation (while translation is applied as before). Also, an interpolation func is applied to blend amount to make large-amplitude movements more or less natural looking.

Also added support for playing anms around custom pivot points.

Fixed `blend_move_anims` command to affect weapons with GLs as well.

