### PR TITLE
feat(ai): per-NPC passive health-restore boost setter

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -663,6 +663,7 @@
         // Stalker and Monster
         function invalidate_restrictions()
         void set_vision_speed(float factor) // Per-object vision-speed factor multiplied into get_visible_value on top of the ai_vision_speed_boost cvar. 1.0 = vanilla, higher spots faster, negative clamps to 0. Persists while online; re-set on spawn (memory manager is rebuilt when the NPC comes back online).
+        void set_health_restore_boost(float value) // Per-object additive passive health-restore boost: adds value to the condition's m_fV_HealthRestore velocity applied every UpdateHealth while alive (base ~0.00003/s for stalkers), so the entity regenerates HP over time with no item. 0 = vanilla, higher = faster idle regen, negative clamps to 0. Stalkers and monsters (any CEntityAlive). Persists while online; re-set on spawn (condition rebuilt on re-online).
 
         // Stalker NPCs
         function get_enable_anomalies_pathfinding()

--- a/src/xrGame/EntityCondition.cpp
+++ b/src/xrGame/EntityCondition.cpp
@@ -639,7 +639,7 @@ void CEntityCondition::UpdateHealth()
 	float bleeding_speed = BleedingSpeed() * m_fDeltaTime * change_v().m_fV_Bleeding;
 	m_bIsBleeding = fis_zero(bleeding_speed) ? false : true;
 	m_fDeltaHealth -= CanBeHarmed() ? bleeding_speed : 0;
-	m_fDeltaHealth += m_fDeltaTime * change_v().m_fV_HealthRestore;
+	m_fDeltaHealth += m_fDeltaTime * (change_v().m_fV_HealthRestore + m_health_restore_boost);
 
 	VERIFY(_valid(m_fDeltaHealth));
 	ChangeBleeding(change_v().m_fV_WoundIncarnation * m_fDeltaTime);

--- a/src/xrGame/EntityCondition.h
+++ b/src/xrGame/EntityCondition.h
@@ -246,6 +246,8 @@ protected:
 
 	SConditionChangeV m_change_v;
 
+	float m_health_restore_boost = 0.0f;
+
 	float m_fMinWoundSize;
 	bool m_bIsBleeding; //есть кровотечение
 
@@ -300,4 +302,7 @@ public:
 	IC float& hit_bone_scale() { return (m_fHitBoneScale); }
 	IC float& wound_bone_scale() { return (m_fWoundBoneScale); }
 	virtual SConditionChangeV& change_v();
+
+	IC void set_health_restore_boost(float value) { m_health_restore_boost = (value < 0.f) ? 0.f : value; }
+	IC float health_restore_boost() const { return (m_health_restore_boost); }
 };

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -840,6 +840,7 @@ public:
 	void set_aim_params(float max_angle, float min_angle, float min_speed, float predict_time);
 	void set_fire_queue_scale(float size_k, float interval_k);
 	void set_vision_speed(float value);
+	void set_health_restore_boost(float value);
 	bool can_kill_enemy();
 	bool can_kill_member();
 	bool fire_make_sense();

--- a/src/xrGame/script_game_object3.cpp
+++ b/src/xrGame/script_game_object3.cpp
@@ -27,6 +27,7 @@
 #include "visual_memory_manager.h"
 #include "sound_memory_manager.h"
 #include "hit_memory_manager.h"
+#include "EntityCondition.h"
 #include "sight_manager.h"
 #include "stalker_movement_manager_smart_cover.h"
 #include "smart_cover.h"
@@ -158,6 +159,16 @@ void CScriptGameObject::set_vision_speed(float value)
 		                                "CCustomMonster : cannot access class member set_vision_speed!");
 	else
 		custom_monster->memory().visual().set_vision_speed(value);
+}
+
+void CScriptGameObject::set_health_restore_boost(float value)
+{
+	CEntityAlive* entity_alive = smart_cast<CEntityAlive*>(&object());
+	if (!entity_alive)
+		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
+		                                "CEntityAlive : cannot access class member set_health_restore_boost!");
+	else
+		entity_alive->conditions().set_health_restore_boost(value);
 }
 
 float CScriptGameObject::GetObjectVisibleDistance(const CScriptGameObject* obj)

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -64,6 +64,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("patrol_path_make_inactual", SAFE_WRAP(&CScriptGameObject::patrol_path_make_inactual))
 		.def("enable_memory_object", SAFE_WRAP(&CScriptGameObject::enable_memory_object))
 		.def("set_vision_speed", SAFE_WRAP(&CScriptGameObject::set_vision_speed))
+		.def("set_health_restore_boost", SAFE_WRAP(&CScriptGameObject::set_health_restore_boost))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)())(&CScriptGameObject::active_sound_count)))
 		.def("active_sound_count", SAFE_WRAP((int (CScriptGameObject::*)(bool))(&CScriptGameObject::active_sound_count)))
 		.def("best_cover", SAFE_WRAP(&CScriptGameObject::best_cover))


### PR DESCRIPTION
## Summary

`npc:set_health_restore_boost(value)` — a per-object float on `CEntityCondition`, added to the passive health-restore velocity each condition update: `m_fDeltaHealth += m_fDeltaTime * (change_v().m_fV_HealthRestore + m_health_restore_boost)` (`EntityCondition.cpp:642`, inside the alive-gated `UpdateHealth`). So a script gives an NPC real heal-over-time with no item. `0` = vanilla, higher regenerates faster, negative clamps to 0. Valid for any `CEntityAlive` (stalkers and monsters — the condition owns passive regen); error-log path otherwise. Not reset in `reinit()`/`reload()`; re-set from script on `npc_on_net_spawn`.

This mirrors the actor's own additive boost `CActorCondition::BoostHpRestore` (`ActorCondition.cpp:782`, `m_change_v.m_fV_HealthRestore += value`) as a separate, revertable per-NPC member on the base `CEntityCondition`.

## Use cases

The engine already applies slow passive regen for NPCs (`health_restore_v` = 0.00003 for stalkers, `m_stalker.ltx:249`) but exposes no runtime per-NPC lever. The only bound NPC health write is `change_health` (a one-shot delta), which forces a scripted per-tick loop to fake regen.

- artefact/consumable carriers that regenerate over time as a set-once modifier at spawn
- temporary heal-over-time effects (a medic aura, a chemical drive) without a per-tick `change_health` script
- per-NPC regen tuning without editing the global `health_restore_v` config

## Performance

No Lua on any per-frame path. The setter runs from script; the per-object cost is a single float add inside `UpdateHealth`, which runs on the condition-update tick (not per frame), O(1). At the default `0` it is a no-op add.

## Constraints

- Not serialized: re-set from script on net spawn (noted in the manifest entry).
- `UpdateHealth` is non-virtual and inherited by `CActorCondition`, so setting this on the actor (a `CEntityAlive`) would give the player passive regen — a caller choice, not a crash. Non-`CEntityAlive` receivers take the error-log path.

## Files changed

| File | Change |
|---|---|
| `src/xrGame/EntityCondition.h` | `m_health_restore_boost` field + clamped setter + getter (+5) |
| `src/xrGame/EntityCondition.cpp` | additive boost in `UpdateHealth` |
| `src/xrGame/script_game_object.h` | decl |
| `src/xrGame/script_game_object3.cpp` | `set_health_restore_boost` (CEntityAlive smart_cast + error-log) + include |
| `src/xrGame/script_game_object_script3.cpp` | `.def` next to `set_vision_speed` |
| `gamedata/scripts/lua_help_ex.script` | manifest entry |

20 lines added, 1 removed.

## Lua usage

```lua
-- this NPC regenerates HP over time; set once on spawn
npc:set_health_restore_boost(0.01)
-- revert to vanilla (no passive boost)
npc:set_health_restore_boost(0)
```

## Testing

Built locally, DX11, zero errors, deployed to a real install. Two NPCs damaged to 50% HP; one given `set_health_restore_boost(0.01)`, the other left vanilla, neither shot. Over 30s the boosted NPC recovered 0.500 -> 1.000 (full) while the control moved 0.500 -> 0.505 (the vanilla trickle). In a 47-NPC fight a carrier consumer wrote the boost at `npc_on_net_spawn` 464 times, no crashes and no cast errors. Setting `0` leaves the NPC at vanilla regen.
