### PR TITLE
feature: motion exists engine call

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -129,6 +129,8 @@
         function ui2world_offscreen(Fvector2 pos) -> Fvector result, u16 object_id
         change_game_news_show_time(CUIWindow* UIWindow, float show_time)
         update_pda_news_from_uiwindow(CUIWindow* UIWindow)
+
+        bool motion_exists(string model_path, string motion_name) -- Loads a HUD model temporarily and checks whether it contains a named cycle motion. Caller must ensure the file exists first — game crashes on a missing path.
     }
 
     ini_file() {

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1547,6 +1547,18 @@ bool AllowHudMotion()
 	return g_player_hud->allow_script_anim();
 }
 
+bool MotionExists(LPCSTR model_path, LPCSTR motion_name)
+{
+	::Render->hud_loading = true;
+	IRenderVisual* vis = ::Render->model_Create(model_path);
+	::Render->hud_loading = false;
+	if (!vis) return false;
+	IKinematicsAnimated* ka = smart_cast<IKinematicsAnimated*>(vis);
+	bool found = ka && ka->ID_Cycle_Safe(motion_name).valid();
+	::Render->model_Delete(vis);
+	return found;
+}
+
 void PlayBlendAnm(LPCSTR name, u8 part, float speed, float power, bool bLooped, bool no_restart, LPCSTR pivot_bone)
 {
 	g_player_hud->PlayBlendAnm(name, part, speed, power, bLooped, no_restart, pivot_bone);
@@ -2701,6 +2713,7 @@ void CLevel::script_register(lua_State* L)
 		def("stop_hud_motion", StopHudMotion),
 		def("get_motion_length", MotionLength),
 		def("hud_motion_allowed", AllowHudMotion),
+		def("motion_exists", MotionExists),
 		def("play_hud_anm", PlayBlendAnm),
 		def("stop_hud_anm", StopBlendAnm),
 		def("stop_all_hud_anms", StopAllBlendAnms),


### PR DESCRIPTION
When developing big modpacks we often need a way to find weapons with missing animations in order to fix them and prevent crashes
Example of mod that utilizes this feature - https://github.com/SaloEater/Anomaly-Weapon-Verify/blob/04bf06cd986f8214024fcd92ab58b29820aee7b6/gamedata/scripts/wpn_snd_checker.script#L31

With it I able to generate lists of missing anim:
```
![wpn_l85_m3_hud]
anm_idle_moving_crouch_empty_w_gl_aim=wpn_hand_walk_w_gl_l85_aim,wpn_idle_w_gl_empty_l85
anm_idle_moving_empty_w_gl_aim=wpn_hand_walk_w_gl_l85_aim,wpn_idle_w_gl_empty_l85
```