### PR TITLE
feat(renderer): texture eviction system — level transition cleanup and mid-session LRU eviction

### DIFF
--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -508,14 +508,25 @@ void CResourceManager::EvictStalledTextures(u32 max_age_frames) {
   u32 scanned = 0;
   for (; I != m_textures.end() && scanned < batch_size; ++I, ++scanned) {
     CTexture *tex = I->second;
-
-    // $user$ textures (render targets, user-managed) already carry bUser=true
     if (tex->flags.bUser) {
       skip_user++;
       continue;
     }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$")) {
+      skip_user++;
+      continue;
+    }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$null")) {
+      skip_user++;
+      continue;
+    }
+    if (!tex->flags.bLoaded) {
+      skip_unloaded++;
+      continue;
+    }
+    // $user$ textures (render targets, user-managed) already carry bUser=true
 
-    // UI textures — PDA, inventory icons, etc. — must never be evicted
+    // UI extures — PDA, inventory icons, etc. — must never be evicted
     LPCSTR name = I->first;
     if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0) {
       skip_name++;

--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -566,6 +566,44 @@ void CResourceManager::EvictStalledTextures(u32 max_age_frames) {
 #endif
 }
 
+void CResourceManager::EvictAllTextures()
+{
+#if defined(USE_DX11)
+    Msg("* [TexEvict] EvictAllTextures called, frame=%u", RDEVICE.dwFrame);
+    if (!RDEVICE.b_is_Ready) return;
+
+    u32 evicted    = 0;
+    u32 evicted_kb = 0;
+    u32 skip_user  = 0;
+    u32 skip_name  = 0;
+    u32 skip_unloaded = 0;
+
+    creationGuard.Enter();
+
+    for (map_Texture::iterator I = m_textures.begin(); I != m_textures.end(); ++I) {
+        CTexture* tex = I->second;
+
+        if (tex->flags.bUser)                                              { skip_user++;     continue; }
+        if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$"))    { skip_user++;     continue; }
+        if (tex->cName.size() && strstr(tex->cName.c_str(), "$null"))     { skip_user++;     continue; }
+        if (!tex->flags.bLoaded)                                           { skip_unloaded++; continue; }
+
+        LPCSTR name = I->first;
+        if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0)
+            { skip_name++; continue; }
+
+        evicted_kb += tex->flags.MemoryUsage / 1024;
+        tex->Unload();
+        evicted++;
+    }
+
+    creationGuard.Leave();
+
+    Msg("* [TexEvict] EvictAll: total=%u evicted=%u skip_user=%u skip_name=%u skip_unloaded=%u freed_kb=%u",
+        (u32)m_textures.size(), evicted, skip_user, skip_name, skip_unloaded, evicted_kb);
+#endif
+}
+
 /*
 BOOL	CResourceManager::_GetDetailTexture(LPCSTR Name,LPCSTR& T, R_constant_setup* &CS)
 {

--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -473,6 +473,88 @@ void CResourceManager::Evict()
 #endif	//	USE_DX10
 }
 
+
+void CResourceManager::EvictStalledTextures(u32 max_age_frames) {
+#if defined(USE_DX11)
+  Msg("* [TexEvict] pass called, frame=%u", RDEVICE.dwFrame);
+  if (!RDEVICE.b_is_Ready)
+    return;
+
+  u32 cur_frame = RDEVICE.dwFrame;
+  u32 evicted = 0;
+  u32 evicted_kb = 0;
+  u32 skip_user = 0;
+  u32 skip_name = 0;
+  u32 skip_unloaded = 0;
+  u32 skip_refs = 0;
+  u32 skip_recent = 0;
+
+  // Persistent cursor so successive calls cycle through the map
+  // instead of restarting from the beginning each time.
+  static xr_string s_evict_cursor;
+  const u32 batch_size = 50;
+
+  creationGuard.Enter();
+
+  map_Texture::iterator I;
+  if (s_evict_cursor.empty()) {
+    I = m_textures.begin();
+  } else {
+    I = m_textures.lower_bound(s_evict_cursor.c_str());
+    if (I == m_textures.end())
+      I = m_textures.begin(); // wrap around to start
+  }
+
+  u32 scanned = 0;
+  for (; I != m_textures.end() && scanned < batch_size; ++I, ++scanned) {
+    CTexture *tex = I->second;
+
+    // $user$ textures (render targets, user-managed) already carry bUser=true
+    if (tex->flags.bUser) {
+      skip_user++;
+      continue;
+    }
+
+    // UI textures — PDA, inventory icons, etc. — must never be evicted
+    LPCSTR name = I->first;
+    if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0) {
+      skip_name++;
+      continue;
+    }
+
+    if (!tex->flags.bLoaded) {
+      skip_unloaded++;
+      continue;
+    }
+    if (tex->dwReference.load(std::memory_order_relaxed) > 1) {
+      u32 refs = tex->dwReference.load(std::memory_order_relaxed);
+      if (refs > 2)
+        Msg("* [TexEvict] stuck: [%4d] %s", refs, tex->cName.c_str());
+      skip_refs++;
+      continue;
+    }
+    if (cur_frame - tex->dwLastUsedFrame < max_age_frames) {
+      skip_recent++;
+      continue;
+    }
+
+    evicted_kb += tex->flags.MemoryUsage / 1024;
+    tex->Unload();
+    evicted++;
+  }
+
+  // Save position for next call; empty string means restart from beginning
+  s_evict_cursor = (I != m_textures.end()) ? xr_string(I->first) : xr_string();
+
+  creationGuard.Leave();
+
+  Msg("* [TexEvict] frame=%u total=%u scanned=%u evicted=%u skip_user=%u "
+      "skip_name=%u skip_unloaded=%u skip_refs=%u skip_recent=%u freed_kb=%u",
+      cur_frame, (u32)m_textures.size(), scanned, evicted, skip_user, skip_name,
+      skip_unloaded, skip_refs, skip_recent, evicted_kb);
+#endif
+}
+
 /*
 BOOL	CResourceManager::_GetDetailTexture(LPCSTR Name,LPCSTR& T, R_constant_setup* &CS)
 {

--- a/src/Layers/xrRender/ResourceManager.h
+++ b/src/Layers/xrRender/ResourceManager.h
@@ -234,6 +234,7 @@ public:
 	void DeferredUnload();
 	void Evict();
     void EvictStalledTextures(u32 max_age_frames = 1800);
+    void EvictAllTextures();
 	void StoreNecessaryTextures();
 	void DestroyNecessaryTextures();
 	void Dump(bool bBrief);

--- a/src/Layers/xrRender/ResourceManager.h
+++ b/src/Layers/xrRender/ResourceManager.h
@@ -233,6 +233,7 @@ public:
 	void DeferredUpload();
 	void DeferredUnload();
 	void Evict();
+    void EvictStalledTextures(u32 max_age_frames = 1800);
 	void StoreNecessaryTextures();
 	void DestroyNecessaryTextures();
 	void Dump(bool bBrief);

--- a/src/Layers/xrRender/SH_Texture.cpp
+++ b/src/Layers/xrRender/SH_Texture.cpp
@@ -162,6 +162,7 @@ void CTexture::apply_gif(u32 dwStage)
 
 void CTexture::apply_normal(u32 dwStage)
 {
+    dwLastUsedFrame = Device.dwFrame;
 	CHK_DX(HW.pDevice->SetTexture(dwStage,pSurface));
 };
 

--- a/src/Layers/xrRender/SH_Texture.h
+++ b/src/Layers/xrRender/SH_Texture.h
@@ -11,7 +11,7 @@ class CGIFAnimationPlayer;
 class ECORE_API CTexture : public xr_resource_named
 {
 public:
-	//	Since DX10 allows up to 128 unique textures, 
+	//	Since DX10 allows up to 128 unique textures,
 	//	distance between enum values should be at leas 128
 	enum ResourceShaderType //	Don't change this since it's hardware-dependent
 	{
@@ -90,6 +90,9 @@ public: //	Public class members (must be encapsulated furthur)
 		u32					bLoadedAsStaging: 1;
 #endif	//	USE_DX10
 	} flags;
+
+
+    u32 dwLastUsedFrame = 0; // frame index of last Apply() call — used for eviction
 
 	fastdelegate::FastDelegate1<u32> bind;
 

--- a/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
@@ -56,6 +56,9 @@ CTexture::~CTexture()
 
 void CTexture::surface_set(ID3DBaseTexture* surf)
 {
+
+    if (cName.size() && strstr(cName.c_str(), "$user$"))
+        flags.bUser = true;
 	if (surf) surf->AddRef();
 	_RELEASE(pSurface);
 	_RELEASE(m_pSRView);
@@ -594,7 +597,7 @@ void CTexture::Load()
 			// pSurface->SetPriority	(PRIORITY_NORMAL);
 			flags.MemoryUsage = mem;
 		}
-		
+
 		if (pSurface && bCreateView)
 			CHK_DX(HW.pDevice->CreateShaderResourceView(pSurface, NULL, &m_pSRView));
 	}

--- a/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
@@ -228,6 +228,8 @@ void CTexture::ProcessStaging()
 
 void CTexture::Apply(u32 dwStage)
 {
+	dwLastUsedFrame = RDEVICE.dwFrame;
+
 	if (flags.bLoadedAsStaging)
 		ProcessStaging();
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -6,6 +6,8 @@
 
 #include "../xrRender/QueryHelper.h"
 
+#include	"../xrRender/dxRenderDeviceRender.h"
+
 IC bool pred_sp_sort(ISpatial* _1, ISpatial* _2)
 {
 	float d1 = _1->spatial.sphere.P.distance_to_sqr(Device.vCameraPosition);

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -251,6 +251,12 @@ void CRender::Render()
 		return;
 	}
 
+
+	// Periodic texture eviction — runs every 600 frames (~10s at 60fps)
+	if ((Device.dwFrame % 600) == 0)
+		dxRenderDeviceRender::Instance().Resources->EvictStalledTextures();
+
+
 	//.	VERIFY					(g_pGameLevel && g_pGameLevel->pHUD);
 
 	// Configure
@@ -335,7 +341,7 @@ void CRender::Render()
 	set_Recorder(NULL);
 	r_pmask(true, false); // disable priority "1"
 	Device.Statistic->RenderCALC.End();
-	
+
 	/*if (RImplementation.o.ssfx_core) // SSS23: DEPRECATED
 	{
 		// HUD Masking rendering
@@ -396,7 +402,7 @@ void CRender::Render()
 		Target->disable_aniso();
 	}
 
-	//  Redotix99: for 3D Shader Based Scopes 	
+	//  Redotix99: for 3D Shader Based Scopes
 	if (scope_3D_fake_enabled)
 	{
 		ID3D11Resource* zbuffer_res;
@@ -458,7 +464,7 @@ void CRender::Render()
 	{
 		PIX_EVENT(DEFER_PART1_SPLIT);
 		// skybox can be drawn here
-		
+
 		if (0)
 		{
 			if (!RImplementation.o.dx10_msaa)
@@ -602,7 +608,7 @@ void CRender::Render()
 		// Render emissive geometry, stencil - write 0x0 at pixel pos
 		RCache.set_xform_project(Device.mProject);
 		RCache.set_xform_view(Device.mView);
-		// Stencil - write 0x1 at pixel pos - 
+		// Stencil - write 0x1 at pixel pos -
 		if (!RImplementation.o.dx10_msaa)
 			RCache.set_Stencil(TRUE, D3DCMP_ALWAYS, 0x01, 0xff, 0xff, D3DSTENCILOP_KEEP, D3DSTENCILOP_REPLACE,
 			                   D3DSTENCILOP_KEEP);

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -188,6 +188,10 @@ void CRender::level_Unload()
 		//Msg("The Level Unloaded.======================== %d", ++unload_counter);
 	}
 
+	// Force-evict all textures on level unload — covers normal transitions,
+	// fast travel, and main menu exit (all converge through level_Unload())
+	dxRenderDeviceRender::Instance().Resources->EvictAllTextures();
+
 	b_loaded = FALSE;
 }
 


### PR DESCRIPTION
While profiling my playthrough, I noticed the game's memory footprint grew indefinitely until it overflowed VRAM and began filling GTT space, eventually causing a sharp FPS collapse. Profiling with MangoHud and /proc/PID/fdinfo on AMD RDNA3 confirmed GTT growing to 15GB+ mid-session, with VRAM peaking at 11.5GB before FPS collapsed. System RAM ballooned to 23GB and never recovered between sessions.

Investigation revealed that CResourceManager::Evict() is compiled out entirely on DX11/DX10 builds — the body is wrapped in #if !defined(USE_DX10) && !defined(USE_DX11), leaving a complete no-op. As a result, textures are never unloaded during a session, and level transitions do nothing to reclaim GPU memory.

This PR adds two new functions:
EvictAllTextures() — unconditionally releases all non-essential texture GPU resources. Called from CRender::level_Unload(), which is the common teardown path for normal level transitions, fast travel, and main menu exit. Confirmed working: Jupiter → Radar transition drops VRAM from ~11.6GB to ~7.4GB and GTT from ~15GB to ~2.2GB before the new zone begins loading.

EvictStalledTextures() — runs every 600 frames, scans 50 textures per pass, and evicts textures that haven't been used in 1800 frames (~30 seconds at 60fps). On my configuration this frees 10-20MB per pass with no noticeable frame impact.
This is a intentionally conservative first implementation of mid-session texture eviction. A more complete implementation would prioritize high-impact textures by size, leverage existing engine events for targeted eviction (emission end, zone clear, weather transitions), and more aggressively address the shader element ref retention that currently prevents ~60-70% of stale textures from being evicted. Feedback welcome on all of the above.