### PR TITLE
use m_location_level to sort map spots

### DIFF
--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -469,6 +469,16 @@ void CUILevelMap::UpdateSpots()
 			(*it).location->UpdateLevelMap(this);
 		}
 	}
+
+	std::stable_sort(m_ChildWndList.begin(), m_ChildWndList.end(),
+		[](CUIWindow* a, CUIWindow* b) {
+			CMapSpot* sa = smart_cast<CMapSpot*>(a);
+			CMapSpot* sb = smart_cast<CMapSpot*>(b);
+			int la = sa ? sa->get_location_level() : 0;
+			int lb = sb ? sb->get_location_level() : 0;
+			return la < lb;
+		}
+	);
 }
 
 Frect CUILevelMap::CalcWndRectOnGlobal()


### PR DESCRIPTION
Consistent draw order. no more squads drawn under smarts icons