### PR TITLE
Update poltergeist.cpp

### DIFF
--- a/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
@@ -371,7 +371,11 @@ BOOL CPoltergeist::net_Spawn(CSE_Abstract* DC)
 	VERIFY(character_physics_support()->movement());
 	character_physics_support()->movement()->DestroyCharacter();
 	// спаунится нивидимым
-	setVisible(false);
+    if (g_Alive())
+	    setVisible(false);
+    else
+        setVisible(true);
+
 	ability()->on_hide();
 
 	return (TRUE);


### PR DESCRIPTION
A small tweak to ensure the dead poltergeist's body is displayed correctly when saving and loading. This tweak only makes sense if changes have been made to `bind_monster`, since in the base game the poltergeist is removed after death.
Created for this mod(or similar) to prevent situations where the body physically exists but is visually hidden.
https://www.moddb.com/mods/stalker-anomaly/addons/poltergeist-dead-body