### PR TITLE
First Person Body

### DIFF
--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -2127,11 +2127,16 @@ bool CActor::AllowActorShadow()
 void CActor::renderable_Render(IDSGraphManager* DM)
 {
 	VERIFY(_valid(XFORM()));
-	
+
 	if (cam_active == eacFirstEye)
 	{
 		if (::Render->active_phase() == 0) // can render first person body here
 		{
+			if (g_player_hud && psHUD_Flags.test(HUD_DRAW) && !m_holder)
+			{
+				g_player_hud->render_legs(DM);
+			}
+
 			//if (fpBody) 
 			//	inherited::renderable_Render(DM);
 		}
@@ -2144,7 +2149,7 @@ void CActor::renderable_Render(IDSGraphManager* DM)
 		}
 	}
 
-// Third Person Body and Weapon/Item
+	// Third Person Body and Weapon/Item
 	else
 	{
 		inherited::renderable_Render(DM);

--- a/src/xrGame/ActorAnimation.cpp
+++ b/src/xrGame/ActorAnimation.cpp
@@ -407,6 +407,9 @@ void CActor::g_SetAnimation(u32 mstate_rl)
 	else if (mstate_rl & mcLStrafe) M_legs = AS->legs_ls;
 	else if (mstate_rl & mcRStrafe) M_legs = AS->legs_rs;
 	else is_standing = true;
+	if (g_player_hud && is_standing && IsFocused() && g_player_hud->m_legs_controller.is_active()) {
+		is_standing = false;
+	}
 
 	if (mstate_rl & mcSprint)
 	{

--- a/src/xrGame/Actor_Movement.cpp
+++ b/src/xrGame/Actor_Movement.cpp
@@ -410,7 +410,13 @@ void CActor::g_Orientate(u32 mstate_rl, float dt)
 	}
 
 	// lerp angle for "effect" and capture torso data from camera
-	angle_lerp(r_model_yaw_delta, calc_yaw, PI_MUL_4, dt);
+	float scale_yaw_offset = 1.0f;
+
+	if (cam_active == eacFirstEye && g_player_hud && g_player_hud->m_legs_controller.is_active()) {
+		scale_yaw_offset = 0.15f;
+	}
+
+	angle_lerp(r_model_yaw_delta, calc_yaw * scale_yaw_offset, PI_MUL_4 * scale_yaw_offset, dt);
 
 	// build matrix
 	Fmatrix mXFORM;

--- a/src/xrGame/IKLimbsController.cpp
+++ b/src/xrGame/IKLimbsController.cpp
@@ -98,6 +98,13 @@ float CIKLimbsController::LegLengthShiftLimit(float current_shift, const SCalcul
 			if (shift_down < s_down)
 				shift_down = s_down;
 		}
+
+	if (Actor() == m_object) {
+		if (Actor()->active_cam() == EActorCameras::eacFirstEye) {
+			clamp(shift_down, -0.1f, 0.1f);
+		}
+	}
+
 	return shift_down;
 }
 
@@ -193,6 +200,13 @@ bool CIKLimbsController::PredictObjectShift(const SCalculateData cd[max_size])
 
 	if (predict_time_shift < EPS_S)
 		predict_time_shift = Device.fTimeDelta;
+
+	if (Actor() == m_object) {
+		if (Actor()->active_cam() == EActorCameras::eacFirstEye) {
+			clamp(predict_shift, -0.1f, 0.1f);
+		}
+	}
+
 	_object_shift.set_taget(predict_shift, predict_time_shift);
 	return true;
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -134,6 +134,7 @@ extern BOOL g_allow_silencer_hide_tracer;
 
 //demonized: new console vars
 extern BOOL firstPersonDeath;
+extern BOOL g_legs_enabled;
 extern BOOL pseudogiantCanDamageObjects;
 extern BOOL use_english_text_for_missing_translations;
 namespace crash_saving {
@@ -3058,6 +3059,10 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "first_person_death_position_smoothing", &firstPersonDeathPositionSmoothing, 1, 30);
 	CMD4(CCC_Integer, "first_person_death_direction_smoothing", &firstPersonDeathDirectionSmoothing, 1, 60);
 	CMD4(CCC_Float, "first_person_death_near_plane_offset", &viewportNearOffset, -.1f, .5f);
+
+	//legs 
+
+	CMD4(CCC_Integer, "g_legs", &g_legs_enabled, 0, 1);
 
 	// PDA commands
 	CMD4(CCC_Integer, "pda_map_zoom_in_to_mouse", &pda_map_zoom_in_to_mouse, 0, 1);

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -14,6 +14,8 @@
 
 extern int g_nearwall;
 
+BOOL g_legs_enabled = TRUE;
+
 player_hud* g_player_hud = NULL;
 Fvector _ancor_pos;
 Fvector _wpn_root_pos;
@@ -58,7 +60,7 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
 			}
 			else
 			{
-				R_ASSERT2(_GetItemCount(anm.c_str())<=4, anm.c_str());
+				R_ASSERT2(_GetItemCount(anm.c_str()) <= 4, anm.c_str());
 				string512 str_item;
 				_GetItem(anm.c_str(), 0, str_item);
 				pm->m_base_name = str_item;
@@ -212,7 +214,7 @@ void attachable_hud_item::set_bone_visible(const shared_str& bone_name, BOOL bVi
 	{
 		if (bSilent) return;
 		R_ASSERT2(
-			0, make_string("model [%s] has no bone [%s]",pSettings->r_string(m_sect_name, "item_visual"), bone_name.
+			0, make_string("model [%s] has no bone [%s]", pSettings->r_string(m_sect_name, "item_visual"), bone_name.
 				c_str()).c_str());
 	}
 	bVisibleNow = m_model->LL_GetBoneVisible(bone_id);
@@ -283,11 +285,11 @@ void attachable_hud_item::setup_firedeps(firedeps& fd)
 		fd.m_FireParticlesXForm.identity();
 		fd.m_FireParticlesXForm.k.set(fd.vLastFD);
 		Fvector::generate_orthonormal_basis_normalized(fd.m_FireParticlesXForm.k,
-		                                               fd.m_FireParticlesXForm.j,
-		                                               fd.m_FireParticlesXForm.i);
+			fd.m_FireParticlesXForm.j,
+			fd.m_FireParticlesXForm.i);
 
 		VERIFY(_valid(fd.m_FireParticlesXForm));
-		
+
 		// demonized: transforms for fire bone/point silencer, they should be identical to above if they dont exist
 		{
 			Fmatrix& fire_mat = m_model->LL_GetTransform(m_measures.m_fire_bone_silencer);
@@ -391,7 +393,7 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 
 		m_fire_point_offset = pSettings->r_fvector3(sect_name, "fire_point");
 		m_fire_direction = READ_IF_EXISTS(pSettings, r_fvector3, sect_name, "fire_direction",
-		                                  Fvector().set(0.f, 0.f, 1.0f));
+			Fvector().set(0.f, 0.f, 1.0f));
 	}
 	else
 		m_fire_point_offset.set(0, 0, 0);
@@ -466,17 +468,17 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 
 	// demonized: removing asserts
 	/*R_ASSERT2(pSettings->line_exist(sect_name,"fire_point")==pSettings->line_exist(sect_name,"fire_bone"),
-	          sect_name.c_str());
+			  sect_name.c_str());
 	R_ASSERT2(pSettings->line_exist(sect_name,"fire_point2")==pSettings->line_exist(sect_name,"fire_bone2"),
-	          sect_name.c_str());
+			  sect_name.c_str());
 	R_ASSERT2(pSettings->line_exist(sect_name,"shell_point")==pSettings->line_exist(sect_name,"shell_bone"),
-	          sect_name.c_str());*/
+			  sect_name.c_str());*/
 
 	m_prop_flags.set(e_16x9_mode_now, is_16x9);
 
 	////////////////////////////////////////////
 	//--#SM+# Begin--
-	const Fvector vZero = {0.f, 0.f, 0.f};
+	const Fvector vZero = { 0.f, 0.f, 0.f };
 
 	// Альтернативное прицеливание
 	strconcat(sizeof(val_name), val_name, "aim_hud_offset_alt_pos", _prefix);
@@ -526,32 +528,32 @@ void hud_item_measures::load(const shared_str& sect_name, IKinematics* K)
 
 	// Загрузка параметров смещения / инерции
 	m_inertion_params.m_tendto_speed = READ_IF_EXISTS(pSettings, r_float, sect_name, "inertion_tendto_speed",
-	                                                  TENDTO_SPEED);
+		TENDTO_SPEED);
 	m_inertion_params.m_tendto_speed_aim = READ_IF_EXISTS(pSettings, r_float, sect_name, "inertion_tendto_aim_speed",
-	                                                      TENDTO_SPEED_AIM);
+		TENDTO_SPEED_AIM);
 	m_inertion_params.m_tendto_ret_speed = READ_IF_EXISTS(pSettings, r_float, sect_name, "inertion_tendto_ret_speed",
-	                                                      TENDTO_SPEED_RET);
+		TENDTO_SPEED_RET);
 	m_inertion_params.m_tendto_ret_speed_aim = READ_IF_EXISTS(pSettings, r_float, sect_name,
-	                                                          "inertion_tendto_ret_aim_speed", TENDTO_SPEED_RET_AIM);
+		"inertion_tendto_ret_aim_speed", TENDTO_SPEED_RET_AIM);
 
 	m_inertion_params.m_min_angle =
 		READ_IF_EXISTS(pSettings, r_float, sect_name, "inertion_min_angle", INERT_MIN_ANGLE);
 	m_inertion_params.m_min_angle_aim = READ_IF_EXISTS(pSettings, r_float, sect_name, "inertion_min_angle_aim",
-	                                                   INERT_MIN_ANGLE_AIM);
+		INERT_MIN_ANGLE_AIM);
 
 	m_inertion_params.m_offset_LRUD = READ_IF_EXISTS(pSettings, r_fvector4, sect_name, "inertion_offset_LRUD",
-	                                                 Fvector4().set(ORIGIN_OFFSET));
+		Fvector4().set(ORIGIN_OFFSET));
 	m_inertion_params.m_offset_LRUD_aim = READ_IF_EXISTS(pSettings, r_fvector4, sect_name, "inertion_offset_LRUD_aim",
-	                                                     Fvector4().set(ORIGIN_OFFSET_AIM));
+		Fvector4().set(ORIGIN_OFFSET_AIM));
 
 	// Загрузка параметров смещения при стрельбе
 	m_shooting_params.bShootShake = READ_IF_EXISTS(pSettings, r_bool, sect_name, "shooting_hud_effect", false);
 	m_shooting_params.m_shot_max_offset_LRUD = READ_IF_EXISTS(pSettings, r_fvector4, sect_name, "shooting_max_LRUD",
-	                                                          Fvector4().set(0, 0, 0, 0));
+		Fvector4().set(0, 0, 0, 0));
 	m_shooting_params.m_shot_max_offset_LRUD_aim = READ_IF_EXISTS(pSettings, r_fvector4, sect_name,
-	                                                              "shooting_max_LRUD_aim", Fvector4().set(0, 0, 0, 0));
+		"shooting_max_LRUD_aim", Fvector4().set(0, 0, 0, 0));
 	m_shooting_params.m_shot_offset_BACKW = READ_IF_EXISTS(pSettings, r_fvector2, sect_name, "shooting_backward_offset",
-	                                                       Fvector2().set(0, 0));
+		Fvector2().set(0, 0));
 	m_shooting_params.m_ret_speed = READ_IF_EXISTS(pSettings, r_float, sect_name, "shooting_ret_speed", 1.0f);
 	m_shooting_params.m_ret_speed_aim = READ_IF_EXISTS(pSettings, r_float, sect_name, "shooting_ret_aim_speed", 1.0f);
 	m_shooting_params.m_min_LRUD_power = READ_IF_EXISTS(pSettings, r_float, sect_name, "shooting_min_LRUD_power", 0.0f);
@@ -611,16 +613,16 @@ player_hud_motion* attachable_hud_item::find_motion(const shared_str& anm_name)
 		anm = m_hand_motions->find_motion(anm_name);
 
 	R_ASSERT2(anm, make_string("model [%s] has no motion alias defined [%s]", m_sect_name.c_str(), anm_name).c_str())
-	;
+		;
 	VERIFY2(anm->m_animations.size(),
-	        make_string("model [%s] has no motion defined in motion_alias [%s]", pSettings->r_string(m_sect_name,
-		        "item_visual"), anim_name_r).c_str());
+		make_string("model [%s] has no motion defined in motion_alias [%s]", pSettings->r_string(m_sect_name,
+			"item_visual"), anim_name_r).c_str());
 
 	return anm;
 }
 
 u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, const CMotionDef*& md, u8& rnd_idx,
-                                   float speed, bool bMixIn2)
+	float speed, bool bMixIn2)
 {
 	player_hud_motion* anm = find_motion(anm_name_b);
 	rnd_idx = (u8)Random.randI(anm->m_animations.size());
@@ -704,6 +706,9 @@ player_hud::player_hud()
 {
 	m_model = nullptr;
 	m_model_2 = nullptr;
+
+	m_legs_controller.destroy();
+
 	m_attached_items[0] = nullptr;
 	m_attached_items[1] = nullptr;
 	m_attached_items[SCOPE_ATTACH_IDX] = nullptr;
@@ -724,7 +729,7 @@ player_hud::player_hud()
 	//m_bone_callback_params.insert(mk_pair(bip01_r_finger1, xr_new<BoneCallbackParams>()));
 	//m_bone_callback_params.insert(mk_pair(bip01_r_finger11, xr_new<BoneCallbackParams>()));
 	//m_bone_callback_params.insert(mk_pair(bip01_r_finger12, xr_new<BoneCallbackParams>()));
-	
+
 	//Movement Layers
 	m_movement_layers.reserve(move_anms_end);
 
@@ -735,7 +740,7 @@ player_hud::player_hud()
 		char temp[20];
 		string512 tmp;
 		strconcat(sizeof(temp), temp, "movement_layer_", std::to_string(i).c_str());
-		
+
 		if (pSettings->line_exist("hud_movement_layers", temp))
 		{
 			LPCSTR layer_def = pSettings->r_string("hud_movement_layers", temp);
@@ -762,6 +767,8 @@ player_hud::~player_hud()
 	v = m_model_2->dcast_RenderVisual();
 	::Render->model_Delete(v);
 	m_model_2 = nullptr;
+
+	m_legs_controller.destroy();
 
 	delete_data(m_hand_motions);
 	delete_data(m_script_layers);
@@ -821,6 +828,8 @@ void player_hud::load(const shared_str& player_hud_sect, bool force)
 		IRenderVisual* v = m_model_2->dcast_RenderVisual();
 		::Render->model_Delete(v);
 	}
+
+	delete_legs_model();
 
 	const shared_str& model_name = pSettings->r_string(player_hud_sect, "visual");
 	::Render->hud_loading = true;
@@ -947,6 +956,12 @@ void player_hud::render_hud(IDSGraphManager* DM)
 	DM->add_Dynamic(m_model->dcast_RenderVisual(), &m_transform);
 	DM->add_Dynamic(m_model_2->dcast_RenderVisual(), &m_transform_2);
 
+	/*
+	if (m_legs_model) {
+		DM->add_Dynamic(m_legs_model->dcast_RenderVisual(), &m_legs_transform);
+	}
+	*/
+
 	if (m_attached_items[0])
 		m_attached_items[0]->render(DM);
 
@@ -981,7 +996,6 @@ void player_hud::render_hud(IDSGraphManager* DM)
 	}
 }
 
-
 #include "../xrEngine/motion.h"
 
 u32 player_hud::motion_length_script(LPCSTR section, LPCSTR anm_name, float speed)
@@ -1015,8 +1029,8 @@ u32 player_hud::motion_length(const shared_str& anim_name, const shared_str& hud
 	if (!pm || !pm->m_animations.size())
 		return 100; // ms TEMPORARY
 	R_ASSERT2(pm,
-	          make_string ("hudItem model [%s] has no motion with alias [%s]", hud_name.c_str(), anim_name.c_str() ).
-	          c_str()
+		make_string("hudItem model [%s] has no motion with alias [%s]", hud_name.c_str(), anim_name.c_str()).
+		c_str()
 	);
 	return motion_length(pm->m_animations[0].mid, md, 1.f);
 }
@@ -1059,6 +1073,8 @@ extern float psHUD_FOV;
 
 void player_hud::update(const Fmatrix& cam_trans)
 {
+	update_legs(cam_trans);
+
 	Fmatrix trans = cam_trans;
 	Fmatrix trans_b = cam_trans;
 	CWeapon* wep = smart_cast<CWeapon*>(Actor()->inventory().ActiveItem());
@@ -1077,7 +1093,7 @@ void player_hud::update(const Fmatrix& cam_trans)
 		float body_yaw = -angle_normalize_signed(Actor()->old_torso_yaw);
 		float cam_yaw = -angle_normalize_signed(Actor()->cam_FirstEye()->yaw);
 		float diff_yaw = angle_difference_signed(body_yaw, cam_yaw);
-		
+
 		if (final_pitch < 0.f)
 			sub_z += final_pitch * .35f;
 
@@ -1133,7 +1149,7 @@ void player_hud::update(const Fmatrix& cam_trans)
 
 	if (m_attached_items[0])
 		m_attached_items[0]->m_parent_hud_item->UpdateHudAdditional(trans);
-	
+
 	if (m_attached_items[1])
 	{
 		m_attached_items[1]->m_parent_hud_item->UpdateHudAdditional(trans_2);
@@ -1145,7 +1161,7 @@ void player_hud::update(const Fmatrix& cam_trans)
 		trans_2 = trans;
 	else if (m_attached_items[1] && !m_attached_items[0])
 		trans = trans_2;
-	
+
 	// override hand offset for single hand animation
 	if (script_anim_part == 2 || (script_anim_part && !m_attached_items[0] && !m_attached_items[1]))
 	{
@@ -1287,7 +1303,7 @@ void player_hud::update(const Fmatrix& cam_trans)
 		{
 			if (anm->blend_amount[0] > 0.f)
 				m_transform.mulB_43(anm->XFORM(0));
-			
+
 			if (anm->blend_amount[1] > 0.f)
 				m_transform_2.mulB_43(anm->XFORM(1));
 		}
@@ -1342,7 +1358,8 @@ void player_hud::updateMovementLayerState()
 
 		if (wep && wep->IsZoomed()) {
 			m_movement_layers[eAimIdle]->Play();
-		} else {
+		}
+		else {
 			m_movement_layers[eIdle]->Play();
 		}
 
@@ -1385,7 +1402,7 @@ void player_hud::PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bo
 
 			if (!anm->anm->IsPlaying())
 				anm->anm->Play(bLooped);
-				
+
 			anm->anm->bLoop = bLooped;
 			anm->m_part = part;
 			anm->anm->Speed() = speed;
@@ -1433,7 +1450,7 @@ float player_hud::SetBlendAnmTime(LPCSTR name, float time)
 			return speed;
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -1477,7 +1494,7 @@ void player_hud::StopScriptAnim()
 	if (part != 2 && !m_attached_items[part])
 		re_sync_anim(part + 1);
 	else
-		OnMovementChanged((ACTOR_DEFS::EMoveCommand) 0);
+		OnMovementChanged((ACTOR_DEFS::EMoveCommand)0);
 }
 
 //part: 0 = right arm; 1 = left arm
@@ -1491,7 +1508,7 @@ u32 player_hud::anim_play(u16 part, const MotionID& M, BOOL bMixIn, const CMotio
 
 	if (override_part != u16(-1))
 		part_id = override_part;
-	
+
 	play_blend(this, part_id, M, bMixIn, speed);
 
 	return motion_length(M, md, speed);
@@ -1504,7 +1521,7 @@ player_hud_motion_container* player_hud::get_hand_motions(LPCSTR section)
 		if (phm->section == section)
 			return &phm->pm;
 	}
-	
+
 	hand_motions* res = xr_new<hand_motions>();
 	res->section = section;
 	res->pm.load(m_model, section);
@@ -1538,7 +1555,7 @@ u32 player_hud::script_anim_play(u8 hand, LPCSTR section, LPCSTR anm_name, bool 
 		Msg("!script motion section [%s] does not exist", section);
 		m_bStopAtEndAnimIsRunning = true;
 		script_anim_end = Device.dwTimeGlobal;
-		
+
 		return 0;
 	}
 
@@ -1550,7 +1567,7 @@ u32 player_hud::script_anim_play(u8 hand, LPCSTR section, LPCSTR anm_name, bool 
 		pos.append("_16x9");
 		rot.append("_16x9");
 	}
-	
+
 	Fvector def = { 0.f, 0.f, 0.f };
 	Fvector offs = READ_IF_EXISTS(pSettings, r_fvector3, section, pos.c_str(), def);
 	Fvector rrot = READ_IF_EXISTS(pSettings, r_fvector3, section, rot.c_str(), def);
@@ -1592,7 +1609,7 @@ u32 player_hud::script_anim_play(u8 hand, LPCSTR section, LPCSTR anm_name, bool 
 
 		return 0;
 	}
-	
+
 	const motion_descr& M = phm->m_animations[Random.randI(phm->m_animations.size())];
 
 	if (script_anim_item_model)
@@ -1680,7 +1697,7 @@ void player_hud::re_sync_anim(u8 part)
 		CBlend* BR = part == 1 ? m_model_2->LL_PartBlend(part, bidx) : m_model->LL_PartBlend(part, bidx);
 		if (!BR)
 			continue;
-			
+
 		MotionID M = BR->motionID;
 
 		u16 pc = m_model->partitions().count(); //same on both armatures
@@ -1810,7 +1827,7 @@ bool player_hud::allow_script_anim()
 void player_hud::calc_transform(u16 attach_slot_idx, const Fmatrix& offset, Fmatrix& result, bool leadGun)
 {
 	IKinematics* kin = (attach_slot_idx == 0) ? m_model->dcast_PKinematics() : m_model_2->dcast_PKinematics();
-	Fmatrix ancor_m =  kin->LL_GetTransform(m_ancors[(leadGun ? 0 : attach_slot_idx)]);
+	Fmatrix ancor_m = kin->LL_GetTransform(m_ancors[(leadGun ? 0 : attach_slot_idx)]);
 	result.mul((attach_slot_idx == 0) ? m_transform : m_transform_2, ancor_m);
 	result.mulB_43(offset);
 }

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -4,6 +4,7 @@
 #include "../Include/xrRender/Kinematics.h"
 #include "../Include/xrRender/KinematicsAnimated.h"
 #include "actor_defs.h"
+#include "player_hud_legs.h"
 
 #define SCOPE_ATTACH_IDX 2
 
@@ -87,7 +88,7 @@ struct movement_layer
 			active = true;
 			return;
 		}
-		
+
 		anm->Play(bLoop);
 		active = true;
 	}
@@ -192,20 +193,17 @@ enum EBoneCallbackParam
 	r_finger0 = 0,
 	r_finger01,
 	r_finger02,
-	//bip01_r_finger1,
-	//bip01_r_finger11,
-	//bip01_r_finger12,
 };
 
 struct hud_item_measures
 {
-	enum { e_fire_point=(1 << 0), e_fire_point2=(1 << 1), e_shell_point=(1 << 2), e_16x9_mode_now=(1 << 3), e_fire_point_silencer=(1 << 4) };
+	enum { e_fire_point = (1 << 0), e_fire_point2 = (1 << 1), e_shell_point = (1 << 2), e_16x9_mode_now = (1 << 3), e_fire_point_silencer = (1 << 4) };
 
 	Flags8 m_prop_flags;
 
-	Fvector m_item_attach[2]; // pos,rot
-	Fvector m_hands_offset[2][8]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2, attach_base, attach_mount --#SM+#--
-	Fvector m_strafe_offset[4][2]; // pos,rot,data1,data2/ normal,aim-GL	 --#SM+#--
+	Fvector m_item_attach[2];
+	Fvector m_hands_offset[2][8];
+	Fvector m_strafe_offset[4][2];
 
 	u16 m_fire_bone;
 	Fvector m_fire_point_offset;
@@ -217,7 +215,7 @@ struct hud_item_measures
 	u16 m_shell_bone;
 	Fvector m_shell_point_offset;
 
-	Fvector m_hands_attach[2]; //pos,rot
+	Fvector m_hands_attach[2];
 
 	void load(const shared_str& sect_name, IKinematics* K);
 
@@ -235,7 +233,7 @@ struct hud_item_measures
 		Fvector4 m_offset_LRUD_aim;
 	};
 
-	inertion_params m_inertion_params; //--#SM+#--
+	inertion_params m_inertion_params;
 
 	struct shooting_params
 	{
@@ -248,7 +246,7 @@ struct hud_item_measures
 		float m_min_LRUD_power;
 	};
 
-	shooting_params m_shooting_params; //--#SM+#--
+	shooting_params m_shooting_params;
 
 	float m_fFreelookZOffset;
 	bool m_bLeadGunLeftHand;
@@ -264,14 +262,14 @@ struct attachable_hud_item
 	u16 m_attach_place_idx;
 	hud_item_measures m_measures;
 
-	//runtime positioning
 	Fmatrix m_attach_offset;
 	Fmatrix m_item_transform;
 
 	player_hud_motion_container* m_hand_motions;
 
-	attachable_hud_item(player_hud* pparent): m_parent(pparent), m_upd_firedeps_frame(u32(-1)), m_parent_hud_item(nullptr),
-	                                          m_model(nullptr), m_attach_place_idx(0) {}
+	attachable_hud_item(player_hud* pparent) : m_parent(pparent), m_upd_firedeps_frame(u32(-1)), m_parent_hud_item(nullptr),
+		m_model(nullptr), m_attach_place_idx(0) {
+	}
 	~attachable_hud_item();
 	void load(const shared_str& sect_name);
 	void update(bool bForce);
@@ -283,27 +281,21 @@ struct attachable_hud_item
 	void set_bone_visible(const shared_str& bone_name, BOOL bVisibility, BOOL bSilent = FALSE);
 	void debug_draw_firedeps();
 	player_hud_motion* find_motion(const shared_str& anm_name);
-	//hands bind position
+
 	Fvector& hands_attach_pos();
 	Fvector& hands_attach_rot();
-
-	//hands runtime offset
 	Fvector& hands_offset_pos();
 	Fvector& hands_offset_rot();
-
 	Fvector& aim_offset_pos();
 	Fvector& aim_offset_rot();
-
 	Fvector& alt_aim_offset_pos();
 	Fvector& alt_aim_offset_rot();
-
 	Fvector& attach_base_offset_pos();
 	Fvector& attach_base_offset_rot();
 	Fvector& attach_mount_offset_pos();
 	Fvector& attach_mount_offset_rot();
 	float attach_scale();
 
-	//props
 	u32 m_upd_firedeps_frame;
 	void tune(Ivector values);
 	u32 anim_play(const shared_str& anim_name, BOOL bMixIn, const CMotionDef*& md, u8& rnd, float speed = 0, bool bMixIn2 = true);
@@ -326,6 +318,7 @@ public:
 	void StopAllBlendAnms(bool bForce);
 	float SetBlendAnmTime(LPCSTR name, float time);
 	void render_hud(IDSGraphManager* DM);
+	void render_legs(IDSGraphManager* DM);
 	void render_item_ui();
 	bool render_item_ui_query();
 	u32 anim_play(u16 part, const MotionID& M, BOOL bMixIn, const CMotionDef*& md, float speed, u16 override_part = u16(-1));
@@ -347,7 +340,6 @@ public:
 	Fmatrix m_item_pos;
 	u8 m_attach_idx;
 
-	//Movement animation layers: 0 = aim_walk, 1 = aim_crouch, 2 = crouch, 3 = walk, 4 = run, 5 = sprint
 	xr_vector<movement_layer*> m_movement_layers;
 	xr_vector<script_layer*> m_script_layers;
 
@@ -387,6 +379,7 @@ public:
 	u32 motion_length(const shared_str& anim_name, const shared_str& hud_name, const CMotionDef*& md);
 	void OnMovementChanged(ACTOR_DEFS::EMoveCommand cmd);
 	bool inertion_allowed();
+
 private:
 	const Fvector attach_rot(u8 part) const;
 	const Fvector attach_pos(u8 part) const;
@@ -394,14 +387,21 @@ private:
 	xr_vector<u16> m_ancors;
 	attachable_hud_item* m_attached_items[3];
 	static void _BCL FingerCallback(CBoneInstance* B);
+
 public:
 	IKinematicsAnimated* m_model;
 	IKinematicsAnimated* m_model_2;
-	Fvector m_adjust_offset[2][10]; // pos,rot/ normal,aim,GL,aim_alt,safemode, normal2, attach_base, attach_mount, aim for attach, alt aim for attach
-	Fvector m_adjust_obj[2]; // pos,rot; used for the item/weapon itself
-	Fvector m_adjust_ui_offset[2]; // pos,rot; used for custom device ui
+
+	player_legs_controller m_legs_controller;
+
+	void update_legs(const Fmatrix& cam_trans);
+	void delete_legs_model();
+
+	Fvector m_adjust_offset[2][10];
+	Fvector m_adjust_obj[2];
+	Fvector m_adjust_ui_offset[2];
 	Fvector m_adjust_firepoint_shell[2][2];
-	xr_map<EBoneCallbackParam, BoneCallbackParams*> m_bone_callback_params; // bonename,params
+	xr_map<EBoneCallbackParam, BoneCallbackParams*> m_bone_callback_params;
 	int m_edit_attachment;
 	float m_adjust_zoom_factor[3];
 	float m_adjust_scale;
@@ -416,27 +416,14 @@ public:
 			m_bone_callback_params[r_finger01]->m_current.set(0.f, 0.f, 0.f);
 			m_bone_callback_params[r_finger02]->m_current.set(0.f, 0.f, 0.f);
 		}
-		
+
 		m_bone_callback_params[r_finger0]->m_target.set(0.f, 0.f, 0.f);
 		m_bone_callback_params[r_finger01]->m_target.set(0.f, 0.f, 0.f);
 		m_bone_callback_params[r_finger02]->m_target.set(0.f, 0.f, 0.f);
 	}
 
-	/*void reset_triggerfinger(bool bForce)
-	{
-		if (bForce)
-		{
-			m_bone_callback_params[bip01_r_finger1]->m_current.set(0.f, 0.f, 0.f);
-			m_bone_callback_params[bip01_r_finger11]->m_current.set(0.f, 0.f, 0.f);
-			m_bone_callback_params[bip01_r_finger12]->m_current.set(0.f, 0.f, 0.f);
-		}
-
-		m_bone_callback_params[bip01_r_finger1]->m_target.set(0.f, 0.f, 0.f);
-		m_bone_callback_params[bip01_r_finger11]->m_target.set(0.f, 0.f, 0.f);
-		m_bone_callback_params[bip01_r_finger12]->m_target.set(0.f, 0.f, 0.f);
-	}*/
-
 	DECLARE_SCRIPT_REGISTER_FUNCTION
 };
 
 extern player_hud* g_player_hud;
+extern BOOL g_legs_enabled;

--- a/src/xrGame/player_hud_legs.cpp
+++ b/src/xrGame/player_hud_legs.cpp
@@ -1,0 +1,276 @@
+#include "stdafx.h"
+#include "player_hud_legs.h"
+#include "player_hud.h"
+#include "actor.h"
+#include "inventory_item.h"
+#include "Inventory.h"
+#include "../Include/xrRender/Kinematics.h"
+#include "../Include/xrRender/KinematicsAnimated.h"
+
+extern BOOL g_legs_enabled;
+
+void player_legs_controller::destroy()
+{
+    if (!m_model)
+        return;
+
+    IRenderVisual* v = m_model->dcast_RenderVisual();
+    if (v)
+        ::Render->model_Delete(v);
+
+    m_model = nullptr;
+    m_visual_name = "";
+}
+
+bool player_legs_controller::resolve_config(CActor* actor, shared_str& out_section)
+{
+    PIItem outfit = actor->inventory().ItemFromSlot(OUTFIT_SLOT);
+    shared_str current_outfit = outfit
+        ? outfit->object().cNameSect()
+        : shared_str("");
+
+    if (m_last_outfit_sect != current_outfit)
+    {
+        m_config_warned = false;
+        m_last_outfit_sect = current_outfit;
+    }
+
+    if (outfit)
+        return resolve_outfit_config(current_outfit, out_section);
+    else
+        return resolve_default_config(out_section);
+}
+
+bool player_legs_controller::resolve_outfit_config(const shared_str& outfit_sect,
+    shared_str& out_section)
+{
+    if (pSettings->line_exist(outfit_sect, "legs_visual_sect"))
+    {
+        shared_str candidate = pSettings->r_string(outfit_sect, "legs_visual_sect");
+        if (pSettings->section_exist(candidate))
+        {
+            out_section = candidate;
+            return true;
+        }
+        warn_once("legs_visual_sect [%s] referenced by outfit [%s] does not exist",
+            candidate.c_str(), outfit_sect.c_str());
+        return false;
+    }
+
+    string256 auto_sect;
+    xr_sprintf(auto_sect, "%s_legs", outfit_sect.c_str());
+    if (pSettings->section_exist(auto_sect))
+    {
+        out_section = auto_sect;
+        return true;
+    }
+
+    if (pSettings->line_exist(outfit_sect, "legs_visual"))
+    {
+        out_section = outfit_sect;
+        return true;
+    }
+
+    warn_once("no legs config for outfit [%s]", outfit_sect.c_str());
+    return false;
+}
+
+bool player_legs_controller::resolve_default_config(shared_str& out_section)
+{
+    if (pSettings->section_exist("actor_legs_default"))
+    {
+        out_section = "actor_legs_default";
+        return true;
+    }
+    warn_once("section [actor_legs_default] not found, legs disabled");
+    return false;
+}
+
+void player_legs_controller::warn_once(const char* fmt, ...)
+{
+    if (m_config_warned) return;
+    m_config_warned = true;
+
+    string512 buf;
+    va_list args;
+    va_start(args, fmt);
+    vsprintf_s(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    Msg("! [player_legs] %s", buf);
+}
+
+bool player_legs_controller::ensure_model(const shared_str& legs_section)
+{
+    LPCSTR key = nullptr;
+
+    if (pSettings->line_exist(legs_section, "legs_visual"))
+        key = "legs_visual";
+    else if (pSettings->line_exist(legs_section, "visual"))
+        key = "visual";
+
+    if (!key)
+    {
+        warn_once("section [%s] has no 'legs_visual' or 'visual' field", legs_section.c_str());
+        destroy();
+        return false;
+    }
+
+    shared_str new_visual = pSettings->r_string(legs_section, key);
+
+    if (m_model && m_visual_name == new_visual)
+        return true;
+
+    destroy();
+
+    IRenderVisual* raw = ::Render->model_Create(new_visual.c_str());
+    if (!raw)
+    {
+        warn_once("failed to create model [%s]", new_visual.c_str());
+        return false;
+    }
+
+    IKinematics* K = smart_cast<IKinematics*>(raw);
+    if (!K)
+    {
+        ::Render->model_Delete(raw);
+        warn_once("model [%s] is not a skeleton", new_visual.c_str());
+        return false;
+    }
+
+    m_model = K;
+    m_visual_name = new_visual;
+
+    m_fwd_offset = READ_IF_EXISTS(pSettings, r_float, legs_section, "legs_fwd_offset", -0.55f);
+
+    return true;
+}
+
+// clean up later
+void player_legs_controller::copy_bones_from_actor(CActor* actor)
+{
+    if (!actor || !m_model)
+        return;
+
+    IKinematics* actor_K = actor->Visual()->dcast_PKinematics();
+    if (!actor_K)
+        return;
+
+    actor_K->CalculateBones(TRUE);
+
+    m_model->CalculateBones_Invalidate();
+    m_model->CalculateBones(TRUE);
+
+    u16 legs_root = m_model->LL_GetBoneRoot();
+    CBoneInstance& root_bi = m_model->LL_GetBoneInstance(legs_root);
+    root_bi.mTransform.identity();
+    root_bi.mRenderTransform.mul_43(root_bi.mTransform,
+        m_model->LL_GetData(legs_root).m2b_transform);
+
+    u16 bone_count = m_model->LL_BoneCount();
+    for (u16 i = 0; i < bone_count; ++i)
+    {
+        if (i == legs_root)
+            continue;
+
+        LPCSTR bone_name = m_model->LL_BoneName_dbg(i);
+        u16 actor_bone_id = actor_K->LL_BoneID(bone_name);
+
+        if (actor_bone_id == BI_NONE)
+            continue;
+
+        CBoneInstance& src = actor_K->LL_GetBoneInstance(actor_bone_id);
+        CBoneInstance& dst = m_model->LL_GetBoneInstance(i);
+
+        dst.mTransform.set(src.mTransform);
+        dst.mRenderTransform.mul_43(dst.mTransform,
+            m_model->LL_GetData(i).m2b_transform);
+    }
+
+    for (u16 i = 0; i < bone_count; ++i)
+    {
+        if (i == legs_root)
+            continue;
+
+        LPCSTR bone_name = m_model->LL_BoneName_dbg(i);
+        u16 actor_bone_id = actor_K->LL_BoneID(bone_name);
+
+        if (actor_bone_id == BI_NONE)
+        {
+            CBoneInstance& dst = m_model->LL_GetBoneInstance(i);
+            dst.mTransform.identity();
+            dst.mRenderTransform.mul_43(dst.mTransform,
+                m_model->LL_GetData(i).m2b_transform);
+        }
+    }
+}
+
+void player_legs_controller::update(CActor* actor)
+{
+    if (!g_legs_enabled || !actor)
+    {
+        destroy();
+        return;
+    }
+
+    if (actor->Holder() != nullptr)
+    {
+        destroy();
+        return;
+    }
+
+    shared_str legs_section;
+    if (!resolve_config(actor, legs_section))
+    {
+        destroy();
+        return;
+    }
+
+    if (!ensure_model(legs_section))
+        return;
+
+    copy_bones_from_actor(actor);
+}
+
+void player_legs_controller::render(IDSGraphManager* DM)
+{
+    if (!g_legs_enabled || !m_model)
+        return;
+
+    CActor* actor = Actor();
+    if (!actor)
+        return;
+
+    u32 move_state = actor->MovingState();
+    if (move_state & mcClimb)
+        return;
+
+    IRenderVisual* visual = m_model->dcast_RenderVisual();
+    if (!visual)
+        return;
+
+    m_legs_transform.set(actor->XFORM());
+
+    Fvector fwd;
+    fwd.set(m_legs_transform.k);
+    fwd.y = 0.f;
+    fwd.normalize_safe();
+    m_legs_transform.c.mad(fwd, m_fwd_offset);
+
+    DM->add_Dynamic(visual, &m_legs_transform);
+}
+
+void player_hud::update_legs(const Fmatrix& cam_trans)
+{
+    m_legs_controller.update(g_actor);
+}
+
+void player_hud::render_legs(IDSGraphManager* DM)
+{
+    m_legs_controller.render(DM);
+}
+
+void player_hud::delete_legs_model()
+{
+    m_legs_controller.destroy();
+}

--- a/src/xrGame/player_hud_legs.h
+++ b/src/xrGame/player_hud_legs.h
@@ -1,0 +1,43 @@
+#pragma once
+
+class CActor;
+class IKinematicsAnimated;
+class IKinematics;
+struct IDSGraphManager;
+
+class player_legs_controller
+{
+public:
+    void    update(CActor* actor);
+    void    render(IDSGraphManager* DM);
+    void    destroy();
+
+    bool    is_active() const { return m_model != nullptr; }
+    IKinematics* model() const { return m_model; }
+
+private:
+    IKinematics* m_model = nullptr;
+    shared_str              m_visual_name;
+    shared_str              m_last_outfit_sect;
+    bool                    m_config_warned = false;
+    float                   m_fwd_offset = -0.55f;
+    float                   m_y_offset = 0.f;
+    Fmatrix                 m_legs_transform;
+    bool                    m_first_frame = true;
+    xr_vector<Fmatrix>      m_prev_bones;
+    bool                    m_has_prev = false;
+    float                   m_blend_speed = 8.f;
+    bool                    m_logged = false;
+    bool is_costume_affected_bone(LPCSTR bone_name) const;
+    bool should_hide_bone(LPCSTR bone_name) const;
+    bool is_spine_bone(LPCSTR bone_name) const;
+    void remove_camera_pitch(Fmatrix& bone_transform);
+
+    bool    resolve_config(CActor* actor, shared_str& out_section);
+    bool    resolve_outfit_config(const shared_str& outfit_sect, shared_str& out_section);
+    bool    resolve_default_config(shared_str& out_section);
+    bool    ensure_model(const shared_str& legs_section);
+    void    copy_bones_from_actor(CActor* actor);
+    void    warn_once(const char* fmt, ...);
+    bool is_keep_bind_bone(LPCSTR bone_name) const;
+};

--- a/src/xrGame/xrGame.vcxproj
+++ b/src/xrGame/xrGame.vcxproj
@@ -1438,6 +1438,7 @@
     <ClInclude Include="ph_shell_interface.h" />
     <ClInclude Include="player_account.h" />
     <ClInclude Include="player_hud.h" />
+    <ClInclude Include="player_hud_legs.h" />
     <ClInclude Include="player_name_modifyer.h" />
     <ClInclude Include="player_spot_params.h" />
     <ClInclude Include="player_state_achilles_heel.h" />
@@ -2987,6 +2988,7 @@
       <PrecompiledHeaderFile>pch_script.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
+    <ClCompile Include="player_hud_legs.cpp" />
     <ClCompile Include="script_imgui_script.cpp">
       <PrecompiledHeaderFile>pch_script.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(ProjectName)_script.pch</PrecompiledHeaderOutputFile>

--- a/src/xrGame/xrGame.vcxproj.filters
+++ b/src/xrGame/xrGame.vcxproj.filters
@@ -7374,6 +7374,9 @@
     <ClInclude Include="..\3rd party\fastdelegate\fastdelegate.h">
       <Filter>Core</Filter>
     </ClInclude>
+    <ClInclude Include="player_hud_legs.h">
+      <Filter>Core\Client\Objects\items &amp; weapons\HudItem</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="damage_manager.cpp">
@@ -11083,6 +11086,9 @@
     </ClCompile>
     <ClCompile Include="searchlight_script.cpp" />
     <ClCompile Include="searchlight_struct.cpp" />
+    <ClCompile Include="player_hud_legs.cpp">
+      <Filter>Core\Client\Objects\items &amp; weapons\HudItem</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="Explosive.h">


### PR DESCRIPTION
**First-person body implementation**

Added full-fledged first-person legs without using fake HUD animations. The system takes the skeleton of an actor from a third person and 1-in-1 copies the bone transformations to a separate leg model for Hud. All movements (walking, running, strafing, squats) work out of the box and look as natural as possible.

Special models without arms and heads are required for operation, and the torso must be attached to the hip bone bip01_pelvis. This implementation requires the same skeleton for the legs model and the actor model.

You can disable or enable it only by calling g_legs 0/1. 

Example of a configuration to enable: 
```
[actor_legs]
legs_fwd_offset = -0.55

![novice_outfit]
legs_visual_sect = novice_outfit_legs

[novice_outfit_legs]:actor_legs
visual = sm\actor_legs\jacket_loner.ogf
```

Later, a complete archive with models and configs for full operation will be published.

I broke the previous pull request, I'm sorry..
