### PR TITLE
Expose script control on whether to activate item on move_to_slot or not

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -659,6 +659,7 @@
         function get_actor_default_action_for_object()
 		function set_actor_box_y_offset(u32 box_num, float offset) --box_num:0 for stand, 1 for crouch, 2 for prone;
         function g_fireParams()
+        function move_to_slot(game_object* pItem, number slot_id, bool doNotActivate)
 
         // Stalker and Monster
         function invalidate_restrictions()

--- a/src/xrGame/Actor_Events.cpp
+++ b/src/xrGame/Actor_Events.cpp
@@ -240,7 +240,8 @@ void CActor::OnEvent(NET_Packet& P, u16 type)
 			case GEG_PLAYER_ITEM2SLOT:
 				{
 					u16 slot_id = P.r_u16();
-					inventory().Slot(slot_id, iitem);
+                    bool bDoNotActivate = P.r_u8() == 1; // conservatively preserve old behaviour unless very specifically (value == 1) requested otherwise
+					inventory().Slot(slot_id, iitem, bDoNotActivate);
 				}
 				break; //2
 			case GEG_PLAYER_ITEM2BELT:

--- a/src/xrGame/Bolt.cpp
+++ b/src/xrGame/Bolt.cpp
@@ -137,6 +137,7 @@ void CBolt::PutNextToSlot()
 				pNext->u_EventGen(P, GEG_PLAYER_ITEM2SLOT, pNext->H_Parent()->ID());
 				P.w_u16(pNext->ID());
 				P.w_u16(pNext->BaseSlot());
+                P.w_u8(0); // do activate
 				pNext->u_EventSend(P);
 				m_pInventory->SetActiveSlot(pNext->BaseSlot());
 			}

--- a/src/xrGame/Grenade.cpp
+++ b/src/xrGame/Grenade.cpp
@@ -274,6 +274,7 @@ void CGrenade::PutNextToSlot()
 				pNext->u_EventGen(P, GEG_PLAYER_ITEM2SLOT, pNext->H_Parent()->ID());
 				P.w_u16(pNext->ID());
 				P.w_u16(pNext->BaseSlot());
+                P.w_u8(0); // do activate
 				pNext->u_EventSend(P);
 				m_pInventory->SetActiveSlot(pNext->BaseSlot());
 			}

--- a/src/xrGame/inventory_quickswitch.cpp
+++ b/src/xrGame/inventory_quickswitch.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "inventory.h"
 #include "weapon.h"
 #include "actor.h"
@@ -169,6 +169,7 @@ bool CInventory::ActivateNextItemInActiveSlot()
 	new_item->object().u_EventGen(P, GEG_PLAYER_ITEM2SLOT, new_item->object().H_Parent()->ID());
 	P.w_u16(new_item->object().ID());
 	P.w_u16(m_iActiveSlot);
+	P.w_u8(0); // do activate
 	new_item->object().u_EventSend(P);
 
 	//activate

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -441,7 +441,7 @@ public:
 	u32 Money();
 	void MakeItemActive(CScriptGameObject* pItem);
 	void MoveItemToRuck(CScriptGameObject* pItem);
-	void MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id);
+	void MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id, bool doNotActivate);
 	void MoveItemToBelt(CScriptGameObject* pItem);
 	void ItemAllowTrade(CScriptGameObject* pItem);
 	void ItemDenyTrade(CScriptGameObject* pItem);

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -487,6 +487,7 @@ void CScriptGameObject::MakeItemActive(CScriptGameObject* pItem)
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2SLOT, owner->object_id());
 	P.w_u16(item->object().ID());
 	P.w_u16(slot);
+	P.w_u8(0); // do activate
 	CGameObject::u_EventSend(P);
 
 	CGameObject::u_EventGen(P, GEG_PLAYER_ACTIVATE_SLOT, owner->object_id());
@@ -514,7 +515,7 @@ void CScriptGameObject::MoveItemToRuck(CScriptGameObject* pItem)
 	CGameObject::u_EventSend(P);
 }
 
-void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id)
+void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id, bool doNotActivate)
 {
 	CInventoryOwner* owner = smart_cast<CInventoryOwner*>(&object());
 	CInventoryItem* item = smart_cast<CInventoryItem*>(&pItem->object());
@@ -548,6 +549,7 @@ void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id)
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2SLOT, owner->object_id());
 	P.w_u16(item->object().ID());
 	P.w_u16(slot_id);
+    P.w_u8(doNotActivate ? 1 : 0);
 	CGameObject::u_EventSend(P);
 }
 

--- a/src/xrGame/ui/UIActorMenuInventory.cpp
+++ b/src/xrGame/ui/UIActorMenuInventory.cpp
@@ -85,6 +85,7 @@ void CUIActorMenu::SendEvent_Item2Slot(PIItem pItem, u16 recipient, u16 slot_id)
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2SLOT, pItem->object().H_Parent()->ID());
 	P.w_u16(pItem->object().ID());
 	P.w_u16(slot_id);
+    P.w_u8(0); // do activate
 	CGameObject::u_EventSend(P);
 
 	PlaySnd(eItemToSlot);


### PR DESCRIPTION
To retain compatibility with existing scripts the boolean flag is flipped - `false` means to preserve old behavior meaning DO activate, `true` means to DO NOT activate the weapon

proof that the changes work correctly is in the attached video:
- equip pistol through equipment UI and it gets activated
- equip pistol through script `move_to_slot` with `true` as 3rd param and pistol is in slot but it does not activate on it's own
- equip pistol through script `move_to_slot` without 3rd param: pistol is in slot and it gets activated so old behavior is preserved and changes are compatible with existing scripts

https://github.com/user-attachments/assets/5f87d4ae-b590-4497-b9e0-5d54dd46b425