### PR TITLE
Add an option "bullet_check_visual" in object section to validate bullet hit.

### DIFF
--- a/gamedata/scripts/ltx_help_ex.script
+++ b/gamedata/scripts/ltx_help_ex.script
@@ -3,6 +3,7 @@
 
     Objects
         ignore_collision - Objects can use "ignore_collision" in section configs to ignore collision with another objects. Can be map geometry, other physic objects, and creatures. Example: ignore_collision = map,obj,npc
+		bullet_check_visual - Bullets must both hit a bone hitbox and a triangle of the bone's visual model to register a hit.
 
     Outfits, Actor
         legs_visual - Model for first person body legs

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -727,6 +727,9 @@
         function set_bone_visible(string bone_name, bool bVisibility, bool bRecursive, bool bHud)
 
         function list_bones(bool bHud = false)
+		
+		bool GetBulletCheckVisual()
+		void SetBulletCheckVisual(bool)
 
         // HUD item fire points/bones
         Fvector hud_fire_point()

--- a/src/build_config_defines.h
+++ b/src/build_config_defines.h
@@ -49,6 +49,7 @@
 #define PROJECTOR_NEW									// Upgrade CProjector.
 #define SPATIAL_CHANGE									// Upgrade spatial and feel_vision.
 #define EXPLOSIVE_CHANGE								// Upgrade CExplosive and its relatives.
+#define CBULLETMANAGER_EX                               // Upgrade CBulletManager.
 
 /*LAYERED_SND_SHOOT by Alundaio
 When defined, it will allow you to play a group of sounds from a specified section for snd_shoot.

--- a/src/xrEngine/xr_object.cpp
+++ b/src/xrEngine/xr_object.cpp
@@ -210,6 +210,10 @@ CObject::CObject() :
 	NameSection = NULL;
 	NameVisual = NULL;
 
+#ifdef CBULLETMANAGER_EX
+    BulletCheckVisual = false;
+#endif
+
 #ifdef DEBUG
     dbg_update_shedule = u32(-1) / 2;
     dbg_update_cl = u32(-1) / 2;
@@ -242,6 +246,10 @@ void CObject::Load(LPCSTR section)
 		cNameVisual_set(tmp);
 	}
 	setVisible(false);
+
+#ifdef CBULLETMANAGER_EX
+    BulletCheckVisual = !!READ_IF_EXISTS(pSettings, r_bool, section, "bullet_check_visual", FALSE);
+#endif
 }
 
 BOOL CObject::net_Spawn(CSE_Abstract* data)

--- a/src/xrEngine/xr_object.h
+++ b/src/xrEngine/xr_object.h
@@ -241,6 +241,16 @@ public:
 public:
 	virtual Fvector get_new_local_point_on_mesh(u16& bone_id) const;
 	virtual Fvector get_last_local_point_on_mesh(Fvector const& last_point, u16 bone_id) const;
+
+#ifdef CBULLETMANAGER_EX
+protected:
+    /* Bullets also check if they hit the mesh of the viusal model, not just bone hitboxes. */
+    bool BulletCheckVisual;
+
+public:
+    bool GetBulletCheckVisual() { return BulletCheckVisual; }
+    void SetBulletCheckVisual(bool value) { BulletCheckVisual = value; }
+#endif
 };
 
 #pragma pack(pop)

--- a/src/xrGame/Level_Bullet_Manager.cpp
+++ b/src/xrGame/Level_Bullet_Manager.cpp
@@ -851,6 +851,14 @@ BOOL CBulletManager::firetrace_callback(collide::rq_result& result, LPVOID param
 	if (!kinematics)
 		return (FALSE);
 
+#ifdef CBULLETMANAGER_EX
+    if (result.O->GetBulletCheckVisual() && !bullet_manager.ValidateHitDynamicVisualMesh(bullet, result, collide_position, data.max_distance))
+    {
+        /* Ignore this hit and allow the bullet to continue flying. */
+        return TRUE;
+    }
+#endif
+
 	CBoneData const& bone_data = kinematics->LL_GetData((u16)result.element);
 	bullet_manager.RegisterEvent(EVENT_HIT, TRUE, &bullet, collide_position, result, bone_data.game_mtl_idx);
 	return (FALSE);
@@ -879,6 +887,9 @@ bool CBulletManager::trajectory_check_error(
 
 	bullet_test_callback_data data;
 	data.pBullet = &bullet;
+#ifdef CBULLETMANAGER_EX
+    data.max_distance = distance;
+#endif
 #if 1//def DEBUG
 	data.high_time = high;
 #endif // #ifdef DEBUG
@@ -1357,3 +1368,16 @@ void CBulletManager::RegisterEvent(EventType Type, BOOL _dynamic, SBullet* bulle
 		break;
 	}
 }
+
+#ifdef CBULLETMANAGER_EX
+bool CBulletManager::ValidateHitDynamicVisualMesh(SBullet& B, collide::rq_result& R, Fvector& collide_position, float range)
+{
+    IKinematics::pick_result res;
+    if (R.O->Visual()->dcast_PKinematics()->PickBone(R.O->XFORM(), res, range, B.bullet_pos, B.dir, (u16)R.element))
+    {
+        collide_position.mad(B.bullet_pos, B.dir, res.dist);
+        return true;
+    }
+    return false;
+}
+#endif

--- a/src/xrGame/Level_Bullet_Manager.h
+++ b/src/xrGame/Level_Bullet_Manager.h
@@ -253,6 +253,10 @@ public:
 	void CommitEvents(); // @ the start of frame
 	void CommitRenderSet(); // @ the end of frame
 	void Render();
+
+#ifdef CBULLETMANAGER_EX
+    bool ValidateHitDynamicVisualMesh(SBullet& B, collide::rq_result& R, Fvector& collide_position, float range);
+#endif
 };
 
 struct bullet_test_callback_data
@@ -263,4 +267,7 @@ struct bullet_test_callback_data
 #if 1//def DEBUG
 	float high_time;
 #endif // #ifdef DEBUG
+#ifdef CBULLETMANAGER_EX
+    float max_distance;
+#endif
 };

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -735,6 +735,18 @@ bool CScriptGameObject::is_bone_visible(u16 bone_id, bool bHud)
 	return result;
 }
 
+#ifdef CBULLETMANAGER_EX
+bool CScriptGameObject::GetBulletCheckVisual()
+{
+    return object().GetBulletCheckVisual();
+}
+
+void CScriptGameObject::SetBulletCheckVisual(bool value)
+{
+    object().SetBulletCheckVisual(value);
+}
+#endif
+
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1106,6 +1106,11 @@ public:
 
 	::luabind::object list_bones(bool bHud = false);
 
+#ifdef CBULLETMANAGER_EX
+    bool GetBulletCheckVisual();
+    void SetBulletCheckVisual(bool value);
+#endif
+
 	bool IsBoneVisible(LPCSTR bone_name, bool bHud = false);	
 	void SetBoneVisible(LPCSTR bone_name, bool bVisibility, bool bRecursive = true, bool bHud = false);	
 	//CAI_Stalker

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -165,6 +165,11 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		// demonized: list all bones
 		.def("list_bones", SAFE_WRAP(&CScriptGameObject::list_bones))
 
+#ifdef CBULLETMANAGER_EX
+		.def("GetBulletCheckVisual", SAFE_WRAP(&CScriptGameObject::GetBulletCheckVisual))
+		.def("SetBulletCheckVisual", SAFE_WRAP(&CScriptGameObject::SetBulletCheckVisual))
+#endif
+
 		//////////////////////////////////////////////////////////////////////////
 		// Space restrictions
 		//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add an option "bullet_check_visual" in object section to validate bullet hit.
Bullets only hit a bone when hitting both bone hitboxes and passing a triangle on the visual model.
Allow a more accurate bullet hit validation. Used for complex objects like physic objects, cars, stationary machine guns.
The bone hitbox must wrap all vertexes of the bone inside.
Not recommended to enable for stalkers, mutants.