### PR TITLE
feat(renderer): mid-session texture eviction system (DX11)

### DIFF
--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -1,4 +1,4 @@
-// TextureManager.cpp: implementation of the CResourceManager class.
+
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -541,12 +541,15 @@ void CResourceManager::EvictStalledTextures() {
 #if defined(USE_DX11)
   if (!ps_r__tex_evict_enabled)
     return;
+#ifdef DEBUG
   Msg("* [TexEvict] pass called, frame=%u", RDEVICE.dwFrame);
+#endif // DEBUG
   if (!RDEVICE.b_is_Ready)
     return;
 
-  u32 cur_frame    = RDEVICE.dwFrame;
-  u32 max_age      = (u32)ps_r__tex_evict_age_frames;
+  u32 cur_frame = RDEVICE.dwFrame;
+  u32 max_age   = (u32)ps_r__tex_evict_age_frames;
+#ifdef DEBUG
   u32 evicted      = 0;
   u32 evicted_kb   = 0;
   u32 skip_user    = 0;
@@ -554,6 +557,7 @@ void CResourceManager::EvictStalledTextures() {
   u32 skip_unloaded = 0;
   u32 skip_refs    = 0;
   u32 skip_recent  = 0;
+#endif // DEBUG
 
   static xr_string s_evict_cursor;
   const u32 batch_size = (u32)ps_r__tex_evict_batch_size;
@@ -566,60 +570,79 @@ void CResourceManager::EvictStalledTextures() {
   } else {
     I = m_textures.lower_bound(s_evict_cursor.c_str());
     if (I == m_textures.end())
-      I = m_textures.begin(); // wrap around to start
+      I = m_textures.begin();
   }
 
   u32 scanned = 0;
   for (; I != m_textures.end() && scanned < batch_size; ++I, ++scanned) {
     CTexture *tex = I->second;
     if (tex->flags.bUser) {
+#ifdef DEBUG
       skip_user++;
+#endif // DEBUG
       continue;
     }
     if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$")) {
+#ifdef DEBUG
       skip_user++;
+#endif // DEBUG
       continue;
     }
     if (tex->cName.size() && strstr(tex->cName.c_str(), "$null")) {
+#ifdef DEBUG
       skip_user++;
+#endif // DEBUG
       continue;
     }
     if (!tex->flags.bLoaded) {
+#ifdef DEBUG
       skip_unloaded++;
+#endif // DEBUG
       continue;
     }
     // UI textures — PDA, inventory icons, etc. — must never be evicted
     LPCSTR name = I->first;
     if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0) {
+#ifdef DEBUG
       skip_name++;
+#endif // DEBUG
       continue;
     }
     if (tex->dwReference.load(std::memory_order_relaxed) > 1) {
+#ifdef DEBUG
       u32 refs = tex->dwReference.load(std::memory_order_relaxed);
       if (refs > 2)
         Msg("* [TexEvict] stuck: [%4d] %s", refs, tex->cName.c_str());
       skip_refs++;
+#endif // DEBUG
       continue;
     }
     if (cur_frame - tex->dwLastUsedFrame < max_age) {
+#ifdef DEBUG
       skip_recent++;
+#endif // DEBUG
       continue;
     }
 
+#ifdef DEBUG
     evicted_kb += tex->flags.MemoryUsage / 1024;
+#endif // DEBUG
     tex->Unload();
+#ifdef DEBUG
     evicted++;
+#endif // DEBUG
   }
 
-  // Save position for next call; empty string means restart from beginning
   s_evict_cursor = (I != m_textures.end()) ? xr_string(I->first) : xr_string();
 
   creationGuard.Leave();
 
+#ifdef DEBUG
   Msg("* [TexEvict] frame=%u total=%u scanned=%u evicted=%u skip_user=%u "
       "skip_name=%u skip_unloaded=%u skip_refs=%u skip_recent=%u freed_kb=%u",
       cur_frame, (u32)m_textures.size(), scanned, evicted, skip_user, skip_name,
       skip_unloaded, skip_refs, skip_recent, evicted_kb);
+#endif // DEBUG
 #endif
 }
 

--- a/src/Layers/xrRender/ResourceManager.cpp
+++ b/src/Layers/xrRender/ResourceManager.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include "xrRender_console.h"
 #pragma hdrstop
 
 #pragma warning(disable:4995)
@@ -535,6 +536,93 @@ void CResourceManager::Evict()
 	CHK_DX(HW.pDevice->EvictManagedResources());
 #endif	//	USE_DX10
 }
+
+void CResourceManager::EvictStalledTextures() {
+#if defined(USE_DX11)
+  if (!ps_r__tex_evict_enabled)
+    return;
+  Msg("* [TexEvict] pass called, frame=%u", RDEVICE.dwFrame);
+  if (!RDEVICE.b_is_Ready)
+    return;
+
+  u32 cur_frame    = RDEVICE.dwFrame;
+  u32 max_age      = (u32)ps_r__tex_evict_age_frames;
+  u32 evicted      = 0;
+  u32 evicted_kb   = 0;
+  u32 skip_user    = 0;
+  u32 skip_name    = 0;
+  u32 skip_unloaded = 0;
+  u32 skip_refs    = 0;
+  u32 skip_recent  = 0;
+
+  static xr_string s_evict_cursor;
+  const u32 batch_size = (u32)ps_r__tex_evict_batch_size;
+
+  creationGuard.Enter();
+
+  map_Texture::iterator I;
+  if (s_evict_cursor.empty()) {
+    I = m_textures.begin();
+  } else {
+    I = m_textures.lower_bound(s_evict_cursor.c_str());
+    if (I == m_textures.end())
+      I = m_textures.begin(); // wrap around to start
+  }
+
+  u32 scanned = 0;
+  for (; I != m_textures.end() && scanned < batch_size; ++I, ++scanned) {
+    CTexture *tex = I->second;
+    if (tex->flags.bUser) {
+      skip_user++;
+      continue;
+    }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$user$")) {
+      skip_user++;
+      continue;
+    }
+    if (tex->cName.size() && strstr(tex->cName.c_str(), "$null")) {
+      skip_user++;
+      continue;
+    }
+    if (!tex->flags.bLoaded) {
+      skip_unloaded++;
+      continue;
+    }
+    // UI textures — PDA, inventory icons, etc. — must never be evicted
+    LPCSTR name = I->first;
+    if (strncmp(name, "ui\\", 3) == 0 || strncmp(name, "ui/", 3) == 0) {
+      skip_name++;
+      continue;
+    }
+    if (tex->dwReference.load(std::memory_order_relaxed) > 1) {
+      u32 refs = tex->dwReference.load(std::memory_order_relaxed);
+      if (refs > 2)
+        Msg("* [TexEvict] stuck: [%4d] %s", refs, tex->cName.c_str());
+      skip_refs++;
+      continue;
+    }
+    if (cur_frame - tex->dwLastUsedFrame < max_age) {
+      skip_recent++;
+      continue;
+    }
+
+    evicted_kb += tex->flags.MemoryUsage / 1024;
+    tex->Unload();
+    evicted++;
+  }
+
+  // Save position for next call; empty string means restart from beginning
+  s_evict_cursor = (I != m_textures.end()) ? xr_string(I->first) : xr_string();
+
+  creationGuard.Leave();
+
+  Msg("* [TexEvict] frame=%u total=%u scanned=%u evicted=%u skip_user=%u "
+      "skip_name=%u skip_unloaded=%u skip_refs=%u skip_recent=%u freed_kb=%u",
+      cur_frame, (u32)m_textures.size(), scanned, evicted, skip_user, skip_name,
+      skip_unloaded, skip_refs, skip_recent, evicted_kb);
+#endif
+}
+
 
 /*
 BOOL	CResourceManager::_GetDetailTexture(LPCSTR Name,LPCSTR& T, R_constant_setup* &CS)

--- a/src/Layers/xrRender/ResourceManager.h
+++ b/src/Layers/xrRender/ResourceManager.h
@@ -233,6 +233,7 @@ public:
 	void DeferredUnload();
 	void UnloadAllTexturesOnLevelUnload();
 	void Evict();
+    void EvictStalledTextures();
 	void StoreNecessaryTextures();
 	void DestroyNecessaryTextures();
 	void Dump(bool bBrief);

--- a/src/Layers/xrRender/SH_Texture.cpp
+++ b/src/Layers/xrRender/SH_Texture.cpp
@@ -201,6 +201,7 @@ void CTexture::apply_normal(u32 dwStage)
 	{
 		SwitchToThread();
 	}
+	dwLastUsedFrame = Device.dwFrame;
 	CHK_DX(HW.pDevice->SetTexture(dwStage,pSurface));
 };
 

--- a/src/Layers/xrRender/SH_Texture.h
+++ b/src/Layers/xrRender/SH_Texture.h
@@ -93,6 +93,8 @@ public: //	Public class members (must be encapsulated furthur)
 #endif	//	USE_DX10
 	} flags;
 
+    u32 dwLastUsedFrame = 0; // frame index of last Apply() call — used for eviction
+
 	xr_delegate<void(u32)> bind;
 
 

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -180,7 +180,7 @@ Flags32 ps_r2_ls_flags = {
 	| R2FLAG_USE_NVSTENCIL | R2FLAG_EXP_SPLIT_SCENE
 	| R2FLAG_EXP_MT_CALC | R3FLAG_DYN_WET_SURF
 	| R3FLAG_VOLUMETRIC_SMOKE
-	//| R3FLAG_MSAA 
+	//| R3FLAG_MSAA
 	//| R3FLAG_MSAA_OPT
 
 	| R2FLAG_DETAIL_BUMP
@@ -232,7 +232,7 @@ float ps_r2_ls_depth_scale = 1.00001f; // 1.00001f
 float ps_r2_ls_depth_bias = -0.001f; // -0.0001f
 float ps_r2_ls_squality = 1.0f; // 1.00f
 float ps_r2_sun_tsm_projection = 0.3f; // 0.18f
-float ps_r2_sun_tsm_bias = -0.01f; // 
+float ps_r2_sun_tsm_bias = -0.01f; //
 float ps_r2_sun_near = 20.f; // 12.0f
 
 extern float OLES_SUN_LIMIT_27_01_07; //	actually sun_far
@@ -246,7 +246,7 @@ float ps_r2_sun_lumscale = 1.0f; // 1.0f
 float ps_r2_sun_lumscale_hemi = 1.0f; // 1.0f
 float ps_r2_sun_lumscale_amb = 1.0f;
 Fvector3 ps_r2_sun_lumscale_color = { 1.f, 1.f, 1.f };
-float ps_r2_gmaterial = 2.2f; // 
+float ps_r2_gmaterial = 2.2f; //
 float ps_r2_zfill = 0.25f; // .1f
 
 float ps_r2_dhemi_sky_scale = 0.08f; // 1.5f
@@ -487,6 +487,10 @@ float ps_r3_dyn_wet_surf_far = 30.f; // 30.0f
 int ps_r3_dyn_wet_surf_sm_res = 256; // 256
 Flags32 psDeviceFlags2 = { 0 };
 Flags32 ps_actor_shadow_flags = {0}; //Swartz: actor shadow
+
+int ps_r__tex_evict_enabled    = 0;
+int ps_r__tex_evict_age_frames = 1800;
+int ps_r__tex_evict_batch_size = 200;
 
 //AVO: detail draw radius
 Flags32 ps_common_flags = {0}; // r1-only
@@ -1072,7 +1076,7 @@ class CCC_Fog_Reload : public IConsole_Command
 {
 public:
 	CCC_Fog_Reload(LPCSTR N) : IConsole_Command(N) { bEmptyArgsHandled = TRUE; };
-	virtual void Execute(LPCSTR args) 
+	virtual void Execute(LPCSTR args)
 	{
 		FluidManager.UpdateProfiles();
 	}
@@ -1326,7 +1330,7 @@ void xrRender_initconsole()
 
 	CMD4(CCC_Integer, "r__heatvision", &ps_r2_heatvision, 0, 1); //--DSR-- HeatVision
 	CMD3(CCC_Mask, "r2_terrain_z_prepass", &ps_r2_ls_flags, R2FLAG_TERRAIN_PREPASS); //Terrain Z Prepass @Zagolski
-	
+
 	//////////other
 	CMD3(CCC_Mask, "r2_water_reflections", &ps_r2_anomaly_flags, R2_AN_FLAG_WATER_REFLECTIONS);
 	CMD3(CCC_Mask, "r2_mblur_enabled", &ps_r2_anomaly_flags, R2_AN_FLAG_MBLUR);
@@ -1337,7 +1341,7 @@ void xrRender_initconsole()
 	CMD4(CCC_Integer,	"r2_gi_depth",			&ps_r2_GI_depth,			1,		5		);
 	CMD4(CCC_Integer,	"r2_gi_photons",		&ps_r2_GI_photons,			8,		256		);
 	CMD4(CCC_Float,		"r2_gi_refl",			&ps_r2_GI_refl,				EPS_L,	0.99f	);
-	
+
 	//Shader param stuff
 	Fvector4 tw2_min = { -100.f, -100.f, -100.f, -100.f };
 	Fvector4 tw2_max = { 100.f, 100.f, 100.f, 100.f };
@@ -1349,7 +1353,7 @@ void xrRender_initconsole()
 	CMD4(CCC_Vector4, "shader_param_6", &ps_dev_param_6, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "shader_param_7", &ps_dev_param_7, tw2_min, tw2_max);
 	CMD4(CCC_Vector4, "shader_param_8", &ps_dev_param_8, tw2_min, tw2_max);
-	
+
 	// Mark Switch
 	CMD4(CCC_Integer, "markswitch_current", &ps_markswitch_current, 0, 32);
 	CMD4(CCC_Integer, "markswitch_count", &ps_markswitch_count, 0, 32);
@@ -1362,7 +1366,7 @@ void xrRender_initconsole()
 	CMD4(CCC_Vector4, "s3ds_param_4", &ps_s3ds_param_4, tw2_min, tw2_max);
 
 	CMD4(CCC_Float, "hud_fov_aim_factor", &hud_fov_aim_factor, 0.0f, 1.0f);
-	
+
 	// Screen Space Shaders
 	CMD4(CCC_Vector4, "ssfx_floravariation", &ps_ssfx_floravariation, Fvector4().set(0, 0, 0, 0), Fvector4().set(10, 1, 10, 1));
 	CMD4(CCC_Vector4, "ssfx_taa", &ps_ssfx_taa, Fvector4().set(0, 0, 0, 0), Fvector4().set(1, 1, 2, 1));
@@ -1402,7 +1406,7 @@ void xrRender_initconsole()
 	CMD4(CCC_Integer, "ssfx_ssr_quality", &ps_ssfx_ssr_quality, 0, 5);
 	CMD4(CCC_Vector4, "ssfx_ssr", &ps_ssfx_ssr, Fvector4().set(1, 0, 0, 0), Fvector4().set(2, 1, 1, 1));
 	CMD4(CCC_Vector4, "ssfx_ssr_2", &ps_ssfx_ssr_2, Fvector4().set(0, 0, 0, 0), Fvector4().set(2, 2, 2, 2));
-	
+
 	CMD4(CCC_Vector4, "ssfx_terrain_quality", &ps_ssfx_terrain_quality, Fvector4().set(0, 0, 0, 0), Fvector4().set(40, 0, 0, 0));
 	CMD4(CCC_Vector4, "ssfx_terrain_offset", &ps_ssfx_terrain_offset, Fvector4().set(-1, -1, -1, -1), Fvector4().set(1, 1, 1, 1));
 
@@ -1441,11 +1445,11 @@ void xrRender_initconsole()
 
 	CMD4(CCC_Vector4, "ssfx_grass_shadows", &ps_ssfx_grass_shadows, Fvector4().set(0, 0, 0, 0), Fvector4().set(3, 1, 100, 100));
 	CMD4(CCC_ssfx_cascades, "ssfx_shadow_cascades", &ps_ssfx_shadow_cascades, Fvector3().set(1.0f, 1.0f, 1.0f), Fvector3().set(300, 300, 300));
-	
+
 	CMD4(CCC_Vector4, "ssfx_grass_interactive", &ps_ssfx_grass_interactive, Fvector4().set(0, 0, 0, 0), Fvector4().set(1, 15, 5000, 1));
 	CMD4(CCC_Vector4, "ssfx_int_grass_params_1", &ps_ssfx_int_grass_params_1, Fvector4().set(0, 0, 0, 0), Fvector4().set(5, 5, 5, 60));
 	CMD4(CCC_Vector4, "ssfx_int_grass_params_2", &ps_ssfx_int_grass_params_2, Fvector4().set(0, 0, 0, 0), Fvector4().set(5, 20, 1, 5));
-	
+
 	CMD4(CCC_Vector4, "ssfx_wpn_dof_1", &ps_ssfx_wpn_dof_1, tw2_min, tw2_max);
 	CMD4(CCC_Float, "ssfx_wpn_dof_2", &ps_ssfx_wpn_dof_2, 0, 1);
 
@@ -1499,7 +1503,7 @@ void xrRender_initconsole()
 #endif // DEBUG
 
 	CMD3(CCC_Mask,		"r2_shadow_cascede_old", &ps_r2_ls_flags_ext,		R2FLAGEXT_SUN_OLD);
-	
+
 	CMD4(CCC_Float, "r2_ls_depth_scale", &ps_r2_ls_depth_scale, 0.5, 1.5);
 	CMD4(CCC_Float, "r2_ls_depth_bias", &ps_r2_ls_depth_bias, -0.5, +0.5);
 
@@ -1571,6 +1575,9 @@ void xrRender_initconsole()
 	CMD4(CCC_detail_radius, "r__detail_radius", &ps_r__detail_radius, 0, 250);
 	CMD3(CCC_Mask, "r__clear_models_on_unload", &psDeviceFlags2, rsClearModels); //Alundaio
 	CMD3(CCC_Mask, "r__clear_resources_on_unload", &psDeviceFlags2, rsClearAllResources);
+	CMD4(CCC_Integer, "r__tex_evict_enabled",    &ps_r__tex_evict_enabled,    0,   1    );
+	CMD4(CCC_Integer, "r__tex_evict_age_frames", &ps_r__tex_evict_age_frames, 300, 36000);
+	CMD4(CCC_Integer, "r__tex_evict_batch_size", &ps_r__tex_evict_batch_size, 10,  1000 );
 	CMD3(CCC_Mask, "r__use_precompiled_shaders", &psDeviceFlags2, rsPrecompiledShaders); //Alundaio
 	CMD3(CCC_Mask, "r__enable_grass_shadow", &psDeviceFlags2, rsGrassShadow); //Alundaio
 	CMD3(CCC_Mask, "r__no_scale_on_fade", &psDeviceFlags2, rsNoScale); //Alundaio

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -491,6 +491,7 @@ Flags32 ps_actor_shadow_flags = {0}; //Swartz: actor shadow
 int ps_r__tex_evict_enabled    = 0;
 int ps_r__tex_evict_age_frames = 1800;
 int ps_r__tex_evict_batch_size = 200;
+int ps_r__tex_evict_interval   = 600;
 
 //AVO: detail draw radius
 Flags32 ps_common_flags = {0}; // r1-only
@@ -1578,6 +1579,7 @@ void xrRender_initconsole()
 	CMD4(CCC_Integer, "r__tex_evict_enabled",    &ps_r__tex_evict_enabled,    0,   1    );
 	CMD4(CCC_Integer, "r__tex_evict_age_frames", &ps_r__tex_evict_age_frames, 300, 36000);
 	CMD4(CCC_Integer, "r__tex_evict_batch_size", &ps_r__tex_evict_batch_size, 10,  1000 );
+	CMD4(CCC_Integer, "r__tex_evict_interval",   &ps_r__tex_evict_interval,   60,  3600 );
 	CMD3(CCC_Mask, "r__use_precompiled_shaders", &psDeviceFlags2, rsPrecompiledShaders); //Alundaio
 	CMD3(CCC_Mask, "r__enable_grass_shadow", &psDeviceFlags2, rsGrassShadow); //Alundaio
 	CMD3(CCC_Mask, "r__no_scale_on_fade", &psDeviceFlags2, rsNoScale); //Alundaio

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -381,6 +381,11 @@ enum
 // demonized:
 extern ECORE_API BOOL occq_debug;
 
+// Texture eviction system
+extern ECORE_API int ps_r__tex_evict_enabled;
+extern ECORE_API int ps_r__tex_evict_age_frames;
+extern ECORE_API int ps_r__tex_evict_batch_size;
+
 extern void xrRender_initconsole();
 extern BOOL xrRender_test_hw();
 

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -385,6 +385,7 @@ extern ECORE_API BOOL occq_debug;
 extern ECORE_API int ps_r__tex_evict_enabled;
 extern ECORE_API int ps_r__tex_evict_age_frames;
 extern ECORE_API int ps_r__tex_evict_batch_size;
+extern ECORE_API int ps_r__tex_evict_interval;
 
 extern void xrRender_initconsole();
 extern BOOL xrRender_test_hw();

--- a/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_Texture.cpp
@@ -62,6 +62,9 @@ void CTexture::surface_set(ID3DBaseTexture* surf)
 	{
 		SwitchToThread();
 	}
+
+	if (cName.size() && strstr(cName.c_str(), "$user$"))
+		flags.bUser = true;
 	if (surf) surf->AddRef();
 	_RELEASE(pSurface);
 	_RELEASE(m_pSRView);
@@ -251,6 +254,8 @@ void CTexture::Apply(u32 dwStage)
 	{
 		SwitchToThread();
 	}
+	dwLastUsedFrame = RDEVICE.dwFrame;
+
 	if (flags.bLoadedAsStaging)
 		ProcessStaging();
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -94,8 +94,7 @@ void CRender::Render()
 		return;
 	}
 
-	// Periodic texture eviction — runs every 600 frames (~10s at 60fps)
-	if ((Device.dwFrame % 600) == 0)
+	if ((Device.dwFrame % (u32)ps_r__tex_evict_interval) == 0)
 		dxRenderDeviceRender::Instance().Resources->EvictStalledTextures();
 
 	//.	VERIFY					(g_pGameLevel && g_pGameLevel->pHUD);

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -8,6 +8,8 @@
 
 #include "../xrRender/QueryHelper.h"
 
+#include	"../xrRender/dxRenderDeviceRender.h"
+
 void CRender::render_menu()
 {
 	PIX_EVENT(render_menu);
@@ -91,6 +93,10 @@ void CRender::Render()
 		m_bFirstFrameAfterReset = false;
 		return;
 	}
+
+	// Periodic texture eviction — runs every 600 frames (~10s at 60fps)
+	if ((Device.dwFrame % 600) == 0)
+		dxRenderDeviceRender::Instance().Resources->EvictStalledTextures();
 
 	//.	VERIFY					(g_pGameLevel && g_pGameLevel->pHUD);
 

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -195,6 +195,9 @@ void CRender::level_Unload()
 		//Msg("The Level Unloaded.======================== %d", ++unload_counter);
 	}
 
+	// Force-evict all textures on level unload — covers normal transitions,
+	// fast travel, and main menu exit (all converge through level_Unload())
+
 	b_loaded = FALSE;
 }
 


### PR DESCRIPTION
This is a refocused version of #589. EvictAllTextures has been removed since it duplicated existing functionality.

This PR contains only EvictStalledTextures, which adds an age-based LRU texture eviction during gameplay sessions. No equivalent exists in the codebase.
UnloadAllTexturesOnLevelUnload() handles level transitions only; nothing currently evicts stale textures during a single play session.

- dwLastUsedFrame field added to CTexture, stamped in Apply() and  apply_normal() after the bLoading spin-wait (MT-safe)
- EvictStalledTextures() scans m_textures in batches, evicting  textures unused beyond a configurable age threshold
- Excludes render targets ($user$*), \$null sentinel, UI textures,  and ref-locked textures (dwReference > 1)
- Fixes surface_set() to correctly set flags.bUser for \$user\$ render targets created before device ready

Tunable via console variables:
- r__tex_evict_enabled (default 0)
- r__tex_evict_age_frames (default 1800, ~30s at 60fps)
- r__tex_evict_batch_size (default 200)
At the default batch size of 200, the engine clears out 100-200Mb of VRAM every 30 seconds on my configurations and it seems to add no stuttering or instability. 