### PR TITLE
PDA map: cap zoom easing and cancel on user pan

### DIFF
--- a/src/xrGame/ui/UIMapWnd.cpp
+++ b/src/xrGame/ui/UIMapWnd.cpp
@@ -326,6 +326,19 @@ void CUIMapWnd::MoveMap(Fvector2 const& pos_delta)
 	GlobalMap()->MoveWndDelta(pos_delta);
 	UpdateScroll();
 	HideCurHint();
+
+	// Cancel any in-progress zoom/pan easing. Without this the action planner
+	// would lerp the map rect back toward m_desiredMapRect on the next Update,
+	// fighting the user's drag input and causing visible bounce-back.
+	Frect vis_rect = ActiveMapRect();
+	vis_rect.getcenter(m_tgtCenter);
+	Fvector2 pos;
+	GlobalMap()->GetAbsolutePos(pos);
+	m_tgtCenter.sub(pos);
+	m_tgtCenter.div(GlobalMap()->GetCurrentZoom());
+	m_ActionPlanner->m_storage.set_property(1, true);
+	m_ActionPlanner->m_storage.set_property(2, false);
+	m_ActionPlanner->m_storage.set_property(3, false);
 }
 
 void CUIMapWnd::Draw()
@@ -440,9 +453,7 @@ bool CUIMapWnd::OnMouseAction(float x, float y, EUIMessages mouse_action)
 		case WINDOW_MOUSE_MOVE:
 			if (pInput->iGetAsyncBtnState(0))
 			{
-				GlobalMap()->MoveWndDelta(GetUICursor().GetCursorPositionDelta());
-				UpdateScroll();
-				HideCurHint();
+				MoveMap(GetUICursor().GetCursorPositionDelta());
 				return true;
 			}
 			break;

--- a/src/xrGame/ui/UIMapWndActions.cpp
+++ b/src/xrGame/ui/UIMapWndActions.cpp
@@ -209,9 +209,10 @@ void CMapActionZoomControl::init_internal()
 	bool bMove = !fis_zero(dist, EPS_L);
 	bool bZoom = !fsimilar(m_targetZoom, m_object->GlobalMap()->GetCurrentZoom().x, EPS_L);
 	m_endMovingTime = Device.fTimeGlobal;
-	if (bZoom && bMove) m_endMovingTime += _max(map_zoom_time, dist / map_resize_speed);
-	else if (bZoom) m_endMovingTime += map_zoom_time;
-	else if (bMove) m_endMovingTime += _max(dist / map_resize_speed, min_move_time);
+	// Cap duration at map_zoom_time. The original dist/map_resize_speed scaling produced
+	// multi-second eases on enlarged maps, which blocked user pan during the ease.
+	if (bZoom) m_endMovingTime += map_zoom_time;
+	else if (bMove) m_endMovingTime += _min(_max(dist / map_resize_speed, min_move_time), map_zoom_time);
 }
 
 void CMapActionZoomControl::update_target_state()


### PR DESCRIPTION
The zoom/pan action planner used dist/map_resize_speed for its easing duration, which produced multi-second eases on enlarged maps. During the ease, user drag input was overwritten each frame by the planner lerping the rect back toward m_desiredMapRect causing the map to jump back to the ease point.

**Changes:** 
- Cap CMapActionZoomControl easing duration at map_zoom_time (0.5s).
- MoveMap now clears the action planner state and resyncs m_tgtCenter to the current visible center, so user drag/keyboard pan immediately ends any in-progress ease instead of being snapped back.
- OnMouseAction drag path routed through MoveMap for the same reason.

Before the fix:
https://github.com/user-attachments/assets/dccb82ca-fb68-4fcb-80ad-7808560d3d82

After the fix:
https://github.com/user-attachments/assets/531133f0-463a-4751-847d-dd62477d50b4

