### PR TITLE
feat(ai): runtime cvars for stalker rank-dispersion curve

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -954,6 +954,18 @@
 	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_move_to_cover_run_desc">
 		<text>If enabled, NPCs will run instead of walk when taking cover during combat. This makes firefights more dynamic and prevents NPCs from slowly walking while under fire.</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_novice_k">
+		<text>AI Dispersion Scale at Rank 0 (ai_dispersion_novice_k)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_novice_k_desc">
+		<text>Multiplier applied on top of the vanilla rank-dispersion curve at rank 0 (novice).\n \nDefault: 1.0 (no change from vanilla).\n \nLower values reduce low-rank NPC dispersion; higher values increase it. Applies on every NPC's next shot.</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_experienced_k">
+		<text>AI Dispersion Scale at Rank 100 (ai_dispersion_experienced_k)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_experienced_k_desc">
+		<text>Multiplier applied on top of the vanilla rank-dispersion curve at rank 100 (legend tier; cvar name follows the vanilla LTX naming convention).\n \nDefault: 1.0 (no change from vanilla).\n \nLower values reduce high-rank NPC dispersion; higher values increase it. Applies on every NPC's next shot.</text>
+	</string>
 
 	<!-- Monsters -->
 	<string id="ui_mm_menu_monsters">

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -953,6 +953,18 @@
 	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_move_to_cover_run_desc">
 		<text>≈сли включено, NPC будут бежать, а не идти шагом при поиске укрыти€ во врем€ бо€. Ёто делает перестрелки более динамичными и не дает NPC медленно прогуливатьс€ под огнем.</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_novice_k">
+		<text>ћножитель разброса »» при ранге 0 (ai_dispersion_novice_k)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_novice_k_desc">
+		<text>ћножитель, примен€емый поверх стандартной кривой разброса по рангу при ранге 0 (новичок).\n \nѕо умолчанию: 1.0 (без изменений относительно оригинала).\n \nЅолее низкие значени€ уменьшают разброс у NPC низкого ранга, а более высокие увеличивают его. ѕримен€етс€ при следующем выстреле каждого NPC.</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_experienced_k">
+		<text>ћножитель разброса »» при ранге 100 (ai_dispersion_experienced_k)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_stalkers_ai_dispersion_experienced_k_desc">
+		<text>ћножитель, примен€емый поверх стандартной кривой разброса по рангу при ранге 100 (легенда; им€ cvar соответствует названию переменной в стандартном LTX).\n \nѕо умолчанию: 1.0 (без изменений относительно оригинала).\n \nЅолее низкие значени€ уменьшают разброс у NPC высокого ранга, а более высокие увеличивают его. ѕримен€етс€ при следующем выстреле каждого NPC.</text>
+	</string>
 
 	<!-- Monsters -->
 	<string id="ui_mm_menu_monsters">

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -65,6 +65,9 @@
         g_decouple_horz_recoil // calculate horz recoil independently of vert recoil
         g_use_non_linear_inertia // enable non linear weapon inertia movement
 
+        ai_dispersion_novice_k [0; 10] // Stalker NPC weapon-dispersion scale on top of vanilla rank curve, at rank 0; live per shot. Default 1.0 (identity).
+        ai_dispersion_experienced_k [0; 10] // Stalker NPC weapon-dispersion scale on top of vanilla rank curve, at rank 100; live per shot. Default 1.0 (identity).
+
     }
 
     lua extensions {

--- a/gamedata/scripts/options_modded_exes_stalkers.script
+++ b/gamedata/scripts/options_modded_exes_stalkers.script
@@ -135,4 +135,21 @@ PAGE = page {
 		def = false,
 		cmd = "ai_move_to_cover_run",
 	},
+	line {},
+	track {
+		id = "ai_dispersion_novice_k",
+		def = 1.0,
+		min = 0.0,
+		max = 10.0,
+		step = 0.1,
+		cmd = "ai_dispersion_novice_k",
+	},
+	track {
+		id = "ai_dispersion_experienced_k",
+		def = 1.0,
+		min = 0.0,
+		max = 10.0,
+		step = 0.1,
+		cmd = "ai_dispersion_experienced_k",
+	},
 }

--- a/src/xrGame/ai/stalker/ai_stalker_fire.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_fire.cpp
@@ -71,11 +71,18 @@ static float const min_throw_distance = 10.f;
 
 float g_dispersion_base = 1.0f;
 float g_dispersion_factor = 1.0f;
+float g_ai_dispersion_novice_k = 1.0f;
+float g_ai_dispersion_experienced_k = 1.0f;
 
 float CAI_Stalker::GetWeaponAccuracy() const
 {
 	float base = PI / 180.f;
 	base *= m_fRankDisperison;
+	// cvar-driven rank-curve scale on top of vanilla, identity at defaults (1.0 / 1.0)
+	CHARACTER_RANK_VALUE rank = Rank();
+	clamp(rank, 0, 100);
+	float rank_k = float(rank) / 100.f;
+	base *= g_ai_dispersion_experienced_k * rank_k + g_ai_dispersion_novice_k * (1.f - rank_k);
 	CWeapon* W = smart_cast<CWeapon*>(inventory().ActiveItem());
 
 	if (!movement().path_completed())

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -3025,6 +3025,12 @@ void CCC_RegisterCommands()
 	extern float g_ai_aim_max_angle;
 	CMD4(CCC_Float, "ai_aim_max_angle", &g_ai_aim_max_angle, 0.f, 10.f*PI);
 
+	extern float g_ai_dispersion_novice_k;
+	CMD4(CCC_Float, "ai_dispersion_novice_k", &g_ai_dispersion_novice_k, 0.f, 10.f);
+
+	extern float g_ai_dispersion_experienced_k;
+	CMD4(CCC_Float, "ai_dispersion_experienced_k", &g_ai_dispersion_experienced_k, 0.f, 10.f);
+
 #ifdef DEBUG
 	extern BOOL g_debug_doors;
 	CMD4(CCC_Integer, "ai_debug_doors", &g_debug_doors, 0, 1);


### PR DESCRIPTION
## Summary

Adds `ai_dispersion_novice_k` and `ai_dispersion_experienced_k` `CCC_Float` console variables that scale the per-rank weapon-dispersion multiplier on top of vanilla's rank curve in `CAI_Stalker::GetWeaponAccuracy`. Defaults 1.0/1.0 produce identity scaling; vanilla behavior is bit-identical without any cvar override. A cvar write from console, `user.ltx`, the in-game options menu, MCM, or `exec_console_cmd` takes effect on every stalker NPC's next shot.

The PR is purely additive. Vanilla `m_fRankDisperison`, its `net_Spawn` assignment, and the `pSettings->r_float("ranks_properties", "dispersion_*_k")` LTX reads are untouched. The new code adds one block after the existing `base *= m_fRankDisperison;` line that applies the cvar-driven scale factor interpolated by NPC rank. DLTX patches to those LTX keys continue to work normally; the cvars compose multiplicatively on top.

The PR also wires the cvars into the "Stalkers" section of the modded exes options menu introduced by PR #523, with English and Russian translation strings.

The pattern matches the existing `ai_aim_*` cvar family (`g_ai_aim_min_speed`, `g_ai_aim_min_angle`, `g_ai_aim_max_angle`, `g_aim_predict_time`): file-scope globals exposed via `CMD4(CCC_Float, ...)` and read in per-frame AI ticks.

## Use cases

Any combat-AI mod that wants runtime control over the rank-dispersion curve.

- MCM difficulty presets in modpacks that swap cvar pairs without engine knowledge.
- Per-scenario Lua tuning (e.g. a boss fight that tightens NPC aim, then restores defaults).
- Replacing the runtime-tuning use case behind Dynamic AI Aim Settings, GAMMA NPCs Faster Reactions, ReDone Combat AI, DLTX_JURASZKA. DLTX patches to those mods' LTX keys still work after this PR; the cvars apply on top.
- Difficulty scaling tied to player rank or story progression from Lua.

## Cvar semantics

The cvars are SCALE factors applied on top of vanilla's rank curve:

```
final_factor = vanilla_curve(R) * cvar_curve(R)
```

`cvar_curve(R)` interpolates between `g_ai_dispersion_novice_k` (at rank 0) and `g_ai_dispersion_experienced_k` (at rank 100) by NPC rank. To widen low-rank dispersion, set `ai_dispersion_novice_k 2.0`. To tighten high-rank, set `ai_dispersion_experienced_k 0.5`.

## Cvar naming

The cvar names match the vanilla LTX key names in `game_relations.ltx [ranks_properties]`. The "novice_k" name is accurate (rank 0 / novice tier) but "experienced_k" is misleading: vanilla applies that value at rank 100, which is the legend tier in Anomaly's rank scale. The cvar names preserve the LTX convention for engine-side consistency; the menu description strings clarify the actual rank tier.

## Mid-session rank changes

The cvar scale layer reads `Rank()` per shot, so mid-session rank promotions are reflected immediately. Vanilla `m_fRankDisperison` stays frozen at spawn. At default cvar values this is invisible; with non-default cvars the cvar curve responds to rank changes live while the vanilla curve does not. Composition is intentional.

## Files changed

Six files, 57 lines added, 0 removed.

- `src/xrGame/ai/stalker/ai_stalker_fire.cpp` — two new file-scope globals, 5 new lines in `GetWeaponAccuracy` after the vanilla `base *= m_fRankDisperison;`.
- `src/xrGame/console_commands.cpp` — two `CMD4(CCC_Float, ...)` entries placed next to the `ai_aim_*` block.
- `gamedata/scripts/lua_help_ex.script` — two cvar manifest entries.
- `gamedata/scripts/options_modded_exes_stalkers.script` — two track sliders (def 1.0, min 0.0, max 10.0, step 0.1).
- `gamedata/configs/text/eng/ui_mm_modded_exes.xml` — four translation strings.
- `gamedata/configs/text/rus/ui_mm_modded_exes.xml` — four translation strings (windows-1251 preserved).

## Console usage

```
ai_dispersion_novice_k 1.5
ai_dispersion_experienced_k 0.5
```

## Lua usage

```
function actor_on_first_update()
    exec_console_cmd("ai_dispersion_novice_k 1.5")
    exec_console_cmd("ai_dispersion_experienced_k 0.5")
end
```
