### PR TITLE
Burer and poltergeist telekinesis fix

### DIFF
--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1056,27 +1056,28 @@ void CActor::g_Physics(Fvector& _accel, float jump, float dt)
 
 	if (Local() && g_Alive())
 	{
-		if (character_physics_support()->movement()->gcontact_Was)
-			Cameras().AddCamEffector(xr_new<CEffectorFall>(character_physics_support()->movement()->gcontact_Power));
+        CPHMovementControl* const mctrl = character_physics_support()->movement();
 
-		if (!fis_zero(character_physics_support()->movement()->gcontact_HealthLost))
+		if (mctrl->gcontact_Was)
+			Cameras().AddCamEffector(xr_new<CEffectorFall>(mctrl->gcontact_Power));
+
+		if (!fis_zero(mctrl->gcontact_HealthLost))
 		{
-			VERIFY(character_physics_support());
-			VERIFY(character_physics_support()->movement());
-			ICollisionDamageInfo* di = character_physics_support()->movement()->CollisionDamageInfo();
+			ICollisionDamageInfo* di = mctrl->CollisionDamageInfo();
 			VERIFY(di);
 			bool b_hit_initiated = di->GetAndResetInitiated();
+            CObject* initiator = mctrl->gcontact_Initiator ? mctrl->gcontact_Initiator : di->DamageInitiator();
 			Fvector hdir;
 			di->HitDir(hdir);
-			SetHitInfo(this, NULL, 0, Fvector().set(0, 0, 0), hdir);
+			SetHitInfo(initiator, NULL, 0, Fvector().set(0, 0, 0), hdir);
 			//				Hit	(m_PhysicMovementControl->gcontact_HealthLost,hdir,di->DamageInitiator(),m_PhysicMovementControl->ContactBone(),di->HitPos(),0.f,ALife::eHitTypeStrike);//s16(6 + 2*::Random.randI(0,2))
 			if (Level().CurrentControlEntity() == this)
 			{
-				SHit HDS = SHit(character_physics_support()->movement()->gcontact_HealthLost,
+				SHit HDS = SHit(mctrl->gcontact_HealthLost,
 				                //.								0.0f,
 				                hdir,
-				                di->DamageInitiator(),
-				                character_physics_support()->movement()->ContactBone(),
+				                initiator,
+				                mctrl->ContactBone(),
 				                di->HitPos(),
 				                0.f,
 				                di->HitType(),
@@ -1086,8 +1087,8 @@ void CActor::g_Physics(Fvector& _accel, float jump, float dt)
 
 				NET_Packet l_P;
 				HDS.GenHeader(GE_HIT, ID());
-				HDS.whoID = di->DamageInitiator()->ID();
-				HDS.weaponID = di->DamageInitiator()->ID();
+				HDS.whoID = initiator->ID();
+				HDS.weaponID = initiator->ID();
 				HDS.Write_Packet(l_P);
 
 				u_EventSend(l_P);

--- a/src/xrGame/CharacterPhysicsSupport.cpp
+++ b/src/xrGame/CharacterPhysicsSupport.cpp
@@ -71,7 +71,7 @@ IC bool is_imotion(interactive_motion* im)
 
 CCharacterPhysicsSupport::~CCharacterPhysicsSupport()
 {
-	set_collision_hit_callback(0);
+	xr_delete(m_collision_hit_callback);
 	if (m_flags.test(fl_skeleton_in_shell))
 	{
 		if (m_physics_skeleton)

--- a/src/xrGame/PHMovementControl.cpp
+++ b/src/xrGame/PHMovementControl.cpp
@@ -65,6 +65,7 @@ CPHMovementControl::CPHMovementControl(CObject* parent)
 	fActualVelocity = 0;
 	m_fGroundDelayFactor = 1.f;
 	gcontact_HealthLost = 0;
+    gcontact_Initiator = nullptr;
 
 	fContactSpeed = 0.f;
 	fAirControlParam = 0.f;
@@ -163,7 +164,7 @@ void CPHMovementControl::Calculate(Fvector& vAccel, const Fvector& camDir, float
 
 	ICollisionDamageInfo* cdi = CollisionDamageInfo();
 	if (cdi->HitCallback())
-		cdi->HitCallback()->call((m_character->PhysicsRefObject()), fMinCrashSpeed, fMaxCrashSpeed, fContactSpeed, gcontact_HealthLost, CollisionDamageInfo());
+		cdi->HitCallback()->call(gcontact_Initiator, fMinCrashSpeed, fMaxCrashSpeed, fContactSpeed, gcontact_HealthLost, cdi);
 
 	TraceBorder(previous_position);
 	CheckEnvironment(vPosition);
@@ -176,6 +177,7 @@ void CPHMovementControl::UpdateCollisionDamage()
 	fContactSpeed = 0.f;
 	gcontact_HealthLost = 0;
 	gcontact_Power = 0;
+    gcontact_Initiator = nullptr;
 	const ICollisionDamageInfo* di = m_character->CollisionDamageInfo();
 	fContactSpeed = di->ContactVelocity();
 

--- a/src/xrGame/PHMovementControl.h
+++ b/src/xrGame/PHMovementControl.h
@@ -152,6 +152,7 @@ public:
 	BOOL gcontact_Was; // Приземление
 	float gcontact_Power; // Насколько сильно ударились
 	float gcontact_HealthLost; // Скоко здоровья потеряли
+    CObject* gcontact_Initiator; // Кто инициатор удара
 
 public:
 	void AllocateCharacterObject(CharacterType type);

--- a/src/xrGame/ai/monsters/burer/burer.cpp
+++ b/src/xrGame/ai/monsters/burer/burer.cpp
@@ -56,6 +56,8 @@ void CBurer::reinit()
 void CBurer::net_Destroy()
 {
 	inherited::net_Destroy();
+    CTelekinesis::remove_object_callbacks();
+	CTelekinesis::deactivate();
 }
 
 void CBurer::reload(LPCSTR section)
@@ -486,14 +488,14 @@ void CBurer::Die(CObject* who)
 		com_man().ta_deactivate();
 	}
 
-	CTelekinesis::Deactivate();
+    CTelekinesis::remove_object_callbacks();
+	CTelekinesis::deactivate();
 }
 
 void CBurer::net_Relcase(CObject* O)
 {
 	inherited::net_Relcase(O);
-
-	TTelekinesis::remove_links(O);
+    CTelekinesis::remove_links(O);
 }
 
 #ifdef DEBUG

--- a/src/xrGame/ai/monsters/burer/burer_state_attack_tele.h
+++ b/src/xrGame/ai/monsters/burer/burer_state_attack_tele.h
@@ -1,12 +1,40 @@
 #pragma once
 #include "../state.h"
 #include "../../../grenade.h"
+#include "../../../../xrPhysics/iphysicsshellholder.h"
+#include "../../../../xrPhysics/icolisiondamageinfo.h"
 
 
 template <typename Object>
 class CStateBurerAttackTele : public CState<Object>
 {
 	typedef CState<Object> inherited;
+
+    struct SCollisionHitCallback :
+        public ICollisionHitCallback
+    {
+        Object* m_object;
+        bool done;
+
+        SCollisionHitCallback(Object* obj)
+            : m_object(obj), done(false)
+        {}
+
+        void call(CObject*& obj, float min_cs, float max_cs, float& cs, float& hl, ICollisionDamageInfo* di) override
+        {
+            if (done) return;
+            done = true;
+
+            obj = nullptr;
+
+            if (cs > min_cs * 0.5f)
+            {
+                obj = m_object;
+            }
+
+            di->SetInitiated();
+        }
+    };
 
 	xr_vector<CPhysicsShellHolder *> tele_objects;
 	CPhysicsShellHolder* selected_object;

--- a/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
+++ b/src/xrGame/ai/monsters/burer/burer_state_attack_tele_inline.h
@@ -272,8 +272,9 @@ void CStateBurerAttackTele<Object>::FireAllToEnemy()
 		return;
 	}
 
-	Fvector enemy_pos;
-	enemy_pos = get_head_position(const_cast<CEntityAlive*>(object->EnemyMan.get_enemy()));
+    CEntityAlive* const enemy = const_cast<CEntityAlive*>(object->EnemyMan.get_enemy());
+    const bool is_actor = enemy->cast_actor() != nullptr;
+	const Fvector enemy_pos = get_head_position(enemy);
 
 	for (u32 i = 0; i < object->CTelekinesis::get_objects_count(); ++i)
 	{
@@ -284,9 +285,12 @@ void CStateBurerAttackTele<Object>::FireAllToEnemy()
 		{
 			continue;
 		}
+
 		float const dist_to_enemy = cur_object->Position().distance_to(enemy_pos);
 		float const fire_time = dist_to_enemy / object->m_tele_fly_velocity;
 
+        SCollisionHitCallback* const hit_callback = is_actor ? xr_new<SCollisionHitCallback>(object) : nullptr;
+        cur_object->set_collision_hit_callback(hit_callback);
 		object->CTelekinesis::fire_t(cur_object, enemy_pos, fire_time);
 
 		u32 const new_num_objects = object->CTelekinesis::get_objects_count();
@@ -346,12 +350,14 @@ void CStateBurerAttackTele<Object>::ExecuteTeleContinue()
 template <typename Object>
 void CStateBurerAttackTele<Object>::ExecuteTeleFire()
 {
-	Fvector enemy_pos;
-	enemy_pos = get_head_position(const_cast<CEntityAlive*>(object->EnemyMan.get_enemy()));
+    CEntityAlive* const enemy = const_cast<CEntityAlive*>(object->EnemyMan.get_enemy());
+	const Fvector enemy_pos = get_head_position(enemy);
 
 	float const dist_to_enemy = selected_object->Position().distance_to(enemy_pos);
 	float const fire_time = dist_to_enemy / object->m_tele_fly_velocity;
 
+    SCollisionHitCallback* const hit_callback = enemy->cast_actor() ? xr_new<SCollisionHitCallback>(object) : nullptr;
+    selected_object->set_collision_hit_callback(hit_callback);
 	object->CTelekinesis::fire_t(selected_object, enemy_pos, fire_time);
 
 	object->StopTeleObjectParticle(selected_object);

--- a/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
@@ -413,6 +413,7 @@ void CPoltergeist::Die(CObject* who)
 	}
 
 	inherited::Die(who);
+    CTelekinesis::remove_object_callbacks();
 	CTelekinesis::deactivate();
 	Energy::disable();
 

--- a/src/xrGame/ai/monsters/poltergeist/poltergeist_telekinesis.cpp
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist_telekinesis.cpp
@@ -292,24 +292,30 @@ struct SCollisionHitCallback :
 
 {
 	//	CollisionHitCallbackFun				*m_collision_hit_callback																																						;
-	CPhysicsShellHolder* m_object;
+	CPoltergeist* m_object;
 	float m_pmt_object_collision_damage;
     bool done = false;
 
-	SCollisionHitCallback(CPhysicsShellHolder* object, float pmt_object_collision_damage):
-		m_object(object), m_pmt_object_collision_damage(pmt_object_collision_damage)
+	SCollisionHitCallback(CPoltergeist* obj, float pmt_object_collision_damage):
+		m_object(obj), m_pmt_object_collision_damage(pmt_object_collision_damage)
 	{
-		VERIFY(object);
+		VERIFY(obj);
 	}
 
-	void call(IPhysicsShellHolder* obj, float min_cs, float max_cs, float& cs, float& hl, ICollisionDamageInfo* di)
+	void call(CObject*& obj, float min_cs, float max_cs, float& cs, float& hl, ICollisionDamageInfo* di) override
 	{
         if (done) return;
-		if (cs > min_cs * 0.5f)
-			hl = m_pmt_object_collision_damage;
-		VERIFY(m_object);
-		di->SetInitiated();
         done = true;
+
+        obj = nullptr;
+
+        if (cs > min_cs * 0.5f)
+        {
+            hl = m_pmt_object_collision_damage;
+            obj = m_object;
+        }
+
+		di->SetInitiated();
 	}
 };
 
@@ -321,15 +327,13 @@ void CPolterTele::tele_fire_objects()
 		//if (tele_object.get_state() != TS_Fire) {
 		if ((tele_object.get_state() == TS_Raise) || (tele_object.get_state() == TS_Keep))
 		{
-			Fvector enemy_pos;
-			enemy_pos = get_head_position(Actor());
 			CPhysicsShellHolder* hobj = tele_object.get_object();
-
 			VERIFY(hobj);
-			hobj->set_collision_hit_callback(xr_new<SCollisionHitCallback>(hobj, m_pmt_object_collision_damage));
-			m_object->CTelekinesis::fire_t(tele_object.get_object(), enemy_pos,
-			                               tele_object.get_object()->Position().distance_to(enemy_pos) /
-			                               m_pmt_fly_velocity);
+
+            const Fvector enemy_pos = get_head_position(Actor());
+            const float fire_time = hobj->Position().distance_to(enemy_pos) / m_pmt_fly_velocity;
+			hobj->set_collision_hit_callback(xr_new<SCollisionHitCallback>(m_object, m_pmt_object_collision_damage));
+			m_object->CTelekinesis::fire_t(hobj, enemy_pos, fire_time);
 			return;
 		}
 	}

--- a/src/xrGame/ai/monsters/telekinesis.cpp
+++ b/src/xrGame/ai/monsters/telekinesis.cpp
@@ -10,11 +10,11 @@ CTelekinesis::CTelekinesis()
 
 CTelekinesis::~CTelekinesis()
 {
-	for (TELE_OBJECTS_IT it = objects.begin(); it != objects.end(); ++it)
-	{
-		(*it)->release();
-		xr_delete(*it);
-	}
+    for (CTelekineticObject* obj : objects)
+    {
+        obj->release();
+        xr_delete(obj);
+    }
 }
 
 CTelekineticObject* CTelekinesis::activate(CPhysicsShellHolder* obj, float strength, float height, u32 max_time_keep,
@@ -26,7 +26,7 @@ CTelekineticObject* CTelekinesis::activate(CPhysicsShellHolder* obj, float stren
 	if (!tele_object->init(this, obj, strength, height, max_time_keep, rot))
 	{
 		xr_delete(tele_object);
-		return 0;
+		return nullptr;
 	}
 
 	// добавить объект
@@ -44,11 +44,13 @@ void CTelekinesis::clear()
 
 void CTelekinesis::remove_object_callbacks()
 {
-    for (auto it : objects)
+    for (CTelekineticObject* it : objects)
     {
-        auto obj = it->get_object();
+        CPhysicsShellHolder* const obj = it->get_object();
         if (obj)
-            obj->set_collision_hit_callback(0);
+        {
+            obj->set_collision_hit_callback(nullptr);
+        }
     }
 }
 
@@ -58,10 +60,10 @@ void CTelekinesis::deactivate()
 
 	// отпустить все объекты
 	// 
-	for (TELE_OBJECTS_IT it = objects.begin(); it != objects.end(); ++it)
+	for (CTelekineticObject* obj : objects)
 	{
-		(*it)->release();
-		xr_delete(*it);
+		obj->release();
+		xr_delete(obj);
 	}
 
 	clear();
@@ -114,7 +116,7 @@ void CTelekinesis::remove_object(CPhysicsShellHolder* obj)
 	TELE_OBJECTS_IT it = std::find_if(objects.begin(), objects.end(), SFindPred(obj));
 	if (it == objects.end()) return;
 	//remove from list, delete...
-    obj->set_collision_hit_callback(0);
+    obj->set_collision_hit_callback(nullptr);
 	remove_object(it);
 }
 

--- a/src/xrGame/ai/monsters/telekinetic_object.cpp
+++ b/src/xrGame/ai/monsters/telekinetic_object.cpp
@@ -16,8 +16,8 @@
 CTelekineticObject::CTelekineticObject()
 {
 	state = TS_None;
-	object = 0;
-	telekinesis = 0;
+	object = nullptr;
+	telekinesis = nullptr;
 	m_rotate = false;
 }
 

--- a/src/xrGame/entity_alive.cpp
+++ b/src/xrGame/entity_alive.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch_script.h"
+#include "pch_script.h"
 #include "entity_alive.h"
 #include "inventoryowner.h"
 #include "inventory.h"
@@ -726,8 +726,8 @@ CPHSoundPlayer* CEntityAlive::ph_sound_player()
 ICollisionHitCallback* CEntityAlive::get_collision_hit_callback()
 {
 	CCharacterPhysicsSupport* cs = character_physics_support();
-	if (cs)return cs->get_collision_hit_callback();
-	else return false;
+	if (cs) return cs->get_collision_hit_callback();
+	return nullptr;
 }
 
 void CEntityAlive::set_collision_hit_callback(ICollisionHitCallback* cc)

--- a/src/xrPhysics/IPhysicsShellHolder.h
+++ b/src/xrPhysics/IPhysicsShellHolder.h
@@ -6,7 +6,7 @@ class IDamageSource;
 class IKinematics;
 class CPhysicsShell;
 class IPHCapture;
-class IPhysicsShellHolder;
+class CObject;
 class CPHSoundPlayer;
 class ICollisionDamageReceiver;
 class ICollisionForm;
@@ -14,7 +14,7 @@ class ICollisionForm;
 class ICollisionHitCallback
 {
 public:
-	virtual void call(IPhysicsShellHolder* obj, float min_cs, float max_cs, float& cs, float& hl,
+	virtual void call(CObject*& obj, float min_cs, float max_cs, float& cs, float& hl,
 	                  ICollisionDamageInfo* di) = 0;
 
 	virtual ~ICollisionHitCallback()


### PR DESCRIPTION
Fixed an issue where objects thrown via telekinesis by burers and poltergeists were not tracked properly, making it impossible to register their hits on the actor. Now, the monster that launched the object is correctly passed to SHit as the damage source, instead of the CActor placeholder.