### PR TITLE
Guard balance underflow in CScriptGameObject::TransferMoney and GiveMoney

### DIFF
--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -690,7 +690,7 @@ void CScriptGameObject::TransferMoney(int money, CScriptGameObject* pForWho)
 	CInventoryOwner* pOtherOwner = smart_cast<CInventoryOwner*>(&pForWho->object());
 	VERIFY(pOtherOwner);
 
-	if (pOurOwner->get_money() - money < 0)
+	if (money < 0 || pOurOwner->get_money() < static_cast<u32>(money))
 	{
 		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "Character does not have enought money");
 		return;
@@ -704,6 +704,12 @@ void CScriptGameObject::GiveMoney(int money)
 {
 	CInventoryOwner* pOurOwner = smart_cast<CInventoryOwner*>(&object());
 	VERIFY(pOurOwner);
+
+	if (money < 0 && static_cast<u32>(-static_cast<s64>(money)) > pOurOwner->get_money())
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "Character does not have enought money");
+		return;
+	}
 
 	pOurOwner->set_money(pOurOwner->get_money() + money, true);
 }


### PR DESCRIPTION
Two `m_money` u32 underflows in `src/xrGame/script_game_object_inventory_owner.cpp`. `TransferMoney`'s overdraw check is dead due to signed-to-unsigned promotion; `GiveMoney` has no overdraw check. Amount > balance silently wraps `m_money` to ~4e9.

### Bug

`TransferMoney` (line 693):

```cpp
if (pOurOwner->get_money() - money < 0)
```

`get_money()` is `u32`, `money` is `int`. Usual arithmetic conversions promote both to `u32`; `u32 < 0` is constant-false. The `script_log("Character does not have enought money")` branch is unreachable.

`GiveMoney` (line 703) has no check. `set_money(get_money() + money, true)` with negative `money` is `set_money(get_money() - |money|, true)` mod 2^32 — wraps when `|money| > balance`.

### Fix

`TransferMoney`:

```diff
-    if (pOurOwner->get_money() - money < 0)
+    if (money < 0 || pOurOwner->get_money() < static_cast<u32>(money))
```

`GiveMoney`:

```diff
+    if (money < 0 && static_cast<u32>(-static_cast<s64>(money)) > pOurOwner->get_money())
+    {
+        ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError, "Character does not have enought money");
+        return;
+    }
+
     pOurOwner->set_money(pOurOwner->get_money() + money, true);
```

Refuse-and-log matches the 172 other `script_log(eLuaMessageTypeError)` sites in this file. `GiveMoney`'s negative branch promotes through `s64` to avoid signed-overflow UB on `INT_MIN`.

### How it gets reached in practice

`give_money(-amount)` is the canonical actor/NPC deduction idiom in vanilla Anomaly:

- `inventory_upgrades.script:428, 806` — upgrade purchase
- `ui_inventory.script:2487, 2531` — repair/install
- `item_money.script:117-135, 165, 184` — wallet items, corpse loot drain
- `xr_effects.script:915, 4209` — quest deduction
- `warfare_faction_control.script:248-332` — squad/heli purchase
- `tasks_guide.script:612`, `dialogs_mlr.script:1381` — task/dialog fees

`transfer_money(amount, npc)` is `dialogs.relocate_money_from_actor` (`dialogs.script:1829`).

Gating lives at the UI button (`menu_money_*`) or dialog XML (`has_money_X`), not at the bind. Missing or broken gates wrap `m_money` to ~4e9; the fix refuses and the balance is preserved. The corpse-drain case (`|delta| == balance`) is unaffected — the guard's `|delta| > balance` is false, `m_money` clears to zero as today.

### Verified

- `git log -S "Character does not have enought money"`: dead check present since the 2021 Anomaly 1.5.1 import; no prior fix attempt upstream.
- `trade2.cpp:103-105` (`CTrade::TransferItem`) has a separate u32 underflow path on the internal trade flow, gated by the trade UI; out of scope.
- Typo `enought` is the original GSC string; left untouched.

### Files changed

- `src/xrGame/script_game_object_inventory_owner.cpp` (+7 -1)
