### PR TITLE
Guard empty m_members in CSE_ALifeOnlineOfflineGroup::update and synchronize_location

### DIFF
--- a/src/xrGame/alife_online_offline_group.cpp
+++ b/src/xrGame/alife_online_offline_group.cpp
@@ -54,7 +54,7 @@ bool CSE_ALifeOnlineOfflineGroup::need_update(CSE_ALifeDynamicObject* object)
 
 void CSE_ALifeOnlineOfflineGroup::update()
 {
-	if (m_bOnline)
+	if (m_bOnline && !m_members.empty())
 	{
 		MEMBER* commander = (*m_members.begin()).second;
 		o_Position = commander->o_Position;
@@ -167,7 +167,7 @@ CSE_ALifeOnlineOfflineGroup::MEMBER* CSE_ALifeOnlineOfflineGroup::member(ALife::
 
 bool CSE_ALifeOnlineOfflineGroup::synchronize_location()
 {
-	if (m_bOnline)
+	if (m_bOnline && !m_members.empty())
 	{
 		MEMBER* member = (*m_members.begin()).second;
 		o_Position = member->o_Position;


### PR DESCRIPTION
Two unguarded `m_members.begin()` dereferences in `src/xrGame/alife_online_offline_group.cpp`. Both sit inside `if (m_bOnline)` blocks with no empty check, so an online squad with zero members triggers UB on the next call.

### Bug

`update()`:

```cpp
void CSE_ALifeOnlineOfflineGroup::update()
{
    if (m_bOnline)
    {
        MEMBER* commander = (*m_members.begin()).second;   // line 59 — UB if empty
        o_Position = commander->o_Position;
        m_tNodeID  = commander->m_tNodeID;
        m_tGraphID = commander->m_tGraphID;
    }
    if (!bfActive()) return;
    ...
}
```

`bfActive()` returns `(!m_bOnline && !m_members.empty())`, so when `m_bOnline == true` the early-return at line 64 is unreachable. The dereference at line 59 happens unconditionally.

`synchronize_location()` at line 170 has the identical pattern.

For comparison, `switch_offline()` (line 273) and `commander_id()` (line 342) check `!m_members.empty()` explicitly before the same dereference. The invariant is established in this file, just missed in these two functions.

### Fix

```diff
 void CSE_ALifeOnlineOfflineGroup::update()
 {
-    if (m_bOnline)
+    if (m_bOnline && !m_members.empty())
     {
         MEMBER* commander = (*m_members.begin()).second;
```

Same one-token change at line 170 in `synchronize_location()`. Behavior change is limited to "skip the position snapshot when there's no commander to read", which is correct.

### How it gets reached in practice

Two paths I've verified are reachable:

- All members of an online squad get unregistered (mass death, surge cleanup, scripted removal) before the squad transitions offline. `unregister_member` does not call `switch_offline` when `m_members` becomes empty, so the squad stays online + empty until the next `update()` tick.
- A `:create_npc` spawn loop adds zero members. Some mods (e.g. ZCP 1.5d's modified `sim_squad_scripted:create_npc`) wrap `add_squad_member` with a filter that can reject every section. If construction happened with the smart terrain online, the squad is online + empty by the next tick.

User-side, this typically surfaces as a `[Lua] sim_squad_scripted.script[146]` error, since that line in the standard `sim_squad_scripted:update` is the call site for `cse_alife_online_offline_group.update(self)`.

### Verified

Same code at the same lines in `xray-1.6-CoC` (the original Anomaly base) — bug inherited from the original GSC source (file header: `Created 25.10.2005, Author: D. Iassenev`). Patch applies cleanly to both forks.
