### PR TITLE
Script Driven Freecam [Regular]

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -374,6 +374,12 @@
         void set_cam_custom_position_direction(Fvector position, Fvector direction)
         void remove_cam_custom_position_direction()
 
+        // Fov override in degrees, clamped to the fov cvar range, applies to the active FPCam
+        // remove_cam_custom_position_direction also resets this since it destroys the effector
+        void set_cam_custom_fov(float fovDeg)
+        void remove_cam_custom_fov()
+        bool is_cam_custom_active()
+
         // Removes all engine-spawned per-animation HUD camera effectors
         // Scripted effectors added via add_cam_effector are not touched.
         void remove_hud_motion_cam_effectors()

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -388,6 +388,10 @@
         Fvector get_cam_custom_position()
         Fvector get_cam_custom_direction()
 
+        // Pin holds the viewmodel at the base pose captured on enable, weapon and hands go stationary, pin wins over hud affect
+        // Holds while the FPCam lives, disable clears it so a later enable recaptures, no-op without an active FPCam
+        void set_cam_custom_hud_pin(bool enable)
+
         // Removes all engine-spawned per-animation HUD camera effectors
         // Scripted effectors added via add_cam_effector are not touched.
         void remove_hud_motion_cam_effectors()

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -373,12 +373,20 @@
         void set_cam_custom_position_direction(Fvector position, Fvector direction, int smoothing)
         void set_cam_custom_position_direction(Fvector position, Fvector direction)
         void remove_cam_custom_position_direction()
+        // Smoothed release, hands the camera back to the base pose over smoothing ema steps then self-removes
+        void remove_cam_custom_position_direction(float smoothing)
 
         // Fov override in degrees, clamped to the fov cvar range, applies to the active FPCam
         // remove_cam_custom_position_direction also resets this since it destroys the effector
         void set_cam_custom_fov(float fovDeg)
         void remove_cam_custom_fov()
         bool is_cam_custom_active()
+
+        // Exclusive positioning pushes the FPCam to the back of the effector list, applied live
+        void set_cam_custom_exclusive(bool exclusive)
+        // Current FPCam target pose, pair with is_cam_custom_active, zero vectors when inactive
+        Fvector get_cam_custom_position()
+        Fvector get_cam_custom_direction()
 
         // Removes all engine-spawned per-animation HUD camera effectors
         // Scripted effectors added via add_cam_effector are not touched.

--- a/src/xrEngine/CameraManager.cpp
+++ b/src/xrEngine/CameraManager.cpp
@@ -240,6 +240,22 @@ void CCameraManager::RemoveCamEffector(CEffectorCam* ef)
 	}
 }
 
+void CCameraManager::RepositionCamEffector(CEffectorCam* ef)
+{
+	for (EffectorCamIt it = m_EffectorsCam.begin(); it != m_EffectorsCam.end(); it++)
+	{
+		if (*it == ef)
+		{
+			m_EffectorsCam.erase(it);
+			if (ef->AbsolutePositioning())
+				m_EffectorsCam.push_front(ef);
+			else
+				m_EffectorsCam.push_back(ef);
+			return;
+		}
+	}
+}
+
 void CCameraManager::RemoveHudMotionEffectors()
 {
 	for (EffectorCamIt it = m_EffectorsCam.begin(); it != m_EffectorsCam.end();)

--- a/src/xrEngine/CameraManager.h
+++ b/src/xrEngine/CameraManager.h
@@ -157,6 +157,9 @@ public:
 	// demonized: removecameffector by pointer
 	void RemoveCamEffector(CEffectorCam* ef);
 
+	// move a live effector between front and back per its AbsolutePositioning without releasing it
+	void RepositionCamEffector(CEffectorCam* ef);
+
 	void RemoveHudMotionEffectors();
 
 	ECamEffectorType RequestCamEffectorId();

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -3055,11 +3055,18 @@ void CActor::initFPCam()
 {
 	if (!m_FPCam) {
 		m_FPCam = xr_new<CFPCamEffector>();
+		m_FPCam->m_on_b_remove_callback = SBaseEffector::CB_ON_B_REMOVE(this, &CActor::OnFPCamReleased);
 		Cameras().AddCamEffector(m_FPCam);
 	}
 }
 
-void CActor::removeFPCam() 
+// clears the dangling pointer when the effector self-removes during a smoothed release
+void CActor::OnFPCamReleased()
+{
+	m_FPCam = NULL;
+}
+
+void CActor::removeFPCam()
 {
 	if (m_FPCam) {
 		Cameras().RemoveCamEffector(m_FPCam);

--- a/src/xrGame/Actor.h
+++ b/src/xrGame/Actor.h
@@ -96,6 +96,7 @@ public:
 public:
 	void initFPCam();
 	void removeFPCam();
+	void OnFPCamReleased();
 
 public:
 	virtual BOOL AlwaysTheCrow() { return TRUE; }

--- a/src/xrGame/ActorEffector.cpp
+++ b/src/xrGame/ActorEffector.cpp
@@ -6,6 +6,7 @@
 #include "../xrEngine/ObjectAnimator.h"
 #include "object_broker.h"
 #include "actor.h"
+#include "EffectorBobbing.h"
 
 void AddEffector(CActor* A, int type, const shared_str& sect_name)
 {
@@ -464,7 +465,24 @@ bool similar_cam_info(const SCamEffectorInfo& c1, const SCamEffectorInfo& c2)
 void CActorCameraManager::UpdateCamEffectors()
 {
 	m_cam_info_hud = m_cam_info;
+
+	// hud pin freezes the viewmodel anchor while this actor FPCam is live and pinned
+	CActor* pin_actor = Actor();
+	CFPCamEffector* pin_cam = (pin_actor && &pin_actor->Cameras() == this) ? pin_actor->m_FPCam : NULL;
+	const bool hud_pinned = pin_cam && pin_cam->m_hud_pin;
+	if (hud_pinned && !pin_cam->m_hud_pin_captured)
+	{
+		pin_cam->m_hud_pin_pose = m_cam_info_hud;
+		pin_cam->m_hud_pin_captured = true;
+	}
+	// hold the pose by value, the effector can free itself inside the update
+	SCamEffectorInfo hud_pin_pose = hud_pinned ? pin_cam->m_hud_pin_pose : m_cam_info_hud;
+
 	inherited::UpdateCamEffectors();
+
+	// pin wins over hud affect deltas so the frozen anchor holds
+	if (hud_pinned)
+		m_cam_info_hud = hud_pin_pose;
 
 	m_cam_info_hud.d.normalize();
 	m_cam_info_hud.n.normalize();

--- a/src/xrGame/EffectorBobbing.cpp
+++ b/src/xrGame/EffectorBobbing.cpp
@@ -122,6 +122,7 @@ CFPCamEffector::CFPCamEffector() : CEffectorCam(eCEUser, INT_MAX) {
 	m_Position.set(0, 0, 0);
 	m_customSmoothing = 0;
 	hudEnabled = false;
+	m_fov = -1.0f;
 }
 
 // EMA smoothing for changing values, frame independent
@@ -171,5 +172,9 @@ BOOL CFPCamEffector::ProcessCam(SCamEffectorInfo& info)
 	info.n.set(m_Camera.j);
 	info.d.set(m_Camera.k);
 	info.p.set(m_Camera.c);
+
+	if (m_fov > 0.0f)
+		info.fFov = m_fov;
+
 	return TRUE;
 }

--- a/src/xrGame/EffectorBobbing.cpp
+++ b/src/xrGame/EffectorBobbing.cpp
@@ -125,6 +125,8 @@ CFPCamEffector::CFPCamEffector() : CEffectorCam(eCEUser, INT_MAX) {
 	m_fov = -1.0f;
 	m_exclusive = false;
 	m_releasing = false;
+	m_hud_pin = false;
+	m_hud_pin_captured = false;
 }
 
 // EMA smoothing for changing values, frame independent

--- a/src/xrGame/EffectorBobbing.cpp
+++ b/src/xrGame/EffectorBobbing.cpp
@@ -123,6 +123,8 @@ CFPCamEffector::CFPCamEffector() : CEffectorCam(eCEUser, INT_MAX) {
 	m_customSmoothing = 0;
 	hudEnabled = false;
 	m_fov = -1.0f;
+	m_exclusive = false;
+	m_releasing = false;
 }
 
 // EMA smoothing for changing values, frame independent
@@ -147,9 +149,16 @@ void CFPCamEffector::ema(Fvector &current, Fvector &target, unsigned int steps) 
 
 BOOL CFPCamEffector::ProcessCam(SCamEffectorInfo& info)
 {
-	// Set target camera
+	// Target camera, normal mode drives to the scripted pose, releasing mode drives to the incoming base pose
 	Fmatrix temp;
-	temp.identity().setHPB(m_HPB.x, m_HPB.y, m_HPB.z).translate_over(m_Position);
+	if (m_releasing) {
+		temp.identity();
+		temp.j.set(info.n);
+		temp.k.set(info.d);
+		temp.c.set(info.p);
+	} else {
+		temp.identity().setHPB(m_HPB.x, m_HPB.y, m_HPB.z).translate_over(m_Position);
+	}
 
 	// Smooth out transition between current camera and target
 	if (m_customSmoothing) {
@@ -175,6 +184,13 @@ BOOL CFPCamEffector::ProcessCam(SCamEffectorInfo& info)
 
 	if (m_fov > 0.0f)
 		info.fFov = m_fov;
+
+	// Self-remove once the released camera has converged onto the base pose
+	if (m_releasing &&
+		m_Camera.c.similar(temp.c) &&
+		m_Camera.k.similar(temp.k) &&
+		m_Camera.j.similar(temp.j))
+		return FALSE;
 
 	return TRUE;
 }

--- a/src/xrGame/EffectorBobbing.h
+++ b/src/xrGame/EffectorBobbing.h
@@ -43,10 +43,12 @@ public:
 	Fmatrix m_Camera;
 	bool hudEnabled = false;
 	unsigned int m_customSmoothing; // 0 - use FPDeath smoothing params, no custom smoothing
+	float m_fov; // <=0 no override, mirrors CAnimatorCamEffector fov
 	virtual void ema(Fvector& current, Fvector& target, unsigned int steps);
-	
+
 public:
 	CFPCamEffector();
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
+	void SetFov(float val) { m_fov = val; }
 
 };

--- a/src/xrGame/EffectorBobbing.h
+++ b/src/xrGame/EffectorBobbing.h
@@ -46,6 +46,9 @@ public:
 	float m_fov; // <=0 no override, mirrors CAnimatorCamEffector fov
 	bool m_exclusive; // true pushes the effector to the back of the list for exclusive positioning
 	bool m_releasing; // smoothed handoff to the base pose then self-remove
+	bool m_hud_pin; // freezes the viewmodel anchor at a captured base pose while true
+	bool m_hud_pin_captured; // set once the manager snapshots the base pose
+	SCamEffectorInfo m_hud_pin_pose; // held hud pose reapplied every pinned frame
 	virtual void ema(Fvector& current, Fvector& target, unsigned int steps);
 
 public:

--- a/src/xrGame/EffectorBobbing.h
+++ b/src/xrGame/EffectorBobbing.h
@@ -44,11 +44,14 @@ public:
 	bool hudEnabled = false;
 	unsigned int m_customSmoothing; // 0 - use FPDeath smoothing params, no custom smoothing
 	float m_fov; // <=0 no override, mirrors CAnimatorCamEffector fov
+	bool m_exclusive; // true pushes the effector to the back of the list for exclusive positioning
+	bool m_releasing; // smoothed handoff to the base pose then self-remove
 	virtual void ema(Fvector& current, Fvector& target, unsigned int steps);
 
 public:
 	CFPCamEffector();
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
+	virtual bool AbsolutePositioning() { return m_exclusive; }
 	void SetFov(float val) { m_fov = val; }
 
 };

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -887,6 +887,9 @@ bool getCamEffectorTransformData(::luabind::object& t, LPCSTR animationFile)
 // demonized: Set custom camera position and direction with movement smoothing (for cutscenes, etc)
 void set_cam_position_direction(Fvector& position, Fvector& direction, unsigned int smoothing, bool hudEnabled, bool hudAffect)
 {
+	if (!g_pGameLevel || !Actor())
+		return;
+
 	CActor* actor = Actor();
 	actor->initFPCam();
 	actor->m_FPCam->m_HPB.set(direction);
@@ -894,6 +897,7 @@ void set_cam_position_direction(Fvector& position, Fvector& direction, unsigned 
 	actor->m_FPCam->m_customSmoothing = _max(1, smoothing);
 	actor->m_FPCam->hudEnabled = hudEnabled;
 	actor->m_FPCam->SetHudAffect(hudAffect);
+	actor->m_FPCam->m_releasing = false;
 }
 
 void set_cam_position_direction(Fvector& position, Fvector& direction)
@@ -911,10 +915,27 @@ void set_cam_position_direction(Fvector& position, Fvector& direction, unsigned 
 	set_cam_position_direction(position, direction, smoothing, hudEnabled, false);
 }
 
-void remove_cam_position_direction() 
+void remove_cam_position_direction()
 {
+	if (!g_pGameLevel || !Actor())
+		return;
+
 	CActor* actor = Actor();
 	actor->removeFPCam();
+}
+
+// Smoothed release, hands the camera back to the base pose over smoothing ema steps then self-removes
+void remove_cam_position_direction(float smoothing)
+{
+	if (!g_pGameLevel || !Actor())
+		return;
+
+	CActor* actor = Actor();
+	if (!actor->m_FPCam)
+		return;
+
+	actor->m_FPCam->m_customSmoothing = _max(1, (unsigned int)smoothing);
+	actor->m_FPCam->m_releasing = true;
 }
 
 // fov clamp bounds match the fov console command, console_commands.cpp line 2664
@@ -951,6 +972,40 @@ bool is_cam_custom_active()
 {
 	CActor* actor = Actor();
 	return actor && actor->m_FPCam;
+}
+
+// Toggle exclusive positioning, when it flips on a live effector reposition it in the manager list
+void set_cam_custom_exclusive(bool exclusive)
+{
+	if (!g_pGameLevel || !Actor())
+		return;
+
+	CActor* actor = Actor();
+	if (!actor->m_FPCam || actor->m_FPCam->m_exclusive == exclusive)
+		return;
+
+	actor->m_FPCam->m_exclusive = exclusive;
+	actor->Cameras().RepositionCamEffector(actor->m_FPCam);
+}
+
+// Current FPCam target position, symmetric with the setter, zero vector when inactive
+Fvector get_cam_custom_position()
+{
+	CActor* actor = Actor();
+	if (!actor || !actor->m_FPCam)
+		return Fvector().set(0, 0, 0);
+
+	return actor->m_FPCam->m_Position;
+}
+
+// Current FPCam target head/pitch/roll, symmetric with the setter, zero vector when inactive
+Fvector get_cam_custom_direction()
+{
+	CActor* actor = Actor();
+	if (!actor || !actor->m_FPCam)
+		return Fvector().set(0, 0, 0);
+
+	return actor->m_FPCam->m_HPB;
 }
 
 void remove_cam_effector(int id)
@@ -2625,12 +2680,16 @@ void CLevel::script_register(lua_State* L)
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int, bool))&set_cam_position_direction)),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int))&set_cam_position_direction)),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&))&set_cam_position_direction)),
-			def("remove_cam_custom_position_direction", &remove_cam_position_direction),
+			def("remove_cam_custom_position_direction", ((void (*)())&remove_cam_position_direction)),
+			def("remove_cam_custom_position_direction", ((void (*)(float))&remove_cam_position_direction)),
 
 			// Override fov on the active FPCam effector, <=0 clears it
 			def("set_cam_custom_fov", &set_cam_custom_fov),
 			def("remove_cam_custom_fov", &remove_cam_custom_fov),
 			def("is_cam_custom_active", &is_cam_custom_active),
+			def("set_cam_custom_exclusive", &set_cam_custom_exclusive),
+			def("get_cam_custom_position", &get_cam_custom_position),
+			def("get_cam_custom_direction", &get_cam_custom_direction),
 
 			def("remove_cam_effector", &remove_cam_effector),
 			def("set_cam_effector_factor", &set_cam_effector_factor),

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1008,6 +1008,19 @@ Fvector get_cam_custom_direction()
 	return actor->m_FPCam->m_HPB;
 }
 
+// Pin freezes the viewmodel anchor at the base pose captured on enable, pin wins over hud affect motion
+// disabling clears the capture so a later enable snapshots fresh, no-op without an active FPCam
+void set_cam_custom_hud_pin(bool enable)
+{
+	CActor* actor = Actor();
+	if (!actor || !actor->m_FPCam)
+		return;
+
+	actor->m_FPCam->m_hud_pin = enable;
+	if (!enable)
+		actor->m_FPCam->m_hud_pin_captured = false;
+}
+
 void remove_cam_effector(int id)
 {
 	Actor()->Cameras().RemoveCamEffector((ECamEffectorType)id);
@@ -2690,6 +2703,7 @@ void CLevel::script_register(lua_State* L)
 			def("set_cam_custom_exclusive", &set_cam_custom_exclusive),
 			def("get_cam_custom_position", &get_cam_custom_position),
 			def("get_cam_custom_direction", &get_cam_custom_direction),
+			def("set_cam_custom_hud_pin", &set_cam_custom_hud_pin),
 
 			def("remove_cam_effector", &remove_cam_effector),
 			def("set_cam_effector_factor", &set_cam_effector_factor),

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -917,6 +917,42 @@ void remove_cam_position_direction()
 	actor->removeFPCam();
 }
 
+// fov clamp bounds match the fov console command, console_commands.cpp line 2664
+const float g_cam_custom_fov_min = 5.0f;
+const float g_cam_custom_fov_max = 180.0f;
+
+// Override fov on the active FPCam effector, <=0 clears it
+void set_cam_custom_fov(float fov)
+{
+	CActor* actor = Actor();
+	if (!actor || !actor->m_FPCam)
+		return;
+
+	if (fov <= 0.0f)
+	{
+		actor->m_FPCam->SetFov(-1.0f);
+		return;
+	}
+
+	clamp(fov, g_cam_custom_fov_min, g_cam_custom_fov_max);
+	actor->m_FPCam->SetFov(fov);
+}
+
+void remove_cam_custom_fov()
+{
+	CActor* actor = Actor();
+	if (!actor || !actor->m_FPCam)
+		return;
+
+	actor->m_FPCam->SetFov(-1.0f);
+}
+
+bool is_cam_custom_active()
+{
+	CActor* actor = Actor();
+	return actor && actor->m_FPCam;
+}
+
 void remove_cam_effector(int id)
 {
 	Actor()->Cameras().RemoveCamEffector((ECamEffectorType)id);
@@ -2590,6 +2626,11 @@ void CLevel::script_register(lua_State* L)
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int))&set_cam_position_direction)),
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&))&set_cam_position_direction)),
 			def("remove_cam_custom_position_direction", &remove_cam_position_direction),
+
+			// Override fov on the active FPCam effector, <=0 clears it
+			def("set_cam_custom_fov", &set_cam_custom_fov),
+			def("remove_cam_custom_fov", &remove_cam_custom_fov),
+			def("is_cam_custom_active", &is_cam_custom_active),
 
 			def("remove_cam_effector", &remove_cam_effector),
 			def("set_cam_effector_factor", &set_cam_effector_factor),


### PR DESCRIPTION
## Free camera lua exports

Adds a script-driven free camera as an `AbsolutePositioning` cam effector
(`SetHudAffect(false)`, so the viewmodel and hud camera stay untouched), plus
five global lua exports:

- `freecam_set(px, py, pz, dx, dy, dz)` -take over the camera; absolute position + direction, zero roll
- `freecam_release()` -hand the camera back to the game
- `freecam_active()` -true while the free camera is driving the view
- `freecam_set_fov(deg)` -FOV override while active; `<= 0` clears, clamped 5–180 (same bounds as the `fov` cvar)
- `freecam_set_roll(deg)` -roll applied to the camera basis, reset on release

The effector is owned by the actor's camera manager (no cached pointers, safe
across level changes), logs `[freecam] activated/released`, and touches nothing
until a script calls it. Exports are documented in `lua_help_ex.script`.

New files: `xrGame/freecam.h`, `xrGame/freecam.cpp`. Registered in
`console_registrator_script.cpp`; effector id `eCEFreeCam` in `CameraEffector.h`.
Built green (DX11-AVX x64/DX-11 x64) on this base.