### PR TITLE
Add level.remove_hud_motion_cam_effectors() for   cancelling per-animation HUD camera effectors

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -323,7 +323,11 @@
         void set_cam_custom_position_direction(Fvector position, Fvector direction, int smoothing)
         void set_cam_custom_position_direction(Fvector position, Fvector direction)
         void remove_cam_custom_position_direction()
-		
+
+        // Removes all engine-spawned per-animation HUD camera effectors
+        // Scripted effectors added via add_cam_effector are not touched.
+        void remove_hud_motion_cam_effectors()
+
         game_object get_target_obj(ETraceTarget)
         game_object get_target_obj()
         number get_target_dist(ETraceTarget)

--- a/src/xrEngine/CameraManager.cpp
+++ b/src/xrEngine/CameraManager.cpp
@@ -240,6 +240,31 @@ void CCameraManager::RemoveCamEffector(CEffectorCam* ef)
 	}
 }
 
+void CCameraManager::RemoveHudMotionEffectors()
+{
+	for (EffectorCamIt it = m_EffectorsCam.begin(); it != m_EffectorsCam.end();)
+	{
+		if ((*it)->IsHudMotionEffector())
+		{
+			OnEffectorReleased(*it);
+			it = m_EffectorsCam.erase(it);
+		}
+		else
+			++it;
+	}
+
+	for (EffectorCamIt it = m_EffectorsCam_added_deffered.begin(); it != m_EffectorsCam_added_deffered.end();)
+	{
+		if ((*it)->IsHudMotionEffector())
+		{
+			OnEffectorReleased(*it);
+			it = m_EffectorsCam_added_deffered.erase(it);
+		}
+		else
+			++it;
+	}
+}
+
 CEffectorPP* CCameraManager::GetPPEffector(EEffectorPPType type)
 {
 	for (EffectorPPIt it = m_EffectorsPP.begin(); it != m_EffectorsPP.end(); it++)

--- a/src/xrEngine/CameraManager.h
+++ b/src/xrEngine/CameraManager.h
@@ -157,6 +157,8 @@ public:
 	// demonized: removecameffector by pointer
 	void RemoveCamEffector(CEffectorCam* ef);
 
+	void RemoveHudMotionEffectors();
+
 	ECamEffectorType RequestCamEffectorId();
 	EEffectorPPType RequestPPEffectorId();
 	CEffectorPP* GetPPEffector(EEffectorPPType type);

--- a/src/xrEngine/Effector.h
+++ b/src/xrEngine/Effector.h
@@ -49,4 +49,5 @@ public:
 	};
 	virtual BOOL AllowProcessingIfInvalid() { return FALSE; }
 	virtual bool AbsolutePositioning() { return false; }
+    virtual bool IsHudMotionEffector() const { return false; }
 };

--- a/src/xrGame/ActorEffector.h
+++ b/src/xrGame/ActorEffector.h
@@ -100,6 +100,12 @@ public:
 	virtual void ProcessIfInvalid(SCamEffectorInfo& info);
 };
 
+class CHudMotionCamEffector : public CAnimatorCamEffector
+{
+public:
+	virtual bool IsHudMotionEffector() const { return true; }
+};
+
 class CAnimatorCamLerpEffector : public CAnimatorCamEffector
 {
 protected:

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -952,6 +952,12 @@ bool check_cam_effector(int id)
 	return false;
 }
 
+void remove_hud_motion_cam_effectors()
+{
+	CActor* actor = Actor();
+	if (actor)
+		actor->Cameras().RemoveHudMotionEffectors();
+}
 
 float get_snd_volume()
 {
@@ -2579,6 +2585,7 @@ void CLevel::script_register(lua_State* L)
 
 			// demonized: Set custom camera position and direction with movement smoothing (for cutscenes, etc)
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int, bool, bool))& set_cam_position_direction)),
+			def("remove_hud_motion_cam_effectors", &remove_hud_motion_cam_effectors),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int, bool))&set_cam_position_direction)),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int))&set_cam_position_direction)),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&))&set_cam_position_direction)),

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -686,7 +686,7 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
 			if (FS.exist(ce_path, "$game_anims$", anm_name))
 			{
 				int rand = ::Random.randI(5000, 10000);
-				CAnimatorCamEffector* e = xr_new<CAnimatorCamEffector>();
+				CAnimatorCamEffector* e = xr_new<CHudMotionCamEffector>();
 				e->SetType(ECamEffectorType(rand));
 				e->SetHudAffect(false);
 				e->SetCyclic(false);


### PR DESCRIPTION
Solution to infamous dumbass:
```
for i = 5000, 9999 do
    level.remove_cam_effector(i)
end
```

needed for my Ammo Check mod, so I can cancel `anm_ammo_check` on ADS easily.
but can be used for many other cases.
once again, a script workaround could cause issues cuz it's used heavily by mods like FDDA, quickdraw, etc.

tested against GAMMA 0.9.5 + 200 mods on top, with various test cases, works fine.