### PR TITLE
Fix/trade manager resupply sync

### DIFF
--- a/gamedata/scripts/trade_manager_modded_exes.script
+++ b/gamedata/scripts/trade_manager_modded_exes.script
@@ -1,0 +1,10 @@
+local old_trade_manager_trade_init = trade_manager.trade_init
+function trade_manager.trade_init(npc, cfg)
+    local id = npc:id()
+    local reup_time = trade_manager.get_trade_profile(id, "resupply_time")
+    old_trade_manager_trade_init(npc, cfg)
+    local trade_profile = trade_manager.get_trade_profile(id)
+    if not trade_profile then return end
+    if not reup_time then return end
+    trade_profile.resupply_time = reup_time
+end

--- a/gamedata/scripts/trade_manager_modded_exes.script
+++ b/gamedata/scripts/trade_manager_modded_exes.script
@@ -3,8 +3,8 @@ function trade_manager.trade_init(npc, cfg)
     local id = npc:id()
     local reup_time = trade_manager.get_trade_profile(id, "resupply_time")
     old_trade_manager_trade_init(npc, cfg)
+    if not reup_time then return end
     local trade_profile = trade_manager.get_trade_profile(id)
     if not trade_profile then return end
-    if not reup_time then return end
     trade_profile.resupply_time = reup_time
 end


### PR DESCRIPTION
Some mods rely on trade_manager.tm[id].resupply_time that is lost after trader is re-init - https://github.com/Tosox/STALKER-Anomaly-gamedata/blob/v1.5.2/gamedata/scripts/trade_manager.script#L44
So we need to restore it in order for trader to know when their last resupply was

Mods such as:
https://www.moddb.com/mods/stalker-anomaly/addons/trader-destockifier
https://github.com/ahuyn/anomaly-dependencies/blob/master/trader_autoinject/gamedata/scripts/trader_autoinject.script#L51

Issue on gamma discord - https://discord.com/channels/912320241713958912/1142498532444610581