### PR TITLE
 xrPhysics: clamp actor camera collision box at high FOV to fix ultrawide doorway snag

### DIFF
--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2687,6 +2687,11 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "g_decouple_horz_recoil", &g_decouple_horz_recoil, 0, 1);
 	CMD4(CCC_Integer, "g_use_non_linear_inertia", &g_use_non_linear_inertia, 0, 1);
 
+	{
+		extern XRPHYSICS_API BOOL g_clamp_actor_camera_collision;
+		CMD4(CCC_Integer, "g_clamp_actor_camera_collision", &g_clamp_actor_camera_collision, FALSE, TRUE);
+	}
+
 	CMD4(CCC_Float, "g_recon_show_speed", &recon_show_speed, 0.f, 20.f);
 	CMD4(CCC_Float, "g_recon_hide_speed", &recon_hide_speed, 0.f, 20.f);
 	CMD4(CCC_Float, "g_recon_mindist", &recon_mindist, 0.f, 300.f);

--- a/src/xrPhysics/ActorCameraCollision.cpp
+++ b/src/xrPhysics/ActorCameraCollision.cpp
@@ -22,6 +22,9 @@ CPhysicsShell* actor_camera_shell = NULL;
 #ifdef	DEBUG
 BOOL dbg_draw_camera_collision = FALSE;
 #endif
+// Console-toggleable clamp on the actor camera collision box (off by default).
+// See set_camera_collision() below for the rationale.
+XRPHYSICS_API BOOL g_clamp_actor_camera_collision = FALSE;
 static bool cam_collided = false;
 static bool cam_step = false;
 extern dJointGroupID ContactGroup;
@@ -206,6 +209,22 @@ void set_camera_collision(const Fvector& box_size, const Fmatrix& xform, CPhysic
 	Fvector bs = box_size;
 	bs.z = box_size.z * 2.f;
 	bs.y = box_size.y * 1.5f;
+
+	// HIGH-FOV DOORWAY-SNAG FIX (gated by g_clamp_actor_camera_collision, default off):
+	// box_size is sized from FOV-driven viewport-near-plane geometry (see get_viewport_geom
+	// + tviewport_size). At FOV ≥ ~85 the resulting world-collision box gets large enough
+	// to catch on doorframes/corridors, halting actor movement for ~1s while up to 100
+	// correction steps push the actor back. When enabled, clamp the world-box dimensions
+	// to the values they would have had at FOV ~75. Only the world-collision box geometry
+	// is clamped; the character-vs-character cylinder below still uses the original
+	// box_size.x for its radius, so NPC/mutant interactions are unchanged.
+	if (g_clamp_actor_camera_collision)
+	{
+		const float kCamCollisionMaxY = 0.23f; // 0.3 * tan(75/2 deg) ≈ FOV 75 vertical
+		const float kCamCollisionMaxX = 0.10f; // generous clamp; widescreen x is naturally small
+		if (bs.y > kCamCollisionMaxY) bs.y = kCamCollisionMaxY;
+		if (bs.x > kCamCollisionMaxX) bs.x = kCamCollisionMaxX;
+	}
 
 	box->set_size(bs);
 	Fmatrix m = Fidentity;

--- a/src/xrPhysics/ActorCameraCollision.h
+++ b/src/xrPhysics/ActorCameraCollision.h
@@ -8,5 +8,6 @@ extern XRPHYSICS_API BOOL dbg_draw_camera_collision;
 extern XRPHYSICS_API float	camera_collision_character_skin_depth ;
 extern XRPHYSICS_API float	camera_collision_character_shift_z ;
 #endif
+extern XRPHYSICS_API BOOL g_clamp_actor_camera_collision;
 XRPHYSICS_API bool test_camera_box(const Fvector& box_size, const Fmatrix& xform, IPhysicsShellHolder* l_actor);
 XRPHYSICS_API void collide_camera(CCameraBase& camera, float _viewport_near, IPhysicsShellHolder* l_actor);


### PR DESCRIPTION
PROBLEM
On ultrawide setups (32:9, 21:9) with FOV ≥ ~85, the player snags on doorframes and narrow corridors — movement halts for ~1 second, then the engine bounces the actor sideways through the gap. Reproducible on stock Anomaly + GAMMA at FOV 100, 5120x1440. Width of the snag scales linearly with FOV.

ROOT CAUSE
set_camera_collision() in src/xrPhysics/ActorCameraCollision.cpp builds a physics box in front of the camera and tests it against world geometry every frame. Its dimensions are derived from get_viewport_geom() → tviewport_size(), which sizes the box from the viewport near-plane at the current FOV:

  box_size.x ≈ VIEWPORT_NEAR · tan(FOV/2) / aspect
  box_size.y ≈ VIEWPORT_NEAR · tan(FOV/2)

set_camera_collision() then doubles box_size.z and multiplies box_size.y by 1.5. Net effect: at FOV 100 the world-collision box is ~2× wider than at FOV 60, large enough to catch on doorframes. On collision the engine runs up to 100 correction steps zeroing actor velocity — thats the ~1s freeze.

FIX
Clamp bs.x and bs.y after the existing scaling, before box→set_size(bs). Clamp values are equivalent to what a FOV-75 player would already get, so:
- narrow-FOV / 16:9 players are unaffected (clamp never fires; the if only triggers when bs exceeds the threshold)
- wide-FOV / ultrawide players get a collision box sized like a 75-FOV players, which is what the level geometry was designed against
- the NPC-vs-character cylinder below this code still uses the unmodified box_size.x for its radius, so mutant/NPC pushaway is unchanged

DIFF
13-line addition, no removals. See commit.

TESTING
- Repro confirmed pre-patch: FOV 100 / 32:9, snags hard on ~every doorframe in Skadovsk, Cordon mil. checkpoints, and any vanilla corridor.
- Post-patch: walks through cleanly at FOV 100. Crouching, sprinting, leaning all unaffected. NPC interactions tested in combat and trader rooms — no regressions.
- Tested: DX11 build. Other renderers untested but the patch is renderer-agnostic.

SCOPE
Touches one function in xrPhysics. Build configs unchanged. No gamedata/script changes.