### PR TITLE
feat(ai): per-NPC aim params and vision speed setters

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -626,6 +626,7 @@
 
         // Stalker and Monster
         function invalidate_restrictions()
+        void set_vision_speed(float factor) // Per-object vision-speed factor multiplied into get_visible_value on top of the ai_vision_speed_boost cvar. 1.0 = vanilla, higher spots faster, negative clamps to 0. Persists while online; re-set on spawn (memory manager is rebuilt when the NPC comes back online).
 
         // Stalker NPCs
         function get_enable_anomalies_pathfinding()
@@ -640,6 +641,7 @@
         function memory_remove_links(game_object)
         function get_object_visible_distance(game_object)
         function get_object_luminocity(game_object)
+        void set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time) // Per-NPC sight-manager aim params (swing speed, firing cone, target lead). Unset or negative components follow the live ai_aim_max_angle / ai_aim_min_angle / ai_aim_min_speed / ai_aim_predict_time cvars, so pass negatives to revert to vanilla. Set once per NPC (e.g. on spawn by rank); read per frame in C++, no per-frame Lua.
         bool can_kill_enemy() // Engine posture-aware shot clearance: fire-point ray (with safety-angle probes) reaches the NPC's current selected enemy. False when no weapon is out. At most one recompute per frame (shared cache with the engine friendly-fire gate).
         bool can_kill_member() // As can_kill_enemy but true when the ray would hit a squad member (friendly fire). False when no weapon is out.
         bool fire_make_sense() // Engine fire-discipline gate for the current selected enemy: occlusion before target (pick_distance + ai_fire_range_extension), floor gap (ai_fire_max_height_diff), point-blank (ai_fire_min_dist), unseen enemy only within ai_fire_make_sense_interval and with an automatic weapon.

--- a/src/xrGame/ai/stalker/ai_stalker.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker.cpp
@@ -80,6 +80,10 @@ int g_ai_unlimited_ammo = 1;
 CAI_Stalker::CAI_Stalker() :
 	m_sniper_update_rate(false),
 	m_sniper_fire_mode(false),
+	m_aim_min_speed(-1.f),
+	m_aim_min_angle(-1.f),
+	m_aim_max_angle(-1.f),
+	m_aim_predict_time(-1.f),
 	m_take_items_enabled(true),
 	m_death_sound_enabled(true)
 {

--- a/src/xrGame/ai/stalker/ai_stalker.h
+++ b/src/xrGame/ai/stalker/ai_stalker.h
@@ -817,11 +817,27 @@ private:
 	bool m_sniper_update_rate;
 	bool m_sniper_fire_mode;
 
+	// Per-NPC aim params, read per frame in CSightManager::Exec_Look (swing speed + firing cone)
+	// and CSightAction (target lead). Negative = unset: the getters fall back to the live console
+	// vars (ai_aim_min_speed / ai_aim_min_angle / ai_aim_max_angle / ai_aim_predict_time), so an
+	// unset NPC and existing cvar consumers keep exact vanilla behavior. set_aim_params with a
+	// negative component reverts that component to the global.
+	float m_aim_min_speed;
+	float m_aim_min_angle;
+	float m_aim_max_angle;
+	float m_aim_predict_time;
+
 public:
 	IC void sniper_update_rate(bool value);
 	IC bool sniper_update_rate() const;
 	IC void sniper_fire_mode(bool value);
 	IC bool sniper_fire_mode() const;
+
+	IC void  set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time);
+	IC float aim_min_speed() const;
+	IC float aim_min_angle() const;
+	IC float aim_max_angle() const;
+	IC float aim_predict_time() const;
 
 private:
 	shared_str m_aim_bone_id;

--- a/src/xrGame/ai/stalker/ai_stalker_inline.h
+++ b/src/xrGame/ai/stalker/ai_stalker_inline.h
@@ -141,6 +141,40 @@ IC bool CAI_Stalker::sniper_fire_mode() const
 	return (m_sniper_fire_mode);
 }
 
+IC void CAI_Stalker::set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time)
+{
+	m_aim_max_angle    = max_angle;
+	m_aim_min_angle    = min_angle;
+	m_aim_min_speed    = min_speed;
+	m_aim_predict_time = predict_time;
+}
+
+// Negative = unset: follow the live console vars, so an unset NPC and existing
+// cvar consumers (e.g. per-rank aim tuning mods) keep exact vanilla behavior.
+IC float CAI_Stalker::aim_min_speed() const
+{
+	extern float g_ai_aim_min_speed;
+	return (m_aim_min_speed < 0.f ? g_ai_aim_min_speed : m_aim_min_speed);
+}
+
+IC float CAI_Stalker::aim_min_angle() const
+{
+	extern float g_ai_aim_min_angle;
+	return (m_aim_min_angle < 0.f ? g_ai_aim_min_angle : m_aim_min_angle);
+}
+
+IC float CAI_Stalker::aim_max_angle() const
+{
+	extern float g_ai_aim_max_angle;
+	return (m_aim_max_angle < 0.f ? g_ai_aim_max_angle : m_aim_max_angle);
+}
+
+IC float CAI_Stalker::aim_predict_time() const
+{
+	extern float g_aim_predict_time;
+	return (m_aim_predict_time < 0.f ? g_aim_predict_time : m_aim_predict_time);
+}
+
 IC void CAI_Stalker::take_items_enabled(bool value)
 {
 	m_take_items_enabled = value;

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -837,6 +837,8 @@ public:
 	void sniper_fire_mode(bool value);
 	bool sniper_fire_mode() const;
 
+	void set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time);
+	void set_vision_speed(float value);
 	bool can_kill_enemy();
 	bool can_kill_member();
 	bool fire_make_sense();

--- a/src/xrGame/script_game_object3.cpp
+++ b/src/xrGame/script_game_object3.cpp
@@ -150,6 +150,16 @@ void CScriptGameObject::SetVisualMemoryEnabled(bool enabled)
 		custom_monster->memory().visual().enable(enabled);
 }
 
+void CScriptGameObject::set_vision_speed(float value)
+{
+	CCustomMonster* custom_monster = smart_cast<CCustomMonster*>(&object());
+	if (!custom_monster)
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CCustomMonster : cannot access class member set_vision_speed!");
+	else
+		custom_monster->memory().visual().set_vision_speed(value);
+}
+
 float CScriptGameObject::GetObjectVisibleDistance(const CScriptGameObject* obj)
 {
     if (obj == nullptr)

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -1916,6 +1916,19 @@ bool CScriptGameObject::sniper_fire_mode() const
 	return (stalker->sniper_fire_mode());
 }
 
+void CScriptGameObject::set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time)
+{
+	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());
+	if (!stalker)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CAI_Stalker : cannot access class member set_aim_params!");
+		return;
+	}
+
+	stalker->set_aim_params(max_angle, min_angle, min_speed, predict_time);
+}
+
 bool CScriptGameObject::can_kill_enemy()
 {
 	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -63,6 +63,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("path_completed", SAFE_WRAP(&CScriptGameObject::path_completed))
 		.def("patrol_path_make_inactual", SAFE_WRAP(&CScriptGameObject::patrol_path_make_inactual))
 		.def("enable_memory_object", SAFE_WRAP(&CScriptGameObject::enable_memory_object))
+		.def("set_vision_speed", SAFE_WRAP(&CScriptGameObject::set_vision_speed))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)())(&CScriptGameObject::active_sound_count)))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)(bool))(&CScriptGameObject::active_sound_count)))
 		.def("best_cover", SAFE_WRAP(&CScriptGameObject::best_cover))
@@ -455,6 +456,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("sniper_fire_mode", SAFE_WRAP((void (CScriptGameObject::*)(bool))&CScriptGameObject::sniper_fire_mode))
 		.def("sniper_fire_mode", SAFE_WRAP((bool (CScriptGameObject::*)() const)&CScriptGameObject::sniper_fire_mode))
 
+		.def("set_aim_params", SAFE_WRAP(&CScriptGameObject::set_aim_params))
 		.def("can_kill_enemy", SAFE_WRAP(&CScriptGameObject::can_kill_enemy))
 		.def("can_kill_member", SAFE_WRAP(&CScriptGameObject::can_kill_member))
 		.def("fire_make_sense", SAFE_WRAP(&CScriptGameObject::fire_make_sense))

--- a/src/xrGame/sight_action.cpp
+++ b/src/xrGame/sight_action.cpp
@@ -380,8 +380,7 @@ void CSightAction::predict_object_position(bool use_exact_position)
 				offset.y = 0.f;
 				Fvector const velocity = Fvector(offset).div(
 					float(current_position.dwTime - previous_position.dwTime) / 1000.f);
-				extern float g_aim_predict_time;
-				float const predict_time = g_aim_predict_time; //*Device.fTimeDelta;
+				float const predict_time = m_object->aim_predict_time(); //*Device.fTimeDelta;
 				m_vector3d.mad(velocity, predict_time);
 			}
 		}

--- a/src/xrGame/sight_manager.cpp
+++ b/src/xrGame/sight_manager.cpp
@@ -161,20 +161,20 @@ void CSightManager::Exec_Look(float time_delta)
 
 		m_object->angle_lerp_bounds(body.current.yaw, body.target.yaw,
 		                            select_speed(angle_difference(body.current.yaw, body.target.yaw), body_speed,
-		                                         g_ai_aim_min_speed, g_ai_aim_min_angle, g_ai_aim_max_angle),
+		                                         m_object->aim_min_speed(), m_object->aim_min_angle(), m_object->aim_max_angle()),
 		                            time_delta);
 		m_object->angle_lerp_bounds(body.current.pitch, body.target.pitch,
 		                            select_speed(angle_difference(body.current.pitch, body.target.pitch), body_speed,
-		                                         g_ai_aim_min_speed, g_ai_aim_min_angle, g_ai_aim_max_angle),
+		                                         m_object->aim_min_speed(), m_object->aim_min_angle(), m_object->aim_max_angle()),
 		                            time_delta);
 
 		m_object->angle_lerp_bounds(head.current.yaw, head.target.yaw,
 		                            select_speed(angle_difference(head.current.yaw, head.target.yaw), head_speed,
-		                                         g_ai_aim_min_speed, g_ai_aim_min_angle, g_ai_aim_max_angle),
+		                                         m_object->aim_min_speed(), m_object->aim_min_angle(), m_object->aim_max_angle()),
 		                            time_delta);
 		m_object->angle_lerp_bounds(head.current.pitch, head.target.pitch,
 		                            select_speed(angle_difference(head.current.pitch, head.target.pitch), head_speed,
-		                                         g_ai_aim_min_speed, g_ai_aim_min_angle, g_ai_aim_max_angle),
+		                                         m_object->aim_min_speed(), m_object->aim_min_angle(), m_object->aim_max_angle()),
 		                            time_delta);
 
 #ifdef DEBUG

--- a/src/xrGame/visual_memory_manager.cpp
+++ b/src/xrGame/visual_memory_manager.cpp
@@ -365,7 +365,7 @@ float CVisualMemoryManager::get_visible_value(const CGameObject* game_object, fl
 	if (ai().script_engine().functor("visual_memory_manager.get_visible_value", funct))
 		return (funct(m_object ? m_object->lua_game_object() : 0, game_object ? game_object->lua_game_object() : 0,
 		              time_delta, current_state().m_time_quant, luminocity, current_state().m_velocity_factor,
-		              object_velocity, distance, object_distance, always_visible_distance)) * g_ai_vision_speed_boost;
+		              object_velocity, distance, object_distance, always_visible_distance)) * g_ai_vision_speed_boost * m_vision_speed;
 	//-Alundaio
 
 	return (
@@ -375,7 +375,7 @@ float CVisualMemoryManager::get_visible_value(const CGameObject* game_object, fl
 		(1.f + current_state().m_velocity_factor * object_velocity) *
 		(distance - object_distance) /
 		(distance - always_visible_distance)
-	) * g_ai_vision_speed_boost;
+	) * g_ai_vision_speed_boost * m_vision_speed;
 }
 
 CNotYetVisibleObject* CVisualMemoryManager::not_yet_visible_object(const CGameObject* game_object)

--- a/src/xrGame/visual_memory_manager.h
+++ b/src/xrGame/visual_memory_manager.h
@@ -58,6 +58,7 @@ private:
 	u32 m_max_object_count;
 	bool m_enabled;
 	u32 m_last_update_time;
+	float m_vision_speed = 1.0f; // per-NPC vision-speed factor; scales get_visible_value (1.0 = vanilla). Deliberately not reset in reinit()/reload(): persists while online, re-set from script on spawn.
 
 public:
 	void add_visible_object(const CObject* object, float time_delta, bool fictitious = false);
@@ -127,6 +128,8 @@ public:
 public:
 	IC bool enabled() const;
 	IC void enable(bool value);
+	void set_vision_speed(float value) { m_vision_speed = (value < 0.f) ? 0.f : value; }
+	float vision_speed() const { return (m_vision_speed); }
 
 public:
 	IC const VISIBLES& objects() const;


### PR DESCRIPTION
## Summary

Two per-object setters so scripts can shape an individual NPC's reaction curve without touching the global cvars:

- `npc:set_aim_params(max_angle, min_angle, min_speed, predict_time)` — 4 floats on `CAI_Stalker`, consumed by `CSightManager::Exec_Look` (body/head swing speed and firing cone, `sight_manager.cpp:162-178`) and `CSightAction::predict_object_position` (target lead, `sight_action.cpp:383`). Fields default to `-1.f` = unset; the inline getters fall back to the live globals (`g_ai_aim_min_speed` / `g_ai_aim_min_angle` / `g_ai_aim_max_angle` / `g_aim_predict_time`) whenever a field is negative. An unset NPC follows the `ai_aim_*` console commands as before, and REDONE Combat AI, which drives these 4 cvars, is unaffected. A negative component reverts that component to the global. The sentinel cannot collide with real values since the cvar domains are non-negative.
- `npc:set_vision_speed(factor)` — per-object float on `CVisualMemoryManager`, multiplied into both `get_visible_value` returns alongside `g_ai_vision_speed_boost` (`visual_memory_manager.cpp:368,378`; the cvar stays live: final = base * factor * boost). 1.0 = vanilla, higher spots faster, negative clamps to 0. Works for any `CCustomMonster`; error-log path for anything else. Deliberately not reset in `reinit()`/`reload()` — the manager is reconstructed when the NPC comes back online, so scripts re-apply on `npc_on_net_spawn`.

## Use cases

The aim and vision knobs are globals on per-frame paths, so a script can only set them server-wide (last writer wins). A per-rank or per-situation reaction curve is impossible without per-frame Lua.

- per-rank reaction curves: a veteran swings onto target faster and spots sooner than a rookie
- temporary per-NPC effects: suppression or blinding slows aim, stimulants speed it
- REDONE-style aim tuning without global writes per NPC per tick

## Performance

No Lua on any per-frame path. The setters run from script at spawn or decision points; the per-frame reads are C++ field reads with one negative compare, and the fallback branch reads the same globals the code read before. `predict_object_position` used to read the global through an `extern`; it now reads the owner's field via `m_object`, which is statically `CAI_Stalker*` (`control_action.h:16`), so no cast was added.

## Constraints

- Not serialized: per-NPC values live on the game object and vanish on offline switch; re-set from script on net spawn (noted in the manifest entries).
- The actor is not a `CAI_Stalker`/`CCustomMonster`; both setters take the error-log path.

## Files changed

| File | Change |
|---|---|
| `src/xrGame/ai/stalker/ai_stalker.h` | 4 fields + accessor decls (+16) |
| `src/xrGame/ai/stalker/ai_stalker.cpp` | ctor inits to -1.f (+4) |
| `src/xrGame/ai/stalker/ai_stalker_inline.h` | setter + 4 fallback getters (+34) |
| `src/xrGame/sight_manager.cpp` | 12 global reads -> getters |
| `src/xrGame/sight_action.cpp` | predict read via owner, extern dropped |
| `src/xrGame/visual_memory_manager.h/.cpp` | m_vision_speed + 2 multiplies (+3/+2) |
| `src/xrGame/script_game_object.h/_script3.cpp/3.cpp/_inventory_owner.cpp` | binds |
| `gamedata/scripts/lua_help_ex.script` | 2 manifest entries |

93 lines added, 8 removed.

## Lua usage

```lua
-- veteran: fast swing, tight cone, sharp eyes; set once on spawn
npc:set_aim_params(0.4, 0.05, 1.2, 0.3)
npc:set_vision_speed(2.0)
-- revert to the live ai_aim_* cvars / vanilla vision
npc:set_aim_params(-1, -1, -1, -1)
npc:set_vision_speed(1)
```

## Testing

Tested in-game on a DX11 build of this branch. I gave one fighting NPC slow aim params and sampled its body yaw every frame: turn rate p95 went from 6.62 rad/s to 0.63 rad/s, and returned to normal after `set_aim_params(-1, -1, -1, -1)`. For vision, I wiped the actor from a calm NPC's visual memory at 10m and timed re-detection: 139ms with factor 10; with factor 0.05 it still had not re-detected after 20s. NPCs with nothing set kept following the `ai_aim_*` console commands. No crashes and no luabind cast errors in the log.

