### PR TITLE
fix busyhands: remove non-savable children

### DIFF
--- a/src/xrGame/alife_switch_manager.cpp
+++ b/src/xrGame/alife_switch_manager.cpp
@@ -80,18 +80,6 @@ void CALifeSwitchManager::remove_online(CSE_ALifeDynamicObject* object, bool upd
 		object->m_bOnline = false;
 
 		m_saved_chidren = object->children;
-		CSE_ALifeTraderAbstract* inventory_owner = smart_cast<CSE_ALifeTraderAbstract*>(object);
-		if (inventory_owner)
-		{
-			m_saved_chidren.erase(
-				std::remove_if(
-					m_saved_chidren.begin(),
-					m_saved_chidren.end(),
-					remove_non_savable_predicate(&server())
-				),
-				m_saved_chidren.end()
-			);
-		}
 
 		server().Perform_destroy(object, net_flags(TRUE,TRUE));
 		VERIFY(object->children.empty());

--- a/src/xrGame/alife_trader_abstract.cpp
+++ b/src/xrGame/alife_trader_abstract.cpp
@@ -265,8 +265,6 @@ void add_offline_impl(CSE_ALifeDynamicObject* object, const xr_vector<ALife::_OB
 		if (!child->can_save())
 		{
 			object->alife().release(child);
-			--i;
-			--n;
 			continue;
 		}
 


### PR DESCRIPTION
nonsavable items became orphaned and reusing their ID lead to busyhands