### PR TITLE
Command to disable actor body/legs model rotation delay

### DIFF
--- a/src/Layers/xrRender/SkeletonAnimated.cpp
+++ b/src/Layers/xrRender/SkeletonAnimated.cpp
@@ -834,6 +834,21 @@ void CKinematicsAnimated::Load(const char* N, IReader* data, u32 dwFlags)
 
 			xr_strcat(nm, ".omf");
 			loadOMF(nm);
+
+            //load extra stalker animations
+            if (strstr(nm, "stalker_animation.omf"))
+            {
+                FS_FileSet extra_anims;
+                FS.file_list(extra_anims, "$game_meshes$", FS_ListFiles, "actors\\modded_stalker_animations\\*.omf");
+
+                if (!extra_anims.empty())
+                {
+                    for (auto it = extra_anims.begin(); it != extra_anims.end(); ++it)
+                    {
+                        loadOMF(it->name.c_str());
+                    }
+                }
+            }
 		}
 	}
 	else if (data->find_chunk(OGF_S_MOTION_REFS2))
@@ -861,6 +876,21 @@ void CKinematicsAnimated::Load(const char* N, IReader* data, u32 dwFlags)
 
 			xr_strcat(nm, ".omf");
 			loadOMF(nm);
+
+            //load extra stalker animations
+            if (strstr(nm, "stalker_animation.omf"))
+            {
+                FS_FileSet extra_anims;
+                FS.file_list(extra_anims, "$game_meshes$", FS_ListFiles, "actors\\modded_stalker_animations\\*.omf");
+
+                if (!extra_anims.empty())
+                {
+                    for (auto it = extra_anims.begin(); it != extra_anims.end(); ++it)
+                    {
+                        loadOMF(it->name.c_str());
+                    }
+                }
+            }
 		}
 	}
 	else

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -111,7 +111,7 @@ static Fbox bbCrouchBox;
 static Fvector vFootCenter;
 static Fvector vFootExt;
 
-BOOL showActorBody = FALSE;
+int showActorBody = 0;
 
 Flags32 psActorFlags = {AF_GODMODE_RT | AF_AUTOPICKUP | AF_RUN_BACKWARD | AF_IMPORTANT_SAVE | AF_USE_TRACERS};
 int psActorSleepTime = 1;
@@ -2139,15 +2139,19 @@ void CActor::renderable_Render()
 	{
 		if (::Render->active_phase() == 0) // can render first person body here
 		{
-			if (g_player_hud && !m_holder && (legs_in_demo_record || pDemoRecords.empty()) && !showActorBody)
+			if (g_player_hud && !m_holder && (legs_in_demo_record || pDemoRecords.empty()) && showActorBody == 0)
 			{
 				g_player_hud->render_legs();
 			}
 
-            if (showActorBody)
+            if (showActorBody == 1 || showActorBody == 2)
             {
                 inherited::renderable_Render();
-                CInventoryOwner::renderable_Render();
+
+                if (showActorBody == 2)
+                {
+                    CInventoryOwner::renderable_Render();
+                }
             }
 
 			//if (fpBody) 

--- a/src/xrGame/Actor_Movement.cpp
+++ b/src/xrGame/Actor_Movement.cpp
@@ -20,6 +20,7 @@
 #ifdef DEBUG
 #include "phdebug.h"
 #endif
+BOOL disableActorBodyRotationDelay = FALSE;
 static const float s_fLandingTime1 = 0.1f; // через сколько снять флаг Landing1 (т.е. включить следующую анимацию)
 static const float s_fLandingTime2 = 0.3f; // через сколько снять флаг Landing2 (т.е. включить следующую анимацию)
 static const float s_fJumpTime = 0.3f;
@@ -531,31 +532,40 @@ void CActor::g_cl_Orientate(u32 mstate_rl, float dt)
 		r_torso.pitch = unaffected_r_torso.pitch + dangle.x;
 	}
 
-	// если есть движение - выровнять модель по камере
-	if (mstate_rl & mcAnyMove)
-	{
-		r_model_yaw = angle_normalize(r_torso.yaw);
-		mstate_real &= ~mcTurn;
-	}
-	else
-	{
-		// if camera rotated more than 45 degrees - align model with it
-		float ty = angle_normalize(r_torso.yaw);
-		if (_abs(r_model_yaw - ty) > PI_DIV_4 - 30)
-		{
-			r_model_yaw_dest = ty;
-			// 
-			mstate_real |= mcTurn;
-		}
-		if (_abs(r_model_yaw - r_model_yaw_dest) < EPS_L)
-		{
-			mstate_real &= ~mcTurn;
-		}
-		if (mstate_rl & mcTurn)
-		{
-			angle_lerp(r_model_yaw, r_model_yaw_dest, PI_MUL_2, dt);
-		}
-	}
+    if (disableActorBodyRotationDelay)
+    {
+        r_model_yaw = angle_normalize(r_torso.yaw);
+        r_model_yaw_dest = r_model_yaw;
+        mstate_real &= ~mcTurn;
+    }
+    else
+    {
+        // если есть движение - выровнять модель по камере
+        if (mstate_rl & mcAnyMove)
+        {
+            r_model_yaw = angle_normalize(r_torso.yaw);
+            mstate_real &= ~mcTurn;
+        }
+        else
+        {
+            // if camera rotated more than 45 degrees - align model with it
+            float ty = angle_normalize(r_torso.yaw);
+            if (_abs(r_model_yaw - ty) > PI_DIV_4 - 30)
+            {
+                r_model_yaw_dest = ty;
+                // 
+                mstate_real |= mcTurn;
+            }
+            if (_abs(r_model_yaw - r_model_yaw_dest) < EPS_L)
+            {
+                mstate_real &= ~mcTurn;
+            }
+            if (mstate_rl & mcTurn)
+            {
+                angle_lerp(r_model_yaw, r_model_yaw_dest, PI_MUL_2, dt);
+            }
+        }
+    }
 }
 
 void CActor::g_sv_Orientate(u32 /**mstate_rl/**/, float /**dt/**/)

--- a/src/xrGame/Actor_Movement.cpp
+++ b/src/xrGame/Actor_Movement.cpp
@@ -532,7 +532,7 @@ void CActor::g_cl_Orientate(u32 mstate_rl, float dt)
 		r_torso.pitch = unaffected_r_torso.pitch + dangle.x;
 	}
 
-    if (disableActorBodyRotationDelay)
+    if (disableActorBodyRotationDelay || Device.time_factor() < 1)
     {
         r_model_yaw = angle_normalize(r_torso.yaw);
         r_model_yaw_dest = r_model_yaw;

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -132,7 +132,7 @@ extern BOOL g_apply_pdm_to_ads;
 extern BOOL g_smooth_ads_transition;
 extern BOOL g_allow_silencer_hide_tracer;
 
-extern BOOL showActorBody; //leer
+extern int showActorBody; //leer
 extern BOOL disableActorBodyRotationDelay; //leer
 
 //demonized: new console vars
@@ -3060,6 +3060,6 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Float, "g_wallmark_range_static", &wallmark_range_static, 0.f, 1000.f);
 	CMD4(CCC_Float, "g_wallmark_range_skeleton", &wallmark_range_skeleton, 0.f, 1000.f);
 
-    CMD4(CCC_Integer, "show_actor_body", &showActorBody, 0, 1);
+    CMD4(CCC_Integer, "show_actor_body", &showActorBody, 0, 2);
     CMD4(CCC_Integer, "disable_actor_body_rotation_delay", &disableActorBodyRotationDelay, 0, 1);
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -133,6 +133,7 @@ extern BOOL g_smooth_ads_transition;
 extern BOOL g_allow_silencer_hide_tracer;
 
 extern BOOL showActorBody; //leer
+extern BOOL disableActorBodyRotationDelay; //leer
 
 //demonized: new console vars
 extern BOOL firstPersonDeath;
@@ -3060,4 +3061,5 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Float, "g_wallmark_range_skeleton", &wallmark_range_skeleton, 0.f, 1000.f);
 
     CMD4(CCC_Integer, "show_actor_body", &showActorBody, 0, 1);
+    CMD4(CCC_Integer, "disable_actor_body_rotation_delay", &disableActorBodyRotationDelay, 0, 1);
 }

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -60,6 +60,7 @@
 #include "alife_registry_wrappers.h"
 #include "cover_manager.h"
 #include "cover_point.h"
+#include "ActorCondition.h"
 
 using namespace luabind;
 
@@ -2241,6 +2242,16 @@ void update_pda_news_from_uiwindow(CUIWindow* CUIWindowPItem) {
 	}
 }
 
+float GetActorAlcohol()
+{
+    if (Actor())
+    {
+        return Actor()->conditions().GetAlcohol();
+    }
+
+    return 0.0f;
+}
+
 script_attachment* AddAttachment(LPCSTR name, LPCSTR model_name)
 {
 	script_attachment* att = xr_new<script_attachment>(name, model_name);
@@ -2712,6 +2723,8 @@ void CLevel::script_register(lua_State* L)
 		
 		// demonized: adjust game news time
 		def("change_game_news_show_time", &change_game_news_show_time),
-		def("update_pda_news_from_uiwindow", &update_pda_news_from_uiwindow)
+		def("update_pda_news_from_uiwindow", &update_pda_news_from_uiwindow),
+
+        def("get_actor_alcohol", &GetActorAlcohol)
 	];
 }


### PR DESCRIPTION
Also added functionality to load new animations for Actor\NPC without editing the existing stalker_animation.omf or including new omf's in the model's motion refs.

All you need to do is place the file with the new animations in the path "gamedata\meshes\actors\modded_stalker_animations"