### PR TITLE
feat(ai): bind can_kill_enemy/member and fire_make_sense fire gates

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -629,6 +629,9 @@
         function memory_remove_links(game_object)
         function get_object_visible_distance(game_object)
         function get_object_luminocity(game_object)
+        bool can_kill_enemy() // Engine posture-aware shot clearance: fire-point ray (with safety-angle probes) reaches the NPC's current selected enemy. False when no weapon is out. At most one recompute per frame (shared cache with the engine friendly-fire gate).
+        bool can_kill_member() // As can_kill_enemy but true when the ray would hit a squad member (friendly fire). False when no weapon is out.
+        bool fire_make_sense() // Engine fire-discipline gate for the current selected enemy: occlusion before target (pick_distance + ai_fire_range_extension), floor gap (ai_fire_max_height_diff), point-blank (ai_fire_min_dist), unseen enemy only within ai_fire_make_sense_interval and with an automatic weapon.
         bool affect_cover() // Returns true when the NPC considers itself in a tactically covered position (physically arrived at cover). Set by combat actions, reset on action transition. Use in BeforeHitCallback to detect hits in the open.
         void best_cover_invalidate() // Forces the NPC to re-evaluate its best cover point on the next tick. Call after affect_cover() returns false on a hit to make the NPC seek new cover.
         string rank_name() // Returns rank id string from CharacterInfo: "novice", "experienced", "veteran", "master", "expert". More reliable than rank() since raw integer thresholds vary per modpack.

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -837,6 +837,10 @@ public:
 	void sniper_fire_mode(bool value);
 	bool sniper_fire_mode() const;
 
+	bool can_kill_enemy();
+	bool can_kill_member();
+	bool fire_make_sense();
+
 	void aim_bone_id(LPCSTR value);
 	LPCSTR aim_bone_id() const;
 

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -1916,6 +1916,53 @@ bool CScriptGameObject::sniper_fire_mode() const
 	return (stalker->sniper_fire_mode());
 }
 
+bool CScriptGameObject::can_kill_enemy()
+{
+	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());
+	if (!stalker)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CAI_Stalker : cannot access class member can_kill_enemy!");
+		return (false);
+	}
+
+	// Callable from script at any time; the engine's own readers (CObjectActionFire) only run
+	// with a weapon out. No active item = no fire point, so no shot clearance to compute.
+	if (!stalker->inventory().ActiveItem())
+		return (false);
+
+	return (stalker->can_kill_enemy());
+}
+
+bool CScriptGameObject::can_kill_member()
+{
+	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());
+	if (!stalker)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CAI_Stalker : cannot access class member can_kill_member!");
+		return (false);
+	}
+
+	if (!stalker->inventory().ActiveItem())
+		return (false);
+
+	return (stalker->can_kill_member());
+}
+
+bool CScriptGameObject::fire_make_sense()
+{
+	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());
+	if (!stalker)
+	{
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CAI_Stalker : cannot access class member fire_make_sense!");
+		return (false);
+	}
+
+	return (stalker->fire_make_sense());
+}
+
 void CScriptGameObject::aim_bone_id(LPCSTR bone_id)
 {
 	CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(&object());

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -455,6 +455,10 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("sniper_fire_mode", SAFE_WRAP((void (CScriptGameObject::*)(bool))&CScriptGameObject::sniper_fire_mode))
 		.def("sniper_fire_mode", SAFE_WRAP((bool (CScriptGameObject::*)() const)&CScriptGameObject::sniper_fire_mode))
 
+		.def("can_kill_enemy", SAFE_WRAP(&CScriptGameObject::can_kill_enemy))
+		.def("can_kill_member", SAFE_WRAP(&CScriptGameObject::can_kill_member))
+		.def("fire_make_sense", SAFE_WRAP(&CScriptGameObject::fire_make_sense))
+
 		.def("aim_bone_id", SAFE_WRAP((void (CScriptGameObject::*)(LPCSTR))&CScriptGameObject::aim_bone_id))
 		.def("aim_bone_id", SAFE_WRAP((LPCSTR (CScriptGameObject::*)() const)&CScriptGameObject::aim_bone_id))
 


### PR DESCRIPTION
## Summary

Binds the three `CAI_Stalker` fire-decision reads as `CScriptGameObject` methods:

- `npc:can_kill_enemy()` / `npc:can_kill_member()` — the engine's posture-aware shot clearance (fire-point ray with safety-angle probes toward the current selected enemy / squad members, `update_can_kill_info`, `ai_stalker_fire.cpp:802-823`).
- `npc:fire_make_sense()` — the fire-discipline gate: occlusion before target (`pick_distance` + `ai_fire_range_extension`), floor gap (`ai_fire_max_height_diff`), point-blank (`ai_fire_min_dist`), and unseen-enemy suppression only within `ai_fire_make_sense_interval` with an automatic weapon.

## Use cases

A script combat overlay that blocks `action_combat_planner` via a GOAP precondition (the standard takeover pattern) loses these gates and has nothing equivalent. A coarse chest-to-chest raycast cannot tell a wall the round hits from a window or railing the round passes, so overlays either shoot into geometry the engine would refuse, or fire through floors and at point-blank. With the engine's own reads bound, an overlay can gate fire the way vanilla does.

## Performance

`can_kill_*` recompute is frame-guarded by `m_pick_frame_id`: at most one 5-raycast clearance per NPC per frame, and the cache is shared with the engine's own friendly-fire gate (`CObjectActionFire`, `object_actions.cpp:234-264`), so a script call on a frame where the engine already computed it is a field read. `fire_make_sense` is interval-guarded internally. All three are decision-point getters; nothing runs per frame.

## Constraints

Both `can_kill_*` wrappers return `false` when the NPC has no active inventory item. The engine methods `VERIFY(ActiveItem())` and would otherwise compute a ray from `Position()` along (0,0,1) through the null `g_fireParams` path (`ai_stalker_fire.cpp:148-156`); engine readers only run with a weapon out, so only script callers could reach that. The guard makes the binds safe to call at any time. `fire_make_sense` needs no guard because `pick_distance` checks `ActiveItem` itself. All three read the NPC's current selected enemy and sight — they take no position argument.

## Files changed

| File | Change |
|---|---|
| `src/xrGame/script_game_object_inventory_owner.cpp` | 3 wrappers (+47) |
| `src/xrGame/script_game_object.h` | decls (+4) |
| `src/xrGame/script_game_object_script3.cpp` | defs (+4) |
| `gamedata/scripts/lua_help_ex.script` | 3 manifest entries |

58 lines added.

## Lua usage

```lua
-- overlay fire decision: shoot only when the engine would
if npc:fire_make_sense() and npc:can_kill_enemy() and not npc:can_kill_member() then
    -- issue fire state
end
```

## Testing

Tested in-game on a DX11 build of this branch. I logged all three gates once per second for a fighting NPC across several firefights: the values follow cover and line of sight, and each gate shows both true and false over time. Calling all three on a holstered camp NPC returns false for each, with no crash and no assert.
