### PR TITLE
[OBSOLETE] fix VEC_ZERO being mutated by certain functions

### DIFF
--- a/gamedata/configs/unlocalizers/unlocalizer_modded_exes_vec_zero_fix.ltx
+++ b/gamedata/configs/unlocalizers/unlocalizer_modded_exes_vec_zero_fix.ltx
@@ -1,0 +1,2 @@
+[xr_campfire_point]
+used_vids

--- a/gamedata/scripts/_g_patches.script
+++ b/gamedata/scripts/_g_patches.script
@@ -711,3 +711,27 @@ _G.log = function(str)
         LuaPanda.printToVSCode(str,1,2)
     end
 end
+
+
+-- VECTORS
+
+-- Global VEC_ZERO is being mutated by some vanilla scripts which can cause bugs.
+-- Therefore VEC_ZERO should no longer be used as long as vanilla functions
+-- aren't fixed!
+-- Use this function instead to get a zero vector that can also be mutated
+_G.vec_zero = function()
+	return vector():set(0,0,0)
+end
+
+-- Same issue prolly applies to VEC_X/Y/Z too
+_G.vec_x = function()
+	return vector():set(1,0,0)
+end
+
+_G.vec_y = function()
+	return vector():set(0,1,0)
+end
+
+_G.vec_z = function()
+	return vector():set(0,0,1)
+end

--- a/gamedata/scripts/aaaa_script_fixes_mp.script
+++ b/gamedata/scripts/aaaa_script_fixes_mp.script
@@ -675,8 +675,8 @@ function trade_manager.trade_init(npc, cfg)
     trade_profile.resupply_time = reup_time
 end
 
--- Private_Pirate: fix VEC_ZERO being mutated by stationary machine gun init function
-ph_minigun.action_mgun.__init = function(self, obj, storage)
+-- Private_Pirate: fix VEC_ZERO being mutated
+function ph_minigun.action_mgun.__init(self, obj, storage)
 --	printf("mgun <state>: init.")
 	self.object = obj
 	self.mgun = self.object:get_car()
@@ -687,3 +687,74 @@ ph_minigun.action_mgun.__init = function(self, obj, storage)
 	self.start_look_pos.z = self.object:position().z + 5*math.cos(self.start_direction.x)
 	self.start_look_pos.y = self.object:position().y
 end
+
+function xr_campfire_point.action_point_campfire.activate_scheme(self)
+	local vid,look
+	if (self.st.smart) then
+ 		local fires = db.campfire_table_by_smart_names[self.st.smart]
+		if (fires and not is_empty(fires)) then
+			local campfire
+			local t = {}
+			local function create_campfire_point(pos,dir)
+				local radius = 8
+				local vertex_id = 4294967295
+				local tmp_pos = vector():set(0,0,0)
+				while (vertex_id >= 4294967295) do
+					tmp_pos.x = pos.x + dir.x * radius
+					tmp_pos.z = pos.z + dir.z * radius
+					tmp_pos.y = pos.y
+
+					vertex_id = level.vertex_id(tmp_pos)
+					if (vertex_id >= 4294967295 or xr_campfire_point.used_vids[vertex_id]) then
+						if (radius > 1) then
+							radius = radius - 1
+						else
+							break
+						end
+					end
+				end
+				return vertex_id
+			end
+			for id,binder in pairs(fires) do
+				if (binder.object) then 
+					local dir = vector():set(binder.object:direction())
+					local pos = binder.object:position()
+					t[#t+1] = pos
+					for i=1,6 do
+						vid = create_campfire_point(pos,vector_rotate_y(dir,i*60))
+						look = pos
+						if (vid and vid < 4294967295 and not xr_campfire_point.used_vids[vid]) then 
+							break 
+						end
+					end
+				end
+				if (vid and vid < 4294967295 and not xr_campfire_point.used_vids[vid]) then 
+					break 
+				end
+			end
+			
+			-- fallback no camp or all space is taken
+			if (vid == nil or vid >= 4294967295 or xr_campfire_point.used_vids[vid]) then
+				local pos = t and #t > 0 and t[math.random(#t)] or self.object:position()
+				vid = utils_obj.find_random_cover(self.object,pos,5,15)
+				look = pos
+			end
+		end
+	end
+	
+	-- fallback if no campfires
+	if (vid == nil or vid >= 4294967295 or xr_campfire_point.used_vids[vid]) then
+		local smart = self.st.smart and SIMBOARD:get_smart_by_name(self.st.smart) or xr_gulag.get_npc_smart(self.object)
+		local pos = smart and smart.position or self.object:position()
+		vid = utils_obj.find_random_cover(self.object,pos,5,15)
+		look = pos
+	end
+	
+	self.st.signals = {}
+	self.st.look_position = look
+	self.st.vid = utils_obj.send_to_nearest_accessible_vertex(self.object,vid or self.object:level_vertex_id())
+	state_mgr.set_state(self.object,xr_logic.pick_section_from_condlist(db.actor, self.object, self.st.reach_movement))
+	
+	xr_campfire_point.used_vids[self.st.vid] = true
+end
+-- Private_Pirate END

--- a/gamedata/scripts/aaaa_script_fixes_mp.script
+++ b/gamedata/scripts/aaaa_script_fixes_mp.script
@@ -674,3 +674,16 @@ function trade_manager.trade_init(npc, cfg)
     
     trade_profile.resupply_time = reup_time
 end
+
+-- Private_Pirate: fix VEC_ZERO being mutated by stationary machine gun init function
+ph_minigun.action_mgun.__init = function(self, obj, storage)
+--	printf("mgun <state>: init.")
+	self.object = obj
+	self.mgun = self.object:get_car()
+	self.st = storage
+	self.start_direction = self.object:direction()
+	self.start_look_pos = vector():(0,0,0)
+	self.start_look_pos.x = self.object:position().x + 5*math.sin(self.start_direction.x)
+	self.start_look_pos.z = self.object:position().z + 5*math.cos(self.start_direction.x)
+	self.start_look_pos.y = self.object:position().y
+end


### PR DESCRIPTION
Global VEC_ZERO (and probably VEC_X/VEC_Y/VEC_Z too) is being mutated by some functions in vanilla scripts. One obvious example is the stationary machine gun init function in ph_minigun.script. It stores the VEC_ZERO reference in a class field and mutates it directly which causes VEC_ZERO to become unequal to (0,0,0) in maps that have a stationary MG like Cordon, Rostok and Deserted Hospital, see image.

<img width="792" height="164" alt="before fix" src="https://github.com/user-attachments/assets/095a341b-c9b4-4626-a9df-e050ccb2ba41" />

This commit fixes such functions and adds global functions that return vectors resembling VEC_ZERO/X/Y/Z that can be mutated without causing issues. For further modding those should be used instead of the conventional globals as long as the problematic vanilla functions haven't been fixed.

After fix:

<img width="469" height="160" alt="after fix" src="https://github.com/user-attachments/assets/75be86e7-f39c-4a96-a8c5-44b507c98df5" />