### PR TITLE
CRayPick: implement get_normal

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -799,6 +799,7 @@
         function get_object() : game_object
         function get_distance() : float
         function get_element() : int (number of triangle)
+        function get_normal() : vector
     }
 
     class script_rq_result {

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -2568,7 +2568,8 @@ void CLevel::script_register(lua_State* L)
 		.def("get_result", &CRayPick::get_result)
 		.def("get_object", &CRayPick::get_object)
 		.def("get_distance", &CRayPick::get_distance)
-		.def("get_element", &CRayPick::get_element),
+		.def("get_element", &CRayPick::get_element)
+		.def("get_normal", &CRayPick::get_normal),
 		class_<script_rq_result>("rq_result")
 		.def_readonly("object", &script_rq_result::O)
 		.def_readonly("range", &script_rq_result::range)

--- a/src/xrGame/raypick.cpp
+++ b/src/xrGame/raypick.cpp
@@ -39,3 +39,14 @@ bool CRayPick::query()
 	else
 		return false;
 }
+
+Fvector CRayPick::get_normal()
+{
+    if (result.O == nullptr && result.element != 0)
+    {
+        Fvector* V = Level().ObjectSpace.GetStaticVerts();
+        CDB::TRI* T = Level().ObjectSpace.GetStaticTris() + result.element;
+        return Fvector().mknormal(V[T->verts[0]], V[T->verts[1]], V[T->verts[2]]);
+    }
+    return Fvector().set(0, 1, 0);
+}

--- a/src/xrGame/raypick.h
+++ b/src/xrGame/raypick.h
@@ -124,6 +124,7 @@ struct CRayPick
 	};
 
 	bool query();
+	Fvector get_normal();
 
 	IC script_rq_result get_result() { return result; };
 	IC CScriptGameObject* get_object() { return result.O; };


### PR DESCRIPTION
Can use get_normal() to get the normal vector of the surface where CRayPick hit. The function only works for static geometry.