### PR TITLE
feat(ai): per-NPC view-distance factor setter

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -663,6 +663,7 @@
         // Stalker and Monster
         function invalidate_restrictions()
         void set_vision_speed(float factor) // Per-object vision-speed factor multiplied into get_visible_value on top of the ai_vision_speed_boost cvar. 1.0 = vanilla, higher spots faster, negative clamps to 0. Persists while online; re-set on spawn (memory manager is rebuilt when the NPC comes back online).
+        void set_view_distance_factor(float factor) // Per-object view-DISTANCE factor, the range sibling of set_vision_speed: multiplies object_visible_distance's return, composing with the per-state max_view_distance LTX multiplier. 1.0 = vanilla, higher sees farther, negative clamps to 0. Persists while online; re-set on spawn.
 
         // Stalker NPCs
         function get_enable_anomalies_pathfinding()

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -840,6 +840,7 @@ public:
 	void set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time);
 	void set_fire_queue_scale(float size_k, float interval_k);
 	void set_vision_speed(float value);
+	void set_view_distance_factor(float value);
 	bool can_kill_enemy();
 	bool can_kill_member();
 	bool fire_make_sense();

--- a/src/xrGame/script_game_object3.cpp
+++ b/src/xrGame/script_game_object3.cpp
@@ -160,6 +160,16 @@ void CScriptGameObject::set_vision_speed(float value)
 		custom_monster->memory().visual().set_vision_speed(value);
 }
 
+void CScriptGameObject::set_view_distance_factor(float value)
+{
+	CCustomMonster* custom_monster = smart_cast<CCustomMonster*>(&object());
+	if (!custom_monster)
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CCustomMonster : cannot access class member set_view_distance_factor!");
+	else
+		custom_monster->memory().visual().set_view_distance_factor(value);
+}
+
 float CScriptGameObject::GetObjectVisibleDistance(const CScriptGameObject* obj)
 {
     if (obj == nullptr)

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -64,6 +64,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("patrol_path_make_inactual", SAFE_WRAP(&CScriptGameObject::patrol_path_make_inactual))
 		.def("enable_memory_object", SAFE_WRAP(&CScriptGameObject::enable_memory_object))
 		.def("set_vision_speed", SAFE_WRAP(&CScriptGameObject::set_vision_speed))
+		.def("set_view_distance_factor", SAFE_WRAP(&CScriptGameObject::set_view_distance_factor))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)())(&CScriptGameObject::active_sound_count)))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)(bool))(&CScriptGameObject::active_sound_count)))
 		.def("best_cover", SAFE_WRAP(&CScriptGameObject::best_cover))

--- a/src/xrGame/visual_memory_manager.cpp
+++ b/src/xrGame/visual_memory_manager.cpp
@@ -315,7 +315,7 @@ float CVisualMemoryManager::object_visible_distance(const CGameObject* game_obje
 
 	float distance = (1.f - alpha / fov) * (max_view_distance - min_view_distance) + min_view_distance;
 
-	return (distance);
+	return (distance * m_view_distance_factor);
 }
 
 float CVisualMemoryManager::object_luminocity(const CGameObject* game_object) const

--- a/src/xrGame/visual_memory_manager.h
+++ b/src/xrGame/visual_memory_manager.h
@@ -59,6 +59,7 @@ private:
 	bool m_enabled;
 	u32 m_last_update_time;
 	float m_vision_speed = 1.0f; // per-NPC vision-speed factor; scales get_visible_value (1.0 = vanilla). Deliberately not reset in reinit()/reload(): persists while online, re-set from script on spawn.
+	float m_view_distance_factor = 1.0f;
 
 public:
 	void add_visible_object(const CObject* object, float time_delta, bool fictitious = false);
@@ -130,6 +131,8 @@ public:
 	IC void enable(bool value);
 	void set_vision_speed(float value) { m_vision_speed = (value < 0.f) ? 0.f : value; }
 	float vision_speed() const { return (m_vision_speed); }
+	void set_view_distance_factor(float value) { m_view_distance_factor = (value < 0.f) ? 0.f : value; }
+	float view_distance_factor() const { return (m_view_distance_factor); }
 
 public:
 	IC const VISIBLES& objects() const;


### PR DESCRIPTION
## Summary

`npc:set_view_distance_factor(factor)` — a per-object float on `CVisualMemoryManager`, the range sibling of `set_vision_speed` (#594). It is multiplied into the return of `object_visible_distance` (`visual_memory_manager.cpp:318`), the effective visible range that the visibility gate compares against at `:426-430`, so it scales the distance at which an NPC acquires a target. `1.0` = vanilla, higher sees farther, negative clamps to 0. Composes with the per-state `max_view_distance` LTX multiplier (the factor is applied on top). Works for any `CCustomMonster`; error-log path for anything else (the actor). Deliberately not reset in `reinit()`/`reload()` — the memory manager is reconstructed when the NPC comes back online, so scripts re-apply on `npc_on_net_spawn`.

Vision internals are already exposed to script here (`GetObjectVisibleDistance` / `GetObjectLuminocity`, `script_game_object3.cpp`), and vision SPEED is per-object via `set_vision_speed`; this adds the missing range half.

## Use cases

Range is `max_view_distance`, a per-state LTX multiplier global to a config section — a script can only change it section-wide, not per NPC. `set_vision_speed` shortens time-to-detect a target already in the field of view but cannot extend the distance at which detection begins.

- per-rank detection range: a veteran begins seeing a target from farther out than a rookie
- optics: a binocular or NVG carrier gets a wider acquisition range while equipped
- gear- or situation-gated vision without global LTX edits

## Performance

No Lua on any per-frame path. The setter runs from script at spawn or a decision point; the per-object cost is a single float multiply on `object_visible_distance`'s existing return, O(1), and at the default `1.0` it is an exact-identity multiply.

## Constraints

- Not serialized: the per-NPC value lives on the game object and vanishes on offline switch; re-set from script on net spawn (noted in the manifest entry).
- The actor is not a `CCustomMonster`; the setter takes the error-log path.

## Files changed

| File | Change |
|---|---|
| `src/xrGame/visual_memory_manager.h` | `m_view_distance_factor` field + clamped setter + getter (+3) |
| `src/xrGame/visual_memory_manager.cpp` | trailing multiply on `object_visible_distance`'s return |
| `src/xrGame/script_game_object.h` | decl |
| `src/xrGame/script_game_object3.cpp` | `set_view_distance_factor` (smart_cast + error-log) |
| `src/xrGame/script_game_object_script3.cpp` | `.def` next to `set_vision_speed` |
| `gamedata/scripts/lua_help_ex.script` | manifest entry |

17 lines added, 1 removed.

## Lua usage

```lua
-- this NPC sees at 2x the normal range; set once on spawn
npc:set_view_distance_factor(2.0)
-- revert to vanilla acquisition range
npc:set_view_distance_factor(1.0)
```

## Testing

Built locally, DX11, zero errors, deployed to a real install. Deterministic read on a single NPC (identical geometry, only the factor changes): `get_object_visible_distance` to the actor went 28.4m -> 58.5m after `set_view_distance_factor(2.0)` (x2.06). In a 47-NPC arena fight a per-rank/optic consumer applied the factor at `npc_on_net_spawn` 561 times over the session (values 0.95-1.5), no crashes and no luabind cast errors in the log. An unset NPC (factor 1.0) acquires at the vanilla range.
