### PR TITLE
Add new Cvar pseudogiant_dodge_stomp_while_falling

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -1149,6 +1149,9 @@
 	<string id="ui_mm_modded_exes_gameplay_monsters_pseudogiant_can_damage_objects_on_stomp">
 		<text>Pseudogiant Damage Objects On Stomp (pseudogiant_can_damage_objects_on_stomp)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_monsters_pseudogiant_dodge_stomp_while_falling">
+		<text>Dodge Pseudogiant Stomp While Falling (pseudogiant_dodge_stomp_while_falling)</text>
+	</string>
 	<string id="ui_mm_modded_exes_gameplay_monsters_telekinetic_objects_include_corpses">
 		<text>Poltergeists and Burers throw Corpses (telekinetic_objects_include_corpses)</text>
 	</string>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -1149,7 +1149,7 @@
 		<text>Псевдогигант повреждает объекты при топоте (pseudogiant_can_damage_objects_on_stomp)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_monsters_pseudogiant_dodge_stomp_while_falling">
-		<text>Уклонение от атаки псевдогиганта в падении (pseudogiant_dodge_stomp_while_falling)</text>
+		<text>Уклонение от хлопка псевдогиганта в падении (pseudogiant_dodge_stomp_while_falling)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_monsters_telekinetic_objects_include_corpses">
 		<text>Полтеры и бюреры кидают трупы (telekinetic_objects_include_corpses)</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -1148,6 +1148,9 @@
 	<string id="ui_mm_modded_exes_gameplay_monsters_pseudogiant_can_damage_objects_on_stomp">
 		<text>Псевдогигант повреждает объекты при топоте (pseudogiant_can_damage_objects_on_stomp)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_monsters_pseudogiant_dodge_stomp_while_falling">
+		<text>Уклонение от атаки псевдогиганта в падении (pseudogiant_dodge_stomp_while_falling)</text>
+	</string>
 	<string id="ui_mm_modded_exes_gameplay_monsters_telekinetic_objects_include_corpses">
 		<text>Полтеры и бюреры кидают трупы (telekinetic_objects_include_corpses)</text>
 	</string>

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -10,6 +10,8 @@
 
         pseudogiant_can_damage_objects_on_stomp [0; 1] // Enable the ability for pseudogiants to damage objects on stomp
 
+        pseudogiant_dodge_stomp_while_falling [0; 1] // Prevent pseudogiants stomp attack from damaging actor if they are falling
+
         telekinetic_objects_include_corpses [0; 1] // Enable the ability for poltergeists and burers to throw corpses
         
         sds_enable [0; 1] // Enable shader based scopes

--- a/gamedata/scripts/options_modded_exes_monsters.script
+++ b/gamedata/scripts/options_modded_exes_monsters.script
@@ -7,6 +7,7 @@ PAGE = page {
 	{ id = "monsters" },
 	list_bool { id = "heat_vision_zombie_cold" },
 	list_bool { id = "pseudogiant_can_damage_objects_on_stomp" },
+	list_bool { id = "pseudogiant_dodge_stomp_while_falling" },
 	list_bool { id = "telekinetic_objects_include_corpses" },
 	list_bool {
 		id = "monster_stuck_fix",

--- a/src/xrGame/ai/monsters/pseudogigant/pseudo_gigant.cpp
+++ b/src/xrGame/ai/monsters/pseudogigant/pseudo_gigant.cpp
@@ -24,6 +24,8 @@
 // demonized: Flag for damaging NPCs and other objects by the stomp attack
 BOOL pseudogiantCanDamageObjects = 1;
 
+// Verdatim: Flag for allowing falling state to count for dodging Earthquake ability 
+BOOL pseudogiantDodgeWhileFalling = 0;
 
 CPseudoGigant::CPseudoGigant()
 {
@@ -373,6 +375,7 @@ void CPseudoGigant::on_threaten_execute()
 	CActor* pA = const_cast<CActor *>(smart_cast<const CActor *>(EnemyMan.get_enemy()));
 	if (!pA) return;
 	if ((pA->MovingState() & ACTOR_DEFS::mcJump) != 0) return;
+    if (pseudogiantDodgeWhileFalling && (pA->MovingState() & ACTOR_DEFS::mcFall) != 0) return;
 
 	float dist_to_enemy = pA->Position().distance_to(Position());
 	float hit_value;

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -136,6 +136,8 @@ extern BOOL g_allow_silencer_hide_tracer;
 extern int showActorBody; //leer
 extern BOOL disableActorBodyRotationDelay; //leer
 
+extern BOOL pseudogiantDodgeWhileFalling; // Verdatim
+
 //demonized: new console vars
 extern BOOL firstPersonDeath;
 extern BOOL pseudogiantCanDamageObjects;
@@ -3068,6 +3070,8 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "binoculars_dynamic_zoom_check", &binoculars_dynamic_zoom_check, 0, 1); //VodoXleb
 
 	CMD4(CCC_Integer, "pseudogiant_can_damage_objects_on_stomp", &pseudogiantCanDamageObjects, 0, 1);
+
+    CMD4(CCC_Integer, "pseudogiant_dodge_stomp_while_falling", &pseudogiantDodgeWhileFalling, 0, 1); // Verdatim
 
 	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
 


### PR DESCRIPTION
Adds new Cvar "pseudogiant_dodge_stomp_while_falling"
Adds one more check to prevent pseudogiant stomp attack from landing if actor is in fall state and Cvar is enabled
The Cvar is off by default.
I dont know russian so russian translation was not by me, it was instead by Google Translate. I'd appreciate if someone checked if it is sensible, thanks!