### PR TITLE
feat(renderer): texture eviction system — MT port of #588

### DIFF
--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -536,6 +536,129 @@ void CResourceManager::Evict()
 #endif	//	USE_DX10
 }
 
+void CResourceManager::EvictStalledTextures(u32 max_age_frames) {
+#if defined(USE_DX11)
+  Msg("* [TexEvict] pass called, frame=%u", RDEVICE.dwFrame);
+  if (!RDEVICE.b_is_Ready)
+    return;
+
+  u32 cur_frame = RDEVICE.dwFrame;
+  u32 evicted = 0;
+  u32 evicted_kb = 0;
+  u32 skip_user = 0;
+  u32 skip_name = 0;
+  u32 skip_unloaded = 0;
+  u32 skip_refs = 0;
+  u32 skip_recent = 0;
+
+  // Persistent cursor so successive calls cycle through the map
+  // instead of restarting from the beginning each time.
+  static xr_string s_evict_cursor;
+  const u32 batch_size = 50;
+
+  creationGuard.Enter();
+
+  map_Texture::iterator I;
+  if (s_evict_cursor.empty()) {
+    I = m_textures.begin();
+  } else {
+    I = m_textures.lower_bound(s_evict_cursor.c_str());
+    if (I == m_textures.end())
+      I = m_textures.begin(); // wrap around to start
+  }
+
+  u32 scanned = 0;
+  for (; I != m_textures.end() && scanned < batch_size; ++I, ++scanned) {
+    CTexture *tex = I->second;
+    if (tex->flags.bUser) {
+      skip_user++;
+      continue;
+    }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$")) {
+      skip_user++;
+      continue;
+    }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$null")) {
+      skip_user++;
+      continue;
+    }
+    if (!tex->flags.bLoaded) {
+      skip_unloaded++;
+      continue;
+    }
+    // UI textures — PDA, inventory icons, etc. — must never be evicted
+    LPCSTR name = I->first;
+    if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0) {
+      skip_name++;
+      continue;
+    }
+    if (tex->dwReference.load(std::memory_order_relaxed) > 1) {
+      u32 refs = tex->dwReference.load(std::memory_order_relaxed);
+      if (refs > 2)
+        Msg("* [TexEvict] stuck: [%4d] %s", refs, tex->cName.c_str());
+      skip_refs++;
+      continue;
+    }
+    if (cur_frame - tex->dwLastUsedFrame < max_age_frames) {
+      skip_recent++;
+      continue;
+    }
+
+    evicted_kb += tex->flags.MemoryUsage / 1024;
+    tex->Unload();
+    evicted++;
+  }
+
+  // Save position for next call; empty string means restart from beginning
+  s_evict_cursor = (I != m_textures.end()) ? xr_string(I->first) : xr_string();
+
+  creationGuard.Leave();
+
+  Msg("* [TexEvict] frame=%u total=%u scanned=%u evicted=%u skip_user=%u "
+      "skip_name=%u skip_unloaded=%u skip_refs=%u skip_recent=%u freed_kb=%u",
+      cur_frame, (u32)m_textures.size(), scanned, evicted, skip_user, skip_name,
+      skip_unloaded, skip_refs, skip_recent, evicted_kb);
+#endif
+}
+
+void CResourceManager::EvictAllTextures()
+{
+#if defined(USE_DX11)
+    Msg("* [TexEvict] EvictAllTextures called, frame=%u", RDEVICE.dwFrame);
+    if (!RDEVICE.b_is_Ready) return;
+
+    u32 evicted    = 0;
+    u32 evicted_kb = 0;
+    u32 skip_user  = 0;
+    u32 skip_name  = 0;
+    u32 skip_unloaded = 0;
+
+    creationGuard.Enter();
+
+    for (map_Texture::iterator I = m_textures.begin(); I != m_textures.end(); ++I) {
+        CTexture* tex = I->second;
+
+        if (tex->flags.bUser)                                              { skip_user++;     continue; }
+        if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$"))    { skip_user++;     continue; }
+        if (tex->cName.size() && strstr(tex->cName.c_str(), "$null"))     { skip_user++;     continue; }
+        if (!tex->flags.bLoaded)                                           { skip_unloaded++; continue; }
+
+        LPCSTR name = I->first;
+        if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0)
+            { skip_name++; continue; }
+
+        evicted_kb += tex->flags.MemoryUsage / 1024;
+        tex->Unload();
+        evicted++;
+    }
+
+    creationGuard.Leave();
+
+    Msg("* [TexEvict] EvictAll: total=%u evicted=%u skip_user=%u skip_name=%u skip_unloaded=%u freed_kb=%u",
+        (u32)m_textures.size(), evicted, skip_user, skip_name, skip_unloaded, evicted_kb);
+#endif
+}
+
 /*
 BOOL	CResourceManager::_GetDetailTexture(LPCSTR Name,LPCSTR& T, R_constant_setup* &CS)
 {

--- a/src/Layers/xrRender/ResourceManager.h
+++ b/src/Layers/xrRender/ResourceManager.h
@@ -233,6 +233,8 @@ public:
 	void DeferredUnload();
 	void UnloadAllTexturesOnLevelUnload();
 	void Evict();
+    void EvictStalledTextures(u32 max_age_frames = 1800);
+    void EvictAllTextures();
 	void StoreNecessaryTextures();
 	void DestroyNecessaryTextures();
 	void Dump(bool bBrief);

--- a/src/Layers/xrRender/SH_Texture.cpp
+++ b/src/Layers/xrRender/SH_Texture.cpp
@@ -201,6 +201,7 @@ void CTexture::apply_normal(u32 dwStage)
 	{
 		SwitchToThread();
 	}
+	dwLastUsedFrame = Device.dwFrame;
 	CHK_DX(HW.pDevice->SetTexture(dwStage,pSurface));
 };
 

--- a/src/Layers/xrRender/SH_Texture.h
+++ b/src/Layers/xrRender/SH_Texture.h
@@ -93,6 +93,8 @@ public: //	Public class members (must be encapsulated furthur)
 #endif	//	USE_DX10
 	} flags;
 
+    u32 dwLastUsedFrame = 0; // frame index of last Apply() call — used for eviction
+
 	xr_delegate<void(u32)> bind;
 
 

--- a/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
@@ -62,6 +62,9 @@ void CTexture::surface_set(ID3DBaseTexture* surf)
 	{
 		SwitchToThread();
 	}
+
+	if (cName.size() && strstr(cName.c_str(), "$user$"))
+		flags.bUser = true;
 	if (surf) surf->AddRef();
 	_RELEASE(pSurface);
 	_RELEASE(m_pSRView);
@@ -251,6 +254,8 @@ void CTexture::Apply(u32 dwStage)
 	{
 		SwitchToThread();
 	}
+	dwLastUsedFrame = RDEVICE.dwFrame;
+
 	if (flags.bLoadedAsStaging)
 		ProcessStaging();
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -8,6 +8,8 @@
 
 #include "../xrRender/QueryHelper.h"
 
+#include	"../xrRender/dxRenderDeviceRender.h"
+
 void CRender::render_menu()
 {
 	PIX_EVENT(render_menu);
@@ -91,6 +93,10 @@ void CRender::Render()
 		m_bFirstFrameAfterReset = false;
 		return;
 	}
+
+	// Periodic texture eviction — runs every 600 frames (~10s at 60fps)
+	if ((Device.dwFrame % 600) == 0)
+		dxRenderDeviceRender::Instance().Resources->EvictStalledTextures();
 
 	//.	VERIFY					(g_pGameLevel && g_pGameLevel->pHUD);
 

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -195,6 +195,10 @@ void CRender::level_Unload()
 		//Msg("The Level Unloaded.======================== %d", ++unload_counter);
 	}
 
+	// Force-evict all textures on level unload — covers normal transitions,
+	// fast travel, and main menu exit (all converge through level_Unload())
+	dxRenderDeviceRender::Instance().Resources->EvictAllTextures();
+
 	b_loaded = FALSE;
 }
 


### PR DESCRIPTION
MT port of #588  — see that PR for full context, design rationale, and before/after profiling data.
This PR applies the same texture eviction system to the MT build with the following adaptations:
Threading considerations:

dwLastUsedFrame stamps in Apply() and apply_normal() are placed strictly after the bLoading spin-wait, ensuring we never stamp a frame on a texture that hasn't finished loading on the resource thread
EvictStalledTextures() holds creationGuard for the duration of the scan, preventing the resource thread from creating or deleting textures while the eviction pass iterates m_textures
fastdelegate replaced with xr_delegate throughout to match MT branch conventions

Functionality is identical to the ST PR:

EvictAllTextures() called from CRender::level_Unload() for transition cleanup
EvictStalledTextures() wired into CRender::Render() every 600 frames
Same exclusions: $user$ render targets, $null, UI textures
Same confirmed result: Jupiter → Radar drops VRAM ~11.6GB → ~7.4GB and GTT ~15GB → ~2.2GB on transition

Known limitations are the same as the ST PR — ref retention wall and cold load footprint on large zones remain open problems.