### PR TITLE
Fix cross-object skeleton mutex deadlock in CCF_Skeleton::BuildState

### DIFF
--- a/src/xrCore/xrSyncronize.h
+++ b/src/xrCore/xrSyncronize.h
@@ -75,6 +75,25 @@ public:
 	~xrCriticalSectionGuard() { Leave(); }
 };
 
+// Non-blocking variant: tries to acquire the lock and never blocks. If another thread already
+// holds it, owns_lock() is false and the section is left unguarded. Use where a blocking acquire
+// could deadlock (e.g. taking a second object's lock while holding one) and proceeding without
+// the lock is acceptable.
+class xrCriticalSectionTryGuard : xray::noncopyable
+{
+private:
+	xrCriticalSection* critical_section;
+	bool owned;
+
+public:
+	xrCriticalSectionTryGuard(xrCriticalSection* cs) : critical_section(cs), owned(cs->TryEnter() != FALSE) {}
+	xrCriticalSectionTryGuard(xrCriticalSection& cs) : critical_section(&cs), owned(cs.TryEnter() != FALSE) {}
+
+	bool owns_lock() const { return owned; }
+
+	~xrCriticalSectionTryGuard() { if (owned) critical_section->Leave(); }
+};
+
 using ThreadID = HANDLE;
 
 

--- a/src/xrEngine/xr_collide_form.cpp
+++ b/src/xrEngine/xr_collide_form.cpp
@@ -126,6 +126,19 @@ CCF_Skeleton::CCF_Skeleton(CObject* O) : ICollisionForm(O, cftObject)
 	vis_mask = 0;
 }
 
+// Non-blocking guard. BuildState runs inside the IK callback from CalculateBones, which
+// already holds the current skeleton's UCalc_Mutex; here it reads a neighbour skeleton,
+// needing that object's lock. A blocking acquire lets two threads cross-lock in opposite
+// order (AB-BA deadlock). So TryEnter: if the neighbour is mid-recalc elsewhere, skip the
+// lock and read its (1-frame-stale) transforms rather than block.
+struct UCalc_TryGuard
+{
+	xrCriticalSection& cs;
+	const bool owned;
+	UCalc_TryGuard(xrCriticalSection& c) : cs(c), owned(c.TryEnter() != FALSE) {}
+	~UCalc_TryGuard() { if (owned) cs.Leave(); }
+};
+
 void CCF_Skeleton::BuildState()
 {
 	IRenderVisual* pVisual = owner->Visual();
@@ -151,7 +164,7 @@ void CCF_Skeleton::BuildState()
 		}
 	}
 
-    xrCriticalSectionGuard g(K->UCalc_Mutex);
+    UCalc_TryGuard g(K->UCalc_Mutex);
 	for (ElementVecIt I = elements.begin(); I != elements.end(); I++)
 	{
 		if (!I->valid()) continue;

--- a/src/xrEngine/xr_collide_form.cpp
+++ b/src/xrEngine/xr_collide_form.cpp
@@ -126,19 +126,6 @@ CCF_Skeleton::CCF_Skeleton(CObject* O) : ICollisionForm(O, cftObject)
 	vis_mask = 0;
 }
 
-// Non-blocking guard. BuildState runs inside the IK callback from CalculateBones, which
-// already holds the current skeleton's UCalc_Mutex; here it reads a neighbour skeleton,
-// needing that object's lock. A blocking acquire lets two threads cross-lock in opposite
-// order (AB-BA deadlock). So TryEnter: if the neighbour is mid-recalc elsewhere, skip the
-// lock and read its (1-frame-stale) transforms rather than block.
-struct UCalc_TryGuard
-{
-	xrCriticalSection& cs;
-	const bool owned;
-	UCalc_TryGuard(xrCriticalSection& c) : cs(c), owned(c.TryEnter() != FALSE) {}
-	~UCalc_TryGuard() { if (owned) cs.Leave(); }
-};
-
 void CCF_Skeleton::BuildState()
 {
 	IRenderVisual* pVisual = owner->Visual();
@@ -164,7 +151,11 @@ void CCF_Skeleton::BuildState()
 		}
 	}
 
-    UCalc_TryGuard g(K->UCalc_Mutex);
+    // Non-blocking: BuildState runs inside the IK callback from CalculateBones, which already
+    // holds the current skeleton's UCalc_Mutex; a blocking acquire of this neighbour skeleton's
+    // lock could cross-lock two objects in opposite order on two threads (AB-BA deadlock). If
+    // it's mid-recalc elsewhere, read its 1-frame-stale transforms instead of blocking.
+    xrCriticalSectionTryGuard g(K->UCalc_Mutex);
 	for (ElementVecIt I = elements.begin(); I != elements.end(); I++)
 	{
 		if (!I->valid()) continue;


### PR DESCRIPTION
## Problem

On the multithreaded bone-calc path, the game can hit a **silent freeze** (full hang, no crash, nothing in the log) in scenes with several co-located animated objects  - e.g. a stacked NPC squad, a crowded chokepoint, or NPCs throwing bolts. It's intermittent and timing-dependent.

## Root cause: cross-object AB-BA deadlock

`UCalc_Mutex` is one critical section **per skeleton instance**. Two threads end up each holding their object's lock and blocking on the other's:

- `CKinematics::CalculateBones` takes the object's own `UCalc_Mutex` (`SkeletonRigid.cpp:77`) and holds it across the whole body — **including the IK `Update_Callback`** at the end.
- That callback does a foot-IK ray-pick that reaches into a **neighbour** skeleton via `CCF_Skeleton::BuildState`, which took a **blocking** guard on the *neighbour's* `UCalc_Mutex`.

So with the main render thread computing bones for object X and the `CalculateBonesThread` worker computing object Y at the same time:

| Thread | Holds | Blocks acquiring |
|---|---|---|
| Main render | `X.UCalc_Mutex` (CalculateBones) | `Y.UCalc_Mutex` (BuildState) |
| CalculateBonesThread | `Y.UCalc_Mutex` (CalculateBones) | `X.UCalc_Mutex` (BuildState) |

Confirmed with a debugger capture during a live freeze — both threads parked identically entering the second skeleton's lock:

```
xrCriticalSection::Enter            <-- BLOCKED
CCF_Skeleton::BuildState            <-- locks the picked object's UCalc_Mutex
CCF_Skeleton::_RayQuery
CObjectSpace::_RayPick
ik_foot_collider::collide
CIKLimbsController::IKVisualCallback
CKinematics::CalculateBones         <-- already holds THIS object's UCalc_Mutex
  main:   CMissile::UpdateXForm -> CHudItem::renderable_Render -> CRender::Render
  worker: XRay::Engine::CalculateBonesThread
```
<img width="587" height="862" alt="Screenshot 2026-06-17 230401" src="https://github.com/user-attachments/assets/0ae38f0d-0dd2-4788-afbb-230f587a3239" />

## Fix

Make `BuildState`'s neighbour-skeleton lock **non-blocking** (`TryEnter`): if the object is mid-recalc on another thread, skip the lock and read its one-frame-stale bone transforms instead of blocking. This removes the only cross-object *blocking* acquisition, so the cycle can't form — while keeping parallel bone calculation fully intact.

Worst case is a foot-IK ray-pick seeing one neighbour's bones a frame stale (no crash — the bone array is fixed-size; a torn matrix read self-corrects next frame). This is effectively the long-standing pre-lock behaviour, only in the rare contended case.

## Alternatives considered

- **Revert to per-element `LL_GetTransform_safed`** — doesn't help; it's still a *blocking* acquire of the neighbour's lock, so the deadlock persists. The fix has to be non-blocking.
- **Single global lock for all bone calc** — removes the deadlock but serializes all skeleton calculation, defeating the point of the MT branch.
- **Release the object's own lock before the IK callback** — also breaks the cycle, but un-serializes writes to the object's own foot bones (two threads can recalc the same object), a worse race.

## Testing

Reproduced reliably on the current `-mt` build by rushing 2–3 unprotected squads through a shapeless anomaly field (especially acidic anomalies); also reproduced via the bolt path. With this change the freeze no longer reproduces, and foot IK looks correct (no visible popping).
I'm testing with my [own fork](https://github.com/gwalls/Anomaly_MAI/pull/1) of @Priler 's Anomaly NDA. 