### PR TITLE
alife: guard against _SPAWN_ID(-1) in spawn graph traversal

### DIFF
--- a/src/xrGame/alife_spawn_registry_spawn.cpp
+++ b/src/xrGame/alife_spawn_registry_spawn.cpp
@@ -122,7 +122,9 @@ void CALifeSpawnRegistry::fill_new_spawns(SPAWN_GRAPH::CVertex* vertex, SPAWN_ID
 	if (vertex->edges().empty())
 	{
 		//		vertex->data()->object().m_spawn_count++;
-		spawns.push_back(vertex->data()->object().m_tSpawnID);
+		const ALife::_SPAWN_ID sid = vertex->data()->object().m_tSpawnID;
+		if (sid != ALife::_SPAWN_ID(-1))
+			spawns.push_back(sid);
 		return;
 	}
 

--- a/src/xrGame/alife_surge_manager.cpp
+++ b/src/xrGame/alife_surge_manager.cpp
@@ -33,10 +33,13 @@ void CALifeSurgeManager::spawn_new_spawns()
 	xr_vector<ALife::_SPAWN_ID>::const_iterator E = m_temp_spawns.end();
 	for (; I != E; ++I)
 	{
+		const CALifeSpawnRegistry::SPAWN_GRAPH::CVertex* const vertex_ptr = spawns().spawns().vertex(*I);
+		if (!vertex_ptr)
+			continue;
 		CSE_ALifeDynamicObject *object, *spawn = smart_cast<CSE_ALifeDynamicObject*>(
-			                       &spawns().spawns().vertex(*I)->data()->object());
-		VERIFY3(spawn, spawns().spawns().vertex(*I)->data()->object().name(),
-		        spawns().spawns().vertex(*I)->data()->object().name_replace());
+			                       &vertex_ptr->data()->object());
+		VERIFY3(spawn, vertex_ptr->data()->object().name(),
+		        vertex_ptr->data()->object().name_replace());
 
 #ifdef DEBUG
 		CTimer					timer;


### PR DESCRIPTION
Fixes a crash in `CALifeSurgeManager::spawn_new_spawns` on new-game creation on the MT branch only.

This crash occurs on the mod that we are working on and is specific to the MT exes. Works on the non-MT exes.

### Cause

`CALifeSpawnRegistry::fill_new_spawns` (`alife_spawn_registry_spawn.cpp:125`) does:

```cpp
spawns.push_back(vertex->data()->object().m_tSpawnID);
```

for leaf vertices, without checking the id is valid. `m_tSpawnID` defaults to `ALife::_SPAWN_ID(-1)` in the `CSE_ALifeObject` constructor and is only set during `Spawn_Read` when `m_wVersion > 79`. Some leaves in `game.spawn` still have the sentinel.

`CALifeSurgeManager::spawn_new_spawns` then looks that id up in the spawn graph map. `vertex(0xFFFF)` returns null, and the next line dereferences it.

Confirmed by attaching windbg, breaking on AV at `spawn_new_spawns+0x74`, and reading the iterator: the last element of `m_temp_spawns` is `0xFFFF`. Disassembly shows the `std::map` lookup's not-found branch (`xor eax, eax`) flowing straight into `mov rax, [rax+0x20]`.

`fill_new_spawns` traverses the spawn graph randomly (`if (randF(1.f) < weight)`). The two engines reach the RNG with different histories — MT has parallel `level_load.run(...)` work in flight, non-MT doesn't so they consistently visit different leaves. The MT history hits a sentinel-tagged leaf every run; non-MT happens not to. Same bug, same data, just exposed by MT.

### Fix

Two guards:

- Producer (`fill_new_spawns`): skip the leaf if its `m_tSpawnID == _SPAWN_ID(-1)`.
- Consumer (`spawn_new_spawns`): null-check `vertex()` before deref.

Either alone fixes this crash. Both cover the case where some other producer (e.g. `fill_new_spawns_single`) pushes an invalid id.
