### PR TITLE
NPC weapon reload event callbacks (npc_on_weapon_reload_start/stop)

### DIFF
--- a/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/scripts/callbacks_gameobject.script
@@ -391,6 +391,23 @@ _G.CAI_Stalker__OnWeaponShotStop = function(npc)
 	SendScriptCallback("npc_on_weapon_shot_stop", npc)
 end
 
+-- NPC weapon reload start callback. Fires when a stalker's weapon enters the reload state, on every
+-- reload path (planner reload, scripted state, tri-state shotgun shell loading, misfire clear).
+-- The actor is excluded: actor reloads already fire actor_on_weapon_reload.
+AddScriptCallback("npc_on_weapon_reload_start")
+_G.CAI_Stalker__OnWeaponReloadStart = function(npc, weapon)
+	SendScriptCallback("npc_on_weapon_reload_start", npc, weapon)
+end
+
+-- NPC weapon reload stop callback. Fires when the weapon leaves the reload state for any reason
+-- (finished, interrupted by a weapon or state switch). Best-effort: a weapon detached mid-reload
+-- (owner died, weapon dropped) has no stalker parent and fires nothing - where the truth matters,
+-- poll wpn:get_state() == 7 (CWeapon::eReload; eFire=5, eFire2=6, eReload=7 from eLastBaseState=4).
+AddScriptCallback("npc_on_weapon_reload_stop")
+_G.CAI_Stalker__OnWeaponReloadStop = function(npc, weapon)
+	SendScriptCallback("npc_on_weapon_reload_stop", npc, weapon)
+end
+
 -- NPC grenade throw gate. Return false to prevent the throw. Use npc:rank_name() to scale by rank
 -- Note: only fires when throw trajectory is clear, after engine validity checks pass
 AddScriptCallback("npc_on_should_throw")

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -935,6 +935,8 @@
 
 		// Forcibly set the zoom type for the weapon
 		function ForceSetZoomType(float)
+
+        callbacks (see callbacks_gameobject.script): npc_on_weapon_reload_start, npc_on_weapon_reload_stop -- (npc, wpn), fired on a stalker's weapon entering/leaving the reload state; actor reloads fire actor_on_weapon_reload instead
     }
 
     class CWeaponKnife : CWeapon {

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -37,6 +37,7 @@
 #include "../Layers/xrRender/xrRender_console.h"
 #include "pch_script.h"
 #include "script_game_object.h"
+#include "ai/stalker/ai_stalker.h"
 
 #define WEAPON_REMOVE_TIME		60000
 #define ROTATION_TIME			0.25f
@@ -3148,6 +3149,26 @@ void CWeapon::OnStateSwitch(u32 S, u32 oldState)
 {
 	inherited::OnStateSwitch(S, oldState);
 	m_BriefInfo_CalcFrame = 0;
+
+	// NPC reload edges for Lua (npc_on_weapon_reload_start / _stop). Actor reloads already surface
+	// through the actor binder callback (actor_on_weapon_reload); a stalker's reload was observable
+	// only by polling get_state() == eReload per tick. Fired here because every weapon type converges
+	// on CWeapon::OnStateSwitch - the tri-state shotgun path skips CWeaponMagazined's override for
+	// S == eReload. Best-effort stop edge: a weapon detached mid-reload (death, drop) loses its
+	// stalker parent and fires nothing - get_state() stays the authoritative read.
+	if (S != oldState && (S == eReload || oldState == eReload))
+	{
+		CAI_Stalker* stalker = smart_cast<CAI_Stalker*>(H_Parent());
+		if (stalker)
+		{
+			::luabind::functor<void> funct;
+			LPCSTR fname = (S == eReload)
+				? "_G.CAI_Stalker__OnWeaponReloadStart"
+				: "_G.CAI_Stalker__OnWeaponReloadStop";
+			if (ai().script_engine().functor(fname, funct))
+				funct(stalker->lua_game_object(), lua_game_object());
+		}
+	}
 
 	if (GetState() == eReload)
 	{


### PR DESCRIPTION
## Summary
Adds a Lua event pair for NPC weapon reloads: `npc_on_weapon_reload_start(npc, wpn)` when a stalker's weapon enters the reload state and `npc_on_weapon_reload_stop(npc, wpn)` when it leaves it, mirroring the existing `npc_on_weapon_shot_start` / `npc_on_weapon_shot_stop` pair. The actor already surfaces reloads through the actor binder (`actor_on_weapon_reload`); a stalker's reload was observable only by polling `wpn:get_state() == CWeapon::eReload` per NPC per tick.

The fire site is `CWeapon::OnStateSwitch`, not `CWeaponMagazined::OnStateSwitch`, because every weapon type converges there: the tri-state shotgun override (`CWeaponShotgun::OnStateSwitch`) skips the magazined override entirely for `S == eReload` and calls `CWeapon::OnStateSwitch` directly, so a hook one level down would miss shotgun reload starts. Guarded on `S != oldState` (same-state re-switches, e.g. the shotgun shell cycle inside eReload, fire nothing) and on the parent being a `CAI_Stalker`.

The engine changes no behavior; only a subscriber makes the event do anything.

## Use cases
A combat-AI mod repositions an NPC caught reloading under fire to cover (the engine finishes the reload on its own timer during the move), biases aggression while an enemy is inside its ~2s reload window, or replaces its per-tick `get_state()` reload polling with the exact edges.

## Caveats
The stop edge is best-effort: a weapon detached mid-reload (owner died, weapon dropped) has no stalker parent at the switch, so nothing fires. Where the truth matters, `wpn:get_state()` stays the authoritative read; the events are the cheap edge signal.

## Cost
Two integer compares per weapon state switch. The functor lookup runs only on the two reload edges, which are rare, discrete events. No per-frame work.

## Tested
Built locally on all-in-one-vs2022-wpo (DX11, 0 errors). Edge coverage verified against source for the magazined path (`CWeaponMagazined::OnStateSwitch` -> inherited) and the tri-state shotgun path (`CWeaponShotgun::OnStateSwitch` -> `CWeapon::OnStateSwitch` for eReload).

## Files changed
- src/xrGame/Weapon.cpp: reload-edge functor calls in `CWeapon::OnStateSwitch` (+1 include)
- gamedata/scripts/callbacks_gameobject.script: AddScriptCallback + forwarders for both edges
- gamedata/scripts/lua_help_ex.script: callbacks entry in the CWeapon block

## Lua usage
    RegisterScriptCallback("npc_on_weapon_reload_start", function(npc, wpn)
        -- reloading under fire: reposition to cover
    end)
    RegisterScriptCallback("npc_on_weapon_reload_stop", function(npc, wpn)
        -- reload window closed
    end)
