### PR TITLE
fix generate available tasks for warfare traders

### DIFF
--- a/gamedata/scripts/aaaa_script_fixes_mp.script
+++ b/gamedata/scripts/aaaa_script_fixes_mp.script
@@ -1222,6 +1222,14 @@ function luagc_cleanup()
 	printf("~[luagc_cleanup] collectgarbage after=%sKb",collectgarbage("count")*1024)
 end
 
+local old_axr_generate_available_tasks = axr_task_manager.generate_available_tasks
+function axr_task_manager.generate_available_tasks(npc, is_sim)
+	if is_sim and _G.WARFARE and warfare.is_warfare_trader(npc) then
+		is_sim = false
+	end
+	return old_axr_generate_available_tasks(npc, is_sim)
+end
+
 function on_game_start()
 	RegisterScriptCallback("actor_on_first_update", actor_on_first_update_calculate_rankings)
 	RegisterScriptCallback("actor_on_first_update", actor_on_first_update_register_callbacks)


### PR DESCRIPTION
generate_ongoing_tasks already has this fix. applying for generate_available_tasks too