### PR TITLE
Make splash logo window not overlap other windows

### DIFF
--- a/src/xrEngine/x_ray.cpp
+++ b/src/xrEngine/x_ray.cpp
@@ -1050,9 +1050,9 @@ int APIENTRY WinMain_impl(HINSTANCE hInstance,
 	SetWindowPos(
 		logoWindow,
 #ifndef DEBUG
-		HWND_TOPMOST,
+		HWND_BOTTOM,
 #else
-        HWND_NOTOPMOST,
+        HWND_BOTTOM,
 #endif // NDEBUG
 		x,
 		y,


### PR DESCRIPTION
It's irritating when splash screen is on top of other windows and you have to wait for a game to be loaded