### PR TITLE
PDA Map QoL features

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -152,6 +152,9 @@
 	<string id="ui_mm_modded_exes_visual_ui_hud_use_english_text_for_missing_translations">
 		<text>Use English Text For Missing Translations (use_english_text_for_missing_translations)</text>
 	</string>
+	<string id="ui_mm_modded_exes_visual_ui_hud_pda_show_map_labels">
+		<text>Show Level Names On Global Map (pda_show_map_labels)</text>
+	</string>
 
 	<!-- Crosshair -->
 	<string id="ui_mm_crosshair_modded_exes">
@@ -680,7 +683,7 @@
 	<string id="ui_mm_modded_exes_control_pda_pda_map_zoom_out_to_mouse">
 		<text>Map Zoom Out Relative To Mouse (pda_map_zoom_out_to_mouse)</text>
 	</string>
-	
+
 	<!-- Gameplay -->
 	<string id="ui_mm_menu_gameplay">
 		<text>Gameplay</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -152,6 +152,9 @@
 	<string id="ui_mm_modded_exes_visual_ui_hud_use_english_text_for_missing_translations">
 		<text>Использовать английский язык для отсуствующего перевода (use_english_text_for_missing_translations)</text>
 	</string>
+	<string id="ui_mm_modded_exes_visual_ui_hud_pda_show_map_labels">
+		<text>Show Level Names On Global Map (pda_show_map_labels)</text>
+	</string>
 
 	<!-- Crosshair -->
 	<string id="ui_mm_crosshair_modded_exes">

--- a/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/scripts/callbacks_gameobject.script
@@ -272,6 +272,21 @@ _G.COnRightClickMap = function(property_ui, map_table)
 	SendScriptCallback("on_map_right_click", property_ui, map_table)
 end
 
+--[[
+
+On left click on PDA map spot callback
+Params are id, level_name, spot_type
+	id - alife object id of the spot, 65535 if none
+	level_name - name of the level the spot belongs to
+	spot_type - icon id from map_spots XML
+
+--]]
+
+AddScriptCallback("on_map_spot_selected")
+function pda.map_spot_selected(id, level_name, spot_type)
+	SendScriptCallback("on_map_spot_selected", id, level_name, spot_type)
+end
+
 -- On receive game news callback
 AddScriptCallback("on_news_received")
 _G.CUIMessagesWindow__AddIconedPdaMessage = function(UIMessageView, UITimeText, UICaptionText, UIMsgText, UIIconStatic, UIMessagesScrollView)

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -34,6 +34,7 @@
 
         pda_map_zoom_in_to_mouse // Enable map zoom in relative to cursor
         pda_map_zoom_out_to_mouse // Enable map zoom out relative to cursor
+        pda_show_map_labels // Show level name labels on the global PDA map if configured in game_maps_single.ltx
 
         mouse_wheel_change_weapon // Enable changing weapons with mouse wheel
         mouse_wheel_invert_zoom // Invert mouse wheel
@@ -157,9 +158,20 @@
         CUIMessagesWindow get_messages_menu()
     }
 
+    namespace pda {
+        function map_spot_selected(u16 obj_id, string level_name, string spot_type) // fired on left-click of any PDA map spot
+    }
+
     // MT only
     class cse_alife_item_weapon {
         function clone_upgrades(cse_alife_item_weapon*)
+    }
+
+    // MT only
+    class cse_alife_level_changer : cse_alife_space_restrictor {
+        property dest_game_vertex_id    // u16
+        property dest_level_vertex_id   // u32
+        property dest_position          // Fvector
     }
 
     class CUIProgressBar {
@@ -349,6 +361,9 @@
             spot_type: string, icon ID from map_spots XML
             text: string, text when spot is hovered
         // }
+
+        void map_pan_to(LPCSTR level_name, float x, float z, bool zoom_in)
+        void map_pan_to_level(LPCSTR level_name, bool zoom_in)
 
         // MT only
         CMapManager* get_map_manager()

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -158,10 +158,6 @@
         CUIMessagesWindow get_messages_menu()
     }
 
-    namespace pda {
-        function map_spot_selected(u16 obj_id, string level_name, string spot_type) // fired on left-click of any PDA map spot
-    }
-
     // MT only
     class cse_alife_item_weapon {
         function clone_upgrades(cse_alife_item_weapon*)

--- a/gamedata/scripts/options_modded_exes_ui_hud.script
+++ b/gamedata/scripts/options_modded_exes_ui_hud.script
@@ -11,4 +11,5 @@ PAGE = page {
 		id = "use_english_text_for_missing_translations",
 		restart = true,
 	},
+	list_bool { id = "pda_show_map_labels" },
 }

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -146,6 +146,7 @@ namespace crash_saving {
 }
 extern BOOL pda_map_zoom_in_to_mouse;
 extern BOOL pda_map_zoom_out_to_mouse;
+extern BOOL pda_show_map_labels;
 extern BOOL mouseWheelChangeWeapon;
 extern BOOL mouseWheelInvertZoom;
 extern BOOL mouseWheelInvertChangeWeapons;
@@ -3032,6 +3033,7 @@ void CCC_RegisterCommands()
 	// PDA commands
 	CMD4(CCC_Integer, "pda_map_zoom_in_to_mouse", &pda_map_zoom_in_to_mouse, 0, 1);
 	CMD4(CCC_Integer, "pda_map_zoom_out_to_mouse", &pda_map_zoom_out_to_mouse, 0, 1);
+	CMD4(CCC_Integer, "pda_show_map_labels", &pda_show_map_labels, 0, 1);
 
 	// Mouse Wheel
 	CMD4(CCC_Integer, "mouse_wheel_change_weapon", &mouseWheelChangeWeapon, 0, 1);

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -39,6 +39,9 @@
 #include "hudmanager.h"
 #include "ui\UIMainIngameWnd.h"
 #include "ui\UIHudStatesWnd.h"
+#include "ui\UIPdaWnd.h"
+#include "ui\UITaskWnd.h"
+#include "ui\UIMapWnd.h"
 #include "raypick.h"
 #include "../xrcdb/xr_collide_defs.h"
 #include "../xrEngine/Rain.h"
@@ -502,6 +505,30 @@ CUIStatic* map_get_minimap_spot_static(u16 id, LPCSTR spot_type)
 u16 map_has_object_spot(u16 id, LPCSTR spot_type)
 {
 	return Level().MapManager().HasMapLocation(spot_type, id);
+}
+
+void map_pan_to(LPCSTR level_name, float x, float z, bool zoom_in)
+{
+	CUIGameCustom* gameUI = CurrentGameUI();
+	if (!gameUI) return;
+	CUITaskWnd* taskWnd = gameUI->GetPdaMenu().pUITaskWnd;
+	if (!taskWnd) return;
+	CUIMapWnd* mapWnd = taskWnd->GetMapWnd();
+	if (!mapWnd) return;
+	mapWnd->SetTargetMap(shared_str(level_name),
+		Fvector2().set(x, z),
+		zoom_in);
+}
+
+void map_pan_to_level(LPCSTR level_name, bool zoom_in)
+{
+	CUIGameCustom* gameUI = CurrentGameUI();
+	if (!gameUI) return;
+	CUITaskWnd* taskWnd = gameUI->GetPdaMenu().pUITaskWnd;
+	if (!taskWnd) return;
+	CUIMapWnd* mapWnd = taskWnd->GetMapWnd();
+	if (!mapWnd) return;
+	mapWnd->SetTargetMap(shared_str(level_name), zoom_in);
 }
 
 bool patrol_path_exists(LPCSTR patrol_path)
@@ -2509,6 +2536,9 @@ void CLevel::script_register(lua_State* L)
 			def("map_get_object_spot_static", map_get_spot_static),
 			def("map_get_object_minimap_spot_static", map_get_minimap_spot_static),
 			def("map_get_object_spots_by_id", map_get_object_spots_by_id),
+
+			def("map_pan_to", &map_pan_to),
+			def("map_pan_to_level", &map_pan_to_level),
 
 			def("add_dialog_to_render", add_dialog_to_render),
 			def("remove_dialog_to_render", remove_dialog_to_render),

--- a/src/xrGame/map_spot.cpp
+++ b/src/xrGame/map_spot.cpp
@@ -41,9 +41,9 @@ void CMapSpot::Load(CUIXml* xml, LPCSTR path)
 	int i = xml->ReadAttribInt(path, 0, "scale", 0);
 	m_bScale = (i == 1);
 	m_scale_bounds.x = xml->ReadAttribFlt(path, 0, "scale_min", -1.0f);
+	m_scale_bounds.y = xml->ReadAttribFlt(path, 0, "scale_max", -1.0f);
 	if (m_bScale)
 	{
-		m_scale_bounds.y = xml->ReadAttribFlt(path, 0, "scale_max", -1.0f);
 		R_ASSERT2(m_scale_bounds.x>0 && m_scale_bounds.y>0, path);
 	}
 	m_location_level = xml->ReadAttribInt(path, 0, "location_level", 0);

--- a/src/xrGame/map_spot.cpp
+++ b/src/xrGame/map_spot.cpp
@@ -10,6 +10,7 @@
 #include "object_broker.h"
 #include "ui/UITextureMaster.h"
 #include "ui/UIHelper.h"
+#include "UICursor.h"
 
 #include "../Include/xrRender/UIShader.h"
 #include "gametaskmanager.h"
@@ -23,6 +24,8 @@ CMapSpot::CMapSpot(CMapLocation* ml)
 	m_location_level = 0;
 	m_border_static = NULL;
 	m_scale_bounds.set(-1.0f, -1.0f);
+	m_lbtn_down_pos.set(0.0f, 0.0f);
+	m_lbtn_armed = false;
 }
 
 CMapSpot::~CMapSpot()
@@ -87,32 +90,49 @@ void CMapSpot::Update()
 	}
 }
 
-bool CMapSpot::OnMouseDown(int mouse_btn)
+// Cursor must stay within this radius between MOUSE_1 down and up for the
+// press to count as a click rather than a map-pan drag.
+static const float MAP_SPOT_CLICK_THRESHOLD_SQ = 25.0f; // 5px squared
+
+bool CMapSpot::OnMouseAction(float x, float y, EUIMessages mouse_action)
 {
-	if (mouse_btn == MOUSE_1)
+	if (mouse_action == WINDOW_LBUTTON_DOWN)
 	{
-		CGameTask* t = Level().GameTaskManager().HasGameTask(m_map_location, true);
-		if (t)
+		m_lbtn_down_pos = GetUICursor().GetCursorPosition();
+		m_lbtn_armed    = true;
+		// Don't return true — the map needs the DOWN to begin pan tracking.
+	}
+	else if (mouse_action == WINDOW_LBUTTON_UP && m_lbtn_armed)
+	{
+		m_lbtn_armed = false;
+		Fvector2 up = GetUICursor().GetCursorPosition();
+		float dx = up.x - m_lbtn_down_pos.x;
+		float dy = up.y - m_lbtn_down_pos.y;
+		if ((dx * dx + dy * dy) < MAP_SPOT_CLICK_THRESHOLD_SQ)
 		{
 			GetMessageTarget()->SendMessage(this, MAP_SELECT_SPOT);
 			return true;
 		}
-		return false;
 	}
-	else if (mouse_btn == MOUSE_2)
+	return inherited::OnMouseAction(x, y, mouse_action);
+}
+
+bool CMapSpot::OnMouseDown(int mouse_btn)
+{
+	if (mouse_btn == MOUSE_2)
 	{
 		GetMessageTarget()->SendMessage(this, MAP_SELECT_SPOT2);
 		return true;
 	}
-	else
-	{
-		return false;
-	}
+	// MOUSE_1 is handled in OnMouseAction (down arms, up fires if no drag).
+	return false;
 }
 
 
 void CMapSpot::OnFocusLost()
 {
+	// Disarm so a later UP after the cursor re-enters can't fire a stale click.
+	m_lbtn_armed = false;
 	inherited::OnFocusLost();
 	GetMessageTarget()->SendMessage(this, MAP_HIDE_HINT, NULL);
 }

--- a/src/xrGame/map_spot.h
+++ b/src/xrGame/map_spot.h
@@ -17,6 +17,11 @@ private:
 
 	bool m_mark_focused;
 
+	// Map pan and spot click share MOUSE_1, so the click is deferred to
+	// UP and dropped if the cursor moved past MAP_SPOT_CLICK_THRESHOLD_SQ.
+	Fvector2 m_lbtn_down_pos;
+	bool     m_lbtn_armed;
+
 public:
 	bool m_bScale;
 	Fvector2 m_scale_bounds;
@@ -32,6 +37,7 @@ public:
 	virtual LPCSTR GetHint();
 	virtual void SetWndPos(const Fvector2& pos);
 	virtual void Update();
+	virtual bool OnMouseAction(float x, float y, EUIMessages mouse_action);
 	virtual bool OnMouseDown(int mouse_btn);
 	virtual void OnFocusLost();
 

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -573,10 +573,12 @@ void CUILevelMap::Update()
 		float lw = m_label->GetWidth();
 		float lh = m_label->GetHeight();
 		// Offset is in global_rect units (scaled by zoom so it stays anchored);
+		// X also scaled by UI kx since global_rect X is kx-scaled at load.
 		// Y inverted because engine screen Y grows downward.
 		float gmz = MapWnd()->GlobalMap()->GetCurrentZoom().x;
+		float kx  = UI().get_current_kx();
 		m_label->SetWndPos(Fvector2().set(
-			(rect.width()  - lw) * 0.5f + m_label_offset.x * gmz,
+			(rect.width()  - lw) * 0.5f + m_label_offset.x * gmz * kx,
 			(rect.height() - lh) * 0.5f - m_label_offset.y * gmz));
 		if (!m_label->GetParent())
 			AttachChild(m_label);

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -464,6 +464,9 @@ void CUILevelMap::Init_internal(const shared_str& name, CInifile& pLtx, const sh
 			? pGameIni->r_float(MapName(), "label_scale_max")
 			: 0.0f;
 
+		// label_color = R, G, B, A — ints 0-255. Alpha omitted defaults to 255
+		// (per r_color/sscanf), not the engine default of 180, so authors who
+		// want partial transparency must spell out the 4th component.
 		u32 label_color = color_argb(180, 230, 220, 200);
 		if (pGameIni->line_exist(MapName(), "label_color"))
 			label_color = pGameIni->r_color(MapName(), "label_color");

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -416,8 +416,15 @@ void CUILevelMap::Draw()
 					sz.mul(k);
 					sp->SetWndSize(sz);
 				}
-				else if (sp->m_scale_bounds.x > 0.0f)
-					sp->SetVisible(sp->m_scale_bounds.x < gmz);
+				else if (sp->m_scale_bounds.x > 0.0f || sp->m_scale_bounds.y > 0.0f)
+				{
+					bool visible = true;
+					if (sp->m_scale_bounds.x > 0.0f && gmz <= sp->m_scale_bounds.x)
+						visible = false;
+					if (sp->m_scale_bounds.y > 0.0f && gmz >= sp->m_scale_bounds.y)
+						visible = false;
+					sp->SetVisible(visible);
+				}
 			}
 		}
 	}

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -5,6 +5,8 @@
 #include "../map_spot.h"
 #include "UIMap.h"
 #include "UIMapWnd.h"
+#include "UIStatic.h"
+#include "../string_table.h"
 #include "../../xrEngine/xr_input.h"		//remove me !!!
 
 const u32 activeLocalMapColor = 0xffffffff; //0xffc80000;
@@ -386,11 +388,21 @@ float CUIGlobalMap::CalcOpenRect(const Fvector2& center_point, Frect& map_desire
 CUILevelMap::CUILevelMap(CUIMapWnd* p)
 {
 	m_mapWnd = p;
+	m_label = nullptr;
+	m_label_scale_max = 0.0f;
+	m_label_offset.set(0.0f, 0.0f);
 	Show(false);
 }
 
 CUILevelMap::~CUILevelMap()
 {
+	if (m_label)
+	{
+		if (m_label->GetParent() == this)
+			DetachChild(m_label);
+		xr_delete(m_label);
+		m_label = nullptr;
+	}
 }
 
 void CUILevelMap::Draw()
@@ -398,6 +410,9 @@ void CUILevelMap::Draw()
 	if (MapWnd())
 	{
 		float gmz = MapWnd()->GlobalMap()->GetCurrentZoom().x;
+		if (m_label && m_label_scale_max > 0.0f)
+			m_label->SetVisible(gmz < m_label_scale_max);
+
 		for (WINDOW_LIST_it it = m_ChildWndList.begin(); m_ChildWndList.end() != it; ++it)
 		{
 			CMapSpot* sp = smart_cast<CMapSpot*>((*it));
@@ -440,6 +455,32 @@ void CUILevelMap::Init_internal(const shared_str& name, CInifile& pLtx, const sh
 	tmp.z *= UI().get_current_kx();
 	m_GlobalRect.set(tmp.x, tmp.y, tmp.z, tmp.w);
 
+	if (pGameIni->line_exist(MapName(), "label"))
+	{
+		LPCSTR label_id = pGameIni->r_string(MapName(), "label");
+		m_label_scale_max = pGameIni->line_exist(MapName(), "label_scale_max")
+			? pGameIni->r_float(MapName(), "label_scale_max")
+			: 0.0f;
+
+		u32 label_color = color_argb(180, 230, 220, 200);
+		if (pGameIni->line_exist(MapName(), "label_color"))
+			label_color = pGameIni->r_color(MapName(), "label_color");
+
+		if (pGameIni->line_exist(MapName(), "label_offset_x"))
+			m_label_offset.x = pGameIni->r_float(MapName(), "label_offset_x");
+		if (pGameIni->line_exist(MapName(), "label_offset_y"))
+			m_label_offset.y = pGameIni->r_float(MapName(), "label_offset_y");
+
+		CStringTable str_tbl;
+		m_label = xr_new<CUITextWnd>();
+		m_label->SetFont(UI().Font().pFontLetterica18Russian);
+		m_label->SetTextColor(label_color);
+		m_label->SetTextAlignment(CGameFont::alCenter);
+		m_label->SetText(*str_tbl.translate(label_id));
+		m_label->SetWidth(180.0f);
+		m_label->AdjustHeightToText();
+		AttachChild(m_label);
+	}
 
 #ifdef DEBUG
 	float kw = m_GlobalRect.width	()	/	BoundRect().width	();
@@ -519,6 +560,22 @@ void CUILevelMap::Update()
 	SetWndRect(rect);
 
 	inherited::Update();
+
+	// UpdateSpots() calls DetachAll() each frame, so the label must be
+	// re-attached after inherited::Update() runs or it won't draw.
+	if (m_label)
+	{
+		float lw = m_label->GetWidth();
+		float lh = m_label->GetHeight();
+		// Offset is in global_rect units (scaled by zoom so it stays anchored);
+		// Y inverted because engine screen Y grows downward.
+		float gmz = MapWnd()->GlobalMap()->GetCurrentZoom().x;
+		m_label->SetWndPos(Fvector2().set(
+			(rect.width()  - lw) * 0.5f + m_label_offset.x * gmz,
+			(rect.height() - lh) * 0.5f - m_label_offset.y * gmz));
+		if (!m_label->GetParent())
+			AttachChild(m_label);
+	}
 
 	if (m_bCursorOverWindow)
 	{

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -13,6 +13,8 @@ const u32 activeLocalMapColor = 0xffffffff; //0xffc80000;
 const u32 inactiveLocalMapColor = 0xffffffff; //0xff438cd1;
 const u32 ourLevelMapColor = 0xffffffff;
 
+BOOL pda_show_map_labels = TRUE;
+
 
 CUICustomMap::CUICustomMap()
 {
@@ -411,7 +413,7 @@ void CUILevelMap::Draw()
 	{
 		float gmz = MapWnd()->GlobalMap()->GetCurrentZoom().x;
 		if (m_label && m_label_scale_max > 0.0f)
-			m_label->SetVisible(gmz < m_label_scale_max);
+			m_label->SetVisible(!!pda_show_map_labels && (gmz < m_label_scale_max));
 
 		for (WINDOW_LIST_it it = m_ChildWndList.begin(); m_ChildWndList.end() != it; ++it)
 		{

--- a/src/xrGame/ui/UIMap.h
+++ b/src/xrGame/ui/UIMap.h
@@ -117,12 +117,17 @@ protected:
 	virtual void Init_internal(const shared_str& name, CInifile& pLtx, const shared_str& sect_name, LPCSTR sh_name);
 };
 
+class CUITextWnd;
+
 class CUILevelMap : public CUICustomMap
 {
 	typedef CUICustomMap inherited;
 
 	CUIMapWnd* m_mapWnd;
 	Frect m_GlobalRect; // virtual map size (meters)
+	CUITextWnd* m_label;
+	float m_label_scale_max; // hide label when global zoom >= this; 0 = always show
+	Fvector2 m_label_offset; // global_rect units from rect centre; +x right, +y up (scaled by zoom at apply)
 	CUILevelMap(const CUILevelMap& obj)
 	{
 	}

--- a/src/xrGame/ui/UIMap.h
+++ b/src/xrGame/ui/UIMap.h
@@ -125,7 +125,7 @@ class CUILevelMap : public CUICustomMap
 
 	CUIMapWnd* m_mapWnd;
 	Frect m_GlobalRect; // virtual map size (meters)
-	CUITextWnd* m_label;
+	CUITextWnd* m_label; // owned and freed in dtor — do not enable autodelete
 	float m_label_scale_max; // hide label when global zoom >= this; 0 = always show
 	Fvector2 m_label_offset; // global_rect units from rect centre; +x right, +y up (scaled by zoom at apply)
 	CUILevelMap(const CUILevelMap& obj)

--- a/src/xrGame/ui/UIMapWnd.cpp
+++ b/src/xrGame/ui/UIMapWnd.cpp
@@ -978,14 +978,21 @@ void CUIMapWnd::Reset()
 void CUIMapWnd::SpotSelected(CUIWindow* w)
 {
 	CMapSpot* sp = smart_cast<CMapSpot*>(w);
-	if (!sp)
+	if (!sp || !sp->MapLocation())
 	{
 		return;
 	}
+	CMapLocation* ml = sp->MapLocation();
 
-	CGameTask* t = Level().GameTaskManager().HasGameTask(sp->MapLocation(), true);
+	CGameTask* t = Level().GameTaskManager().HasGameTask(ml, true);
 	if (t)
 	{
 		Level().GameTaskManager().SetActiveTask(t);
 	}
+
+	::luabind::functor<void> funct;
+	if (ai().script_engine().functor("pda.map_spot_selected", funct))
+		funct(ml->ObjectID(),
+			ml->GetLevelName().c_str(),
+			ml->spot_type);
 }

--- a/src/xrGame/ui/UITaskWnd.h
+++ b/src/xrGame/ui/UITaskWnd.h
@@ -58,6 +58,7 @@ public:
 	virtual ~CUITaskWnd();
 	virtual void SendMessage(CUIWindow* pWnd, s16 msg, void* pData);
 	void Init();
+	CUIMapWnd* GetMapWnd() const { return m_pMapWnd; }
 	virtual void Update();
 	virtual void Draw();
 	void DrawHint();

--- a/src/xrServerEntities/xrServer_Objects_ALife_script.cpp
+++ b/src/xrServerEntities/xrServer_Objects_ALife_script.cpp
@@ -123,6 +123,9 @@ void CSE_ALifeLevelChanger::script_register(lua_State* L)
 			"cse_alife_level_changer",
 			CSE_ALifeSpaceRestrictor
 		)
+		.def_readonly("dest_game_vertex_id",  &CSE_ALifeLevelChanger::m_tNextGraphID)
+		.def_readonly("dest_level_vertex_id", &CSE_ALifeLevelChanger::m_dwNextNodeID)
+		.def_readonly("dest_position",        &CSE_ALifeLevelChanger::m_tNextPosition)
 	];
 }
 


### PR DESCRIPTION
**Changes**
- Map names which can take an optional colour and offset (see Cordon in the video attached) drawn at lower zoom levels and disappear as you zoom in closer.
- The map name overlay can be disabled via a settings option (Settings -> Modded EXES -> Visual -> UI/HUD) for players who find it immersion breaking. By default without the label set in the LTX there will not be any names drawn, so this will not change existing behaviour of mods.
- LUA callbacks for when the player clicks on map markers so you can toggle scripts (in the attached video, having the level transitions bring the map to the place the player will be transitioned to - this specific implementation is not a part of this PR). But this could be used for other behaviors. I also exposed the PDA map to LUA so scripts can pan the maps to levels or specific points.

Map names, colours and offsets configured in the game_maps_single.ltx:

```
[l01_escape]
global_rect     = 357.0, 2022.0, 505.0, 2319.0
weathers        = atmosfear
music_tracks    = l01_escape_musics
label           = st_label_l01_escape
label_scale_max = 2.5
label_color     = 255, 80, 80, 255
label_offset_x  = 20
label_offset_y  = 100
```

Demo:

https://github.com/user-attachments/assets/a29a44ae-c30b-4b22-9976-b4dcca610062

(Please ignore the broken looking Agroprom map in the video - this is an incomplete part of a map mod that's being worked on and is not related to this set of changes).