### PR TITLE
feat(ai): combat action-switch veto callback (npc_on_combat_action_switch)

### DIFF
--- a/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/scripts/callbacks_gameobject.script
@@ -414,6 +414,19 @@ _G.CAI_Stalker__OnCombatActionChanged = function(npc, old_op, new_op)
 	SendScriptCallback("npc_on_combat_action_changed", npc, old_op, new_op)
 end
 
+-- NPC combat GOAP action switch veto. Fires BEFORE the combat planner swaps actions
+-- (npc_on_combat_action_changed fires after an allowed swap). from_op and to_op match
+-- stalker_ids.action_* values. Set flags.allow = false to keep the current action
+-- (e.g. suppress the take_cover <-> look_out oscillation); real switches (grenade,
+-- hit, target dead) should be left through. Re-fires each AI update while the
+-- proposed switch stays denied, so keep subscribers cheap.
+AddScriptCallback("npc_on_combat_action_switch")
+_G.CAI_Stalker__AllowCombatActionSwitch = function(npc, from_op, to_op)
+	local flags = { allow = true }
+	SendScriptCallback("npc_on_combat_action_switch", npc, from_op, to_op, flags)
+	return flags.allow ~= false
+end
+
 -- NPC TakeCover destination callback. Only fires when a real cover point is found, not on fallback paths
 AddScriptCallback("npc_on_take_cover_destination")
 _G.CAI_Stalker__OnTakeCoverDestination = function(npc, cover_pos, enemy)

--- a/src/xrGame/action_planner.h
+++ b/src/xrGame/action_planner.h
@@ -94,6 +94,10 @@ public:
 	virtual ~CActionPlanner();
 	virtual void setup(_object_type* object);
 	virtual void update();
+	// Called at the action-switch decision point in update() (action_planner_inline.h), only when a
+	// switch is proposed (current != solution front). Default allows every switch; a derived planner
+	// may veto to keep the current action executing. Base behavior = vanilla for every planner.
+	virtual bool allow_action_switch(const _action_id_type& /*from_action_id*/, const _action_id_type& /*to_action_id*/) { return (true); }
 	virtual void finalize();
 	IC COperator& action(const _action_id_type& action_id);
 	IC CConditionEvaluator& evaluator(const _condition_type& evaluator_id);

--- a/src/xrGame/action_planner_inline.h
+++ b/src/xrGame/action_planner_inline.h
@@ -108,7 +108,7 @@ void CPlanner::update()
 
 	if (initialized())
 	{
-		if (current_action_id() != solution().front())
+		if (current_action_id() != solution().front() && allow_action_switch(current_action_id(), solution().front()))
 		{
 			current_action().finalize();
 			m_current_action_id = solution().front();

--- a/src/xrGame/stalker_combat_planner.cpp
+++ b/src/xrGame/stalker_combat_planner.cpp
@@ -120,6 +120,20 @@ void CStalkerCombatPlanner::update()
 	//	m_last_wounded					= stalker && stalker->wounded();
 }
 
+bool CStalkerCombatPlanner::allow_action_switch(const _action_id_type& from_action_id, const _action_id_type& to_action_id)
+{
+	// Veto gate, fired BEFORE the planner swaps actions (npc_on_combat_action_changed fires after an
+	// allowed swap). A Lua subscriber may return false to keep the current action (e.g. suppress the
+	// take_cover <-> look_out oscillation); no subscriber = vanilla. Re-asked each brain update while
+	// the proposed switch stays denied. A denied swap produces no transition, so the changed-callback
+	// stays silent for it.
+	luabind::functor<bool> funct;
+	if (ai().script_engine().functor("_G.CAI_Stalker__AllowCombatActionSwitch", funct))
+		return (funct(object().lua_game_object(), (u32)from_action_id, (u32)to_action_id));
+
+	return (true);
+}
+
 void CStalkerCombatPlanner::initialize()
 {
 	inherited::initialize();

--- a/src/xrGame/stalker_combat_planner.h
+++ b/src/xrGame/stalker_combat_planner.h
@@ -40,6 +40,7 @@ public:
 	virtual ~CStalkerCombatPlanner();
 	virtual void setup(CAI_Stalker* object, CPropertyStorage* storage);
 	virtual void update();
+	virtual bool allow_action_switch(const _action_id_type& from_action_id, const _action_id_type& to_action_id);
 	virtual void initialize();
 	virtual void execute();
 	virtual void finalize();


### PR DESCRIPTION
## Summary

Adds `virtual bool allow_action_switch(from, to)` to `CActionPlanner` (default `true`) and gates the action swap in `CPlanner::update()` on it (`action_planner_inline.h:111`). Only `CStalkerCombatPlanner` overrides it, firing the `_G.CAI_Stalker__AllowCombatActionSwitch` functor through a snake_case `npc_on_combat_action_switch` forwarder in `callbacks_gameobject.script` — the same functor + forwarder shape as `npc_on_combat_action_changed`. A subscriber that sets `flags.allow = false` keeps the current action executing via the same steady-frame path (`current_action().execute()`), so a denied swap creates no new engine state. No subscriber = vanilla behavior for every planner.

This is the veto counterpart to the existing `npc_on_combat_action_changed`, which is a post-transition notification (void, fires after the swap already happened). This one fires before the swap and can hold it. A denied swap produces no transition, so the changed notification stays silent while a denial holds — the two compose.

## Use cases

The take_cover <-> look_out combat shuffle. `on_best_cover_changed` flips `InCover` by direct `m_storage.set_property` writes (`stalker_combat_planner.cpp:58-64`), bypassing evaluators, so cover churn makes NPCs thrash finalize/initialize mid-motion (the twitchy duck-peek-duck flicker) and abandon shots. That property churn cannot be reached from Lua, and a dwell timer is the wrong fix because it goes deaf to a grenade during the window. A pre-swap veto is the only seam that can hold an action without blocking the planner: the subscriber decides which switches are oscillation, and grenade, hit-reaction, and target-dead switches pass through.

## Safety

- Only `CStalkerCombatPlanner` overrides the virtual. Base-brain switches (death / danger / combat planner selection, `stalker_planner.cpp:146-178`) are ungated, as is initial action selection, so a bad subscriber cannot hold an NPC against death or combat exit.
- The forwarder returns `flags.allow ~= false`, so the engine-facing return is always a real boolean. A nil from a subscriber would otherwise hit the `luabind::functor<bool>` cast and `Debug.fatal`.

## Performance / cadence

The functor fires only when a switch is proposed; `front != current` short-circuits the steady state. While a subscriber holds a denial, the planner re-proposes each brain update and the callback re-fires — this is documented at the forwarder, and subscribers should be cheap. With no subscriber the cost is one functor lookup per proposed switch.

## Files changed

| File | Change |
|---|---|
| `src/xrGame/action_planner.h` | the virtual, default true (+4) |
| `src/xrGame/action_planner_inline.h` | 1-line condition at the swap site |
| `src/xrGame/stalker_combat_planner.h` | decl (+1) |
| `src/xrGame/stalker_combat_planner.cpp` | override firing the functor (+14) |
| `gamedata/scripts/callbacks_gameobject.script` | AddScriptCallback forwarder (+13) |

33 lines added, 1 changed.

## Lua usage

```lua
RegisterScriptCallback("npc_on_combat_action_switch", function(npc, from, to, flags)
    -- commit the current action: suppress the cover<->lookout oscillation only
    if (from == stalker_ids.action_take_cover and to == stalker_ids.action_look_out)
    or (from == stalker_ids.action_look_out and to == stalker_ids.action_take_cover) then
        flags.allow = false
    end
end)
```

## Testing

Tested in-game on a DX11 build of this branch. A subscriber denied every proposed switch for one fighting NPC for 25 seconds: the log shows 183 proposals and 58 held denials, the vetoed NPC never changed action while held, and it went back to normal switching after release. A second subscriber on `npc_on_combat_action_changed` stayed silent during the held denials and fired for the transitions that actually happened. No crash.
