### PR TITLE
[Main Branch] Numpad Support for Console

### DIFF
--- a/src/xrEngine/XR_IOConsole_callback.cpp
+++ b/src/xrEngine/XR_IOConsole_callback.cpp
@@ -20,7 +20,7 @@ void CConsole::Register_callbacks()
 	ec().assign_callback(DIK_PRIOR, text_editor::ks_Ctrl, Callback(this, &CConsole::Begin_log));
 	ec().assign_callback(DIK_NEXT, text_editor::ks_Ctrl, Callback(this, &CConsole::End_log));
 
-	ec().assign_callback(DIK_TAB, text_editor::ks_free, Callback(this, &CConsole::Find_cmd));
+    ec().assign_callback(DIK_TAB, text_editor::ks_free, Callback(this, &CConsole::Find_cmd));
 	ec().assign_callback(DIK_TAB, text_editor::ks_Shift, Callback(this, &CConsole::Find_cmd_back));
 	ec().assign_callback(DIK_TAB, text_editor::ks_Alt, Callback(this, &CConsole::GamePause));
 
@@ -42,7 +42,20 @@ void CConsole::Register_callbacks()
 
 	//Screenshot
 	ec().assign_callback(DIK_F12, text_editor::ks_free, Callback(this, &CConsole::Screenshot));
+
+    //Antglobes: Include support for numpad keys only when numlock is toggle on
+    //home=7, 1=end, pgup=9, 3=pgdwn 
+    ec().assign_callback(DIK_NUMPAD9, text_editor::ks_NumLock, Callback(this, &CConsole::Prev_log)); //, text_editor::ks_free));
+    ec().assign_callback(DIK_NUMPAD3, text_editor::ks_NumLock, Callback(this, &CConsole::Next_log)); //, text_editor::ks_free));
+    ec().assign_callback(DIK_NUMPAD9, text_editor::ks_NumLk_Ctrl, Callback(this, &CConsole::Begin_log)); //, text_editor::ks_Ctrl));
+    ec().assign_callback(DIK_NUMPAD3, text_editor::ks_NumLk_Ctrl, Callback(this, &CConsole::End_log)); //, text_editor::ks_Ctrl));
+
+    ec().assign_callback(DIK_NUMPAD7, text_editor::ks_NumLk_Alt, Callback(this, &CConsole::Begin_tips));
+    ec().assign_callback(DIK_NUMPAD1, text_editor::ks_NumLk_Alt, Callback(this, &CConsole::End_tips));
+    ec().assign_callback(DIK_NUMPAD9, text_editor::ks_NumLk_Alt, Callback(this, &CConsole::PageUp_tips)); //, text_editor::ks_Alt));
+    ec().assign_callback(DIK_NUMPAD3, text_editor::ks_NumLk_Alt, Callback(this, &CConsole::PageDown_tips)); //, text_editor::ks_Alt));
 }
+
 
 void CConsole::Screenshot()
 {

--- a/src/xrEngine/Xr_input.cpp
+++ b/src/xrEngine/Xr_input.cpp
@@ -371,7 +371,7 @@ bool CInput::dik_to_text(int dik, bool shift, bool caps, bool ctrl, bool alt, bo
 		ks[VK_CONTROL] = 0x80;
 		ks[VK_MENU] = 0x80;
 	}
-
+    
 	wchar_t wbuf[8] = {};
 	const int rc = ToUnicodeEx(vk, scan, ks, wbuf, (int)std::size(wbuf), 0, hkl);
 

--- a/src/xrEngine/edit_actions.cpp
+++ b/src/xrEngine/edit_actions.cpp
@@ -14,50 +14,79 @@
 
 namespace text_editor
 {
-	base::base() : m_previous_action(NULL)
-	{
-	}
+    base::base() : m_previous_action(NULL)
+    {
+    }
 
-	base::~base()
-	{
-		xr_delete(m_previous_action);
-	}
+    base::~base()
+    {
+        xr_delete(m_previous_action);
+    }
 
-	void base::on_assign(base* const prev_action)
-	{
-		m_previous_action = prev_action;
-	}
+    void base::on_assign(base* const prev_action)
+    {
+        m_previous_action = prev_action;
+    }
 
-	void base::on_key_press(line_edit_control* const control)
-	{
-		if (m_previous_action)
-		{
-			m_previous_action->on_key_press(control);
-		}
-	}
+    void base::on_key_press(line_edit_control* const control)
+    {
+        if (m_previous_action)
+        {
+            m_previous_action->on_key_press(control);
+        }
+    }
 
-	// -------------------------------------------------------------------------------------------------
+    // -------------------------------------------------------------------------------------------------
 
-	callback_base::callback_base(Callback const& callback, key_state state)
-	{
-		m_callback = callback;
-		m_run_state = state;
-	}
+    callback_base::callback_base(Callback const& callback, u32 const dik, key_state state)
+    {
+        m_callback = callback;
+        m_run_state = state;
+        m_dik = dik;
+    }
 
-	callback_base::~callback_base()
-	{
-	}
+    callback_base::~callback_base()
+    {
+    }
 
-	void callback_base::on_key_press(line_edit_control* const control)
-	{
-		if (control->get_key_state(m_run_state))
-		{
-			m_callback();
-			return;
+    static inline bool is_numpad_numkey(u32 dik)
+    {
+        switch (dik)
+        {
+        case DIK_NUMPAD0:
+        case DIK_NUMPAD1:
+        case DIK_NUMPAD2:
+        case DIK_NUMPAD3:
+        case DIK_NUMPAD4:
+        case DIK_NUMPAD5:
+        case DIK_NUMPAD6:
+        case DIK_NUMPAD7:
+        case DIK_NUMPAD8:
+        case DIK_NUMPAD9:
+            return true;
+            break;
+        }
+        return false;
+    }
+
+    void callback_base::on_key_press(line_edit_control* const control)
+    {
+        if (control->get_key_state(m_run_state))
+        {
+            if (
+                (!is_numpad_numkey(m_dik)) ||
+                (control->get_num_lock_state()) && (  
+                    (m_run_state == ks_NumLock && (!control->get_key_state(ks_Ctrl) && !control->get_key_state(ks_Alt)))
+                    || (m_run_state == ks_NumLk_Ctrl && control->get_key_state(ks_Ctrl))
+                    || (m_run_state == ks_NumLk_Alt && control->get_key_state(ks_Alt)))
+                )
+            {
+                m_callback();
+                return;
+            }
 		}
 		base::on_key_press(control);
 	}
-
 	// -------------------------------------------------------------------------------------------------
 
 	type_pair::type_pair(u32 dik, char c, char c_shift, bool b_translate)
@@ -85,7 +114,7 @@ namespace text_editor
 		const bool ctrl = control->get_key_state(ks_Ctrl);
 		const bool alt = control->get_key_state(ks_Alt);
 		const bool altgr = control->get_key_state(ks_RAlt);
-
+        const bool numlock = control->get_key_state(ks_NumLock);
 		if (m_translate) {
 			if (pInput->dik_to_text((int)m_dik, shift, caps, ctrl, alt, altgr, out, sizeof(out)))
 			{

--- a/src/xrEngine/edit_actions.cpp
+++ b/src/xrEngine/edit_actions.cpp
@@ -114,7 +114,6 @@ namespace text_editor
 		const bool ctrl = control->get_key_state(ks_Ctrl);
 		const bool alt = control->get_key_state(ks_Alt);
 		const bool altgr = control->get_key_state(ks_RAlt);
-        const bool numlock = control->get_key_state(ks_NumLock);
 		if (m_translate) {
 			if (pInput->dik_to_text((int)m_dik, shift, caps, ctrl, alt, altgr, out, sizeof(out)))
 			{

--- a/src/xrEngine/edit_actions.h
+++ b/src/xrEngine/edit_actions.h
@@ -35,13 +35,14 @@ namespace text_editor
 		typedef fastdelegate::FastDelegate0<void> Callback;
 
 	public:
-		callback_base(Callback const& callback, key_state state);
+		callback_base(Callback const& callback, u32 const dik, key_state state);
 		virtual ~callback_base();
 		virtual void on_key_press(line_edit_control* const control);
 
 	protected:
 		key_state m_run_state;
 		Callback m_callback;
+        u32 m_dik;
 	}; // class callback_base
 
 	// -------------------------------------------------------------------------------------------------

--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -111,6 +111,11 @@ namespace text_editor
 		return (GetKeyState(VK_CAPITAL) & 1) != 0;
 	}
 
+    bool line_edit_control::get_num_lock_state()
+    {
+        return (GetKeyState(VK_NUMLOCK) & 1) != 0;
+    }
+
 	void line_edit_control::update_key_states()
 	{
 		m_key_state.zero();
@@ -122,6 +127,7 @@ namespace text_editor
 		set_key_state(ks_LAlt, !!pInput->iGetAsyncKeyState(DIK_LALT));
 		set_key_state(ks_RAlt, !!pInput->iGetAsyncKeyState(DIK_RALT));
 		set_key_state(ks_CapsLock, text_editor::get_caps_lock_state());
+        set_key_state(ks_NumLock, get_num_lock_state());
 	}
 
 	void line_edit_control::clear_states()
@@ -199,6 +205,16 @@ namespace text_editor
 			assign_callback(DIK_RIGHT, ks_free, Callback(this, &line_edit_control::move_pos_right));
 			assign_callback(DIK_LEFT, ks_Ctrl, Callback(this, &line_edit_control::move_pos_left_word));
 			assign_callback(DIK_RIGHT, ks_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
+
+            //Antglobes: Include support for numpad keys only when numlock is toggle on
+            //home=7, up=8, pgup=9, left=4, right=6, 1=end, 2=down, 3=pgdwn
+            //assign_callback(DIK_NUMPAD7, ks_NumLock, Callback(this, &line_edit_control::move_pos_home));
+            //assign_callback(DIK_NUMPAD1, ks_NumLock, Callback(this, &line_edit_control::move_pos_end));
+            //assign_callback(DIK_NUMPAD4, ks_NumLock, Callback(this, &line_edit_control::move_pos_left));
+            //assign_callback(DIK_NUMPAD6, ks_NumLock, Callback(this, &line_edit_control::move_pos_right));
+            //assign_callback(DIK_NUMPAD4, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_left_word));
+            //assign_callback(DIK_NUMPAD6, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
+
 		}
 		else
 		{
@@ -230,6 +246,16 @@ namespace text_editor
 
 			assign_callback(DIK_LSHIFT, ks_Ctrl, Callback(this, &line_edit_control::SwitchKL));
 			assign_callback(DIK_LSHIFT, ks_Alt, Callback(this, &line_edit_control::SwitchKL));
+
+            //Antglobes: Include support for numpad keys only when numlock is toggle on
+            //home=7, 1=end, 4=left, 6=right
+            assign_callback(DIK_NUMPAD7, ks_NumLock, Callback(this, &line_edit_control::move_pos_home));
+            assign_callback(DIK_NUMPAD1, ks_NumLock, Callback(this, &line_edit_control::move_pos_end));
+            assign_callback(DIK_NUMPAD4, ks_NumLock, Callback(this, &line_edit_control::move_pos_left));
+            assign_callback(DIK_NUMPAD6, ks_NumLock, Callback(this, &line_edit_control::move_pos_right));
+            assign_callback(DIK_NUMPAD4, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_left_word));
+            assign_callback(DIK_NUMPAD6, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
+
 		} // if mode
 
 		create_key_state(DIK_LSHIFT, ks_LShift);
@@ -238,6 +264,7 @@ namespace text_editor
 		create_key_state(DIK_RCONTROL, ks_RCtrl);
 		create_key_state(DIK_LALT, ks_LAlt);
 		create_key_state(DIK_RALT, ks_RAlt);
+        create_key_state(DIK_NUMLOCK, ks_NumLock);
 	}
 
 	void line_edit_control::assign_char_pairs(init_mode mode)
@@ -372,7 +399,7 @@ namespace text_editor
 	{
 		VERIFY(dik < DIK_COUNT);
 		Base* prev_action = m_actions[dik];
-		m_actions[dik] = xr_new<text_editor::callback_base>(callback, state);
+		m_actions[dik] = xr_new<text_editor::callback_base>(callback, dik, state);
 		m_actions[dik]->on_assign(prev_action);
 	}
 

--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -207,13 +207,13 @@ namespace text_editor
 			assign_callback(DIK_RIGHT, ks_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
 
             //Antglobes: Include support for numpad keys only when numlock is toggle on
-            //home=7, up=8, pgup=9, left=4, right=6, 1=end, 2=down, 3=pgdwn
-            //assign_callback(DIK_NUMPAD7, ks_NumLock, Callback(this, &line_edit_control::move_pos_home));
-            //assign_callback(DIK_NUMPAD1, ks_NumLock, Callback(this, &line_edit_control::move_pos_end));
-            //assign_callback(DIK_NUMPAD4, ks_NumLock, Callback(this, &line_edit_control::move_pos_left));
-            //assign_callback(DIK_NUMPAD6, ks_NumLock, Callback(this, &line_edit_control::move_pos_right));
-            //assign_callback(DIK_NUMPAD4, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_left_word));
-            //assign_callback(DIK_NUMPAD6, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
+            //home=7, 1=end, 4=left, 6=right
+            assign_callback(DIK_NUMPAD7, ks_NumLock, Callback(this, &line_edit_control::move_pos_home));
+            assign_callback(DIK_NUMPAD1, ks_NumLock, Callback(this, &line_edit_control::move_pos_end));
+            assign_callback(DIK_NUMPAD4, ks_NumLock, Callback(this, &line_edit_control::move_pos_left));
+            assign_callback(DIK_NUMPAD6, ks_NumLock, Callback(this, &line_edit_control::move_pos_right));
+            assign_callback(DIK_NUMPAD4, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_left_word));
+            assign_callback(DIK_NUMPAD6, ks_NumLk_Ctrl, Callback(this, &line_edit_control::move_pos_right_word));
 
 		}
 		else
@@ -247,8 +247,7 @@ namespace text_editor
 			assign_callback(DIK_LSHIFT, ks_Ctrl, Callback(this, &line_edit_control::SwitchKL));
 			assign_callback(DIK_LSHIFT, ks_Alt, Callback(this, &line_edit_control::SwitchKL));
 
-            //Antglobes: Include support for numpad keys only when numlock is toggle on
-            //home=7, 1=end, 4=left, 6=right
+            //Antglobes
             assign_callback(DIK_NUMPAD7, ks_NumLock, Callback(this, &line_edit_control::move_pos_home));
             assign_callback(DIK_NUMPAD1, ks_NumLock, Callback(this, &line_edit_control::move_pos_end));
             assign_callback(DIK_NUMPAD4, ks_NumLock, Callback(this, &line_edit_control::move_pos_left));

--- a/src/xrEngine/line_edit_control.h
+++ b/src/xrEngine/line_edit_control.h
@@ -27,10 +27,13 @@ namespace text_editor
 		ks_LAlt = u32(1) << 4,
 		ks_RAlt = u32(1) << 5,
 		ks_CapsLock = u32(1) << 6,
+        ks_NumLock = u32(1) << 7,
 
 		ks_Shift = u32(ks_LShift | ks_RShift),
 		ks_Ctrl = u32(ks_LCtrl | ks_RCtrl),
 		ks_Alt = u32(ks_LAlt | ks_RAlt),
+        ks_NumLk_Ctrl = u32(ks_NumLock | ks_Ctrl),
+        ks_NumLk_Alt = u32(ks_NumLock | ks_Alt),
 
 		ks_force = u32(-1)
 	}; // enum key_state
@@ -84,6 +87,7 @@ namespace text_editor
 		void set_edit(LPCSTR str);
 		void set_selected_mode(bool status) { m_unselected_mode = !status; }
 		bool get_selected_mode() const { return !m_unselected_mode; }
+        bool get_num_lock_state();
 
 	private:
 		line_edit_control(line_edit_control const&);


### PR DESCRIPTION
- Since i'm using an integrated keyboard with my pc, i don't have a dedicated Page up/down key.
- I've added (in a somewhat hacky way) callbacks for the numpad keys, as well as expanded the key state enum to include cases for and in combination with the numlock key being toggled on.
- I've also expanded the callback_base class to register the dik key pressed when assigining a callback.
- These callbacks  only fire when: numlock or numlock and a modifier key has been pressed
- I state that it was hacky as detecting that the numlock + modifier key_state e.g. `ks_NumLk_Alt` or `ks_NumLk_Ctrl`, was failing with the existing implementation.
-  i modified the `callback_base::on_key_press` function to check that if a modifer had been pressed in combination with numlock that the numlock only callbacks for that dik key wouldn't fire, since numlock's key state will be always true/toggled on to when ensure that the character value can also be sent if toggled off.