### PR TITLE
Fix models not compiling the correct shader when set_shader is used

### DIFF
--- a/src/Layers/xrRender/FBasicVisual.cpp
+++ b/src/Layers/xrRender/FBasicVisual.cpp
@@ -45,6 +45,7 @@ void dxRender_Visual::Load(const char* N, IReader* data, u32)
 	dbg_name = N;
 	dbg_id = 1;
 	skinning = ::Render->m_skinning;
+    hud = ::Render->hud_loading;
 
 	// header
 	VERIFY(data);
@@ -145,7 +146,10 @@ void dxRender_Visual::SetShaderTexture(LPCSTR s_shader, LPCSTR s_texture)
 	}
 
 	::Render->m_skinning = skinning;
-	shader.create(*dbg_shader, *dbg_texture);
+    bool prev_hud = ::Render->hud_loading;
+    ::Render->hud_loading = hud;
+    shader.create(*dbg_shader, *dbg_texture);
+    ::Render->hud_loading = prev_hud;
 }
 
 void dxRender_Visual::ResetShaderTexture()
@@ -172,4 +176,5 @@ void dxRender_Visual::Copy(dxRender_Visual* pFrom)
 	PCOPY(dbg_texture);
 	PCOPY(dbg_texture_def);
 	PCOPY(skinning);
+    PCOPY(hud);
 }

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -67,6 +67,7 @@ public:
 	vis_data vis; // visibility-data
 	ref_shader shader; // pipe state, shared
 	s32 skinning;
+    bool hud;
 
 	virtual void Render(float LOD)
 	{


### PR DESCRIPTION
Same as skinning, the state of ::Render->hud_loading has to be stored and set when creating the shader in (re)set_shader