### PR TITLE
Faster CBuffer updates

### DIFF
--- a/src/Layers/xrRenderDX10/dx10BufferUtils.cpp
+++ b/src/Layers/xrRenderDX10/dx10BufferUtils.cpp
@@ -35,9 +35,9 @@ namespace dx10BufferUtils
 	{
 		D3D_BUFFER_DESC desc;
 		desc.ByteWidth = DataSize;
-		desc.Usage = D3D_USAGE_DEFAULT;// D3D_USAGE_DYNAMIC;
+		desc.Usage = D3D_USAGE_DYNAMIC;
 		desc.BindFlags = D3D_BIND_CONSTANT_BUFFER;
-		desc.CPUAccessFlags = 0;// D3D_CPU_ACCESS_WRITE;
+		desc.CPUAccessFlags = D3D_CPU_ACCESS_WRITE;
 		desc.MiscFlags = 0;
 
 		HRESULT res = HW.pDevice->CreateBuffer( &desc, 0, ppBuffer);

--- a/src/Layers/xrRenderDX10/dx10ConstantBuffer.cpp
+++ b/src/Layers/xrRenderDX10/dx10ConstantBuffer.cpp
@@ -84,7 +84,6 @@ void dx10ConstantBuffer::Flush()
 {
     if (m_bChanged)
     {
-/*
         void    *pData;
 #ifdef USE_DX11
         D3D11_MAPPED_SUBRESOURCE    pSubRes;
@@ -101,8 +100,6 @@ void dx10ConstantBuffer::Flush()
 #else
         m_pBuffer->Unmap();
 #endif
-*/
-        HW.pContext->UpdateSubresource(m_pBuffer, 0, NULL, (BYTE*)m_pBufferData, 0, 0);
         m_bChanged = false;
     }
 }


### PR DESCRIPTION
I’ve reverted my old commit. Thanks to v2 for pointing it out - I had overlooked it.

Since we do have couple of CBuffers that requires per-frame updates, Map/Unmap seems to be a better choice. 
