### PR TITLE
New Cvars scale_hud_motion_marks_by_speed and allow_accel_during_lookout

### DIFF
--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -837,8 +837,8 @@
 	<string id="ui_mm_modded_exes_gameplay_weapons_g_auto_reload">
 		<text>Automatically reload weapon when ammo is depleted (g_auto_reload)</text>
 	</string>
-	<string id="ui_mm_modded_exes_gameplay_weapons_g_auto_reload">
-		<text>Automatically reload weapon when ammo is depleted (g_auto_reload)</text>
+	<string id="ui_mm_modded_exes_gameplay_weapons_g_decouple_horz_recoil">
+		<text>Horizontal recoil is independent of vertical (g_decouple_horz_recoil)</text>
 	</string>
 	<string id="ui_mm_modded_exes_gameplay_weapons_scale_hud_motion_marks_by_speed">
 		<text>Scale Hud Motion Marks By Anim Speed (scale_hud_motion_marks_by_speed)</text>

--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -837,8 +837,11 @@
 	<string id="ui_mm_modded_exes_gameplay_weapons_g_auto_reload">
 		<text>Automatically reload weapon when ammo is depleted (g_auto_reload)</text>
 	</string>
-	<string id="ui_mm_modded_exes_gameplay_weapons_g_decouple_horz_recoil">
-		<text>Horizontal recoil is independent of vertical (g_decouple_horz_recoil)</text>
+	<string id="ui_mm_modded_exes_gameplay_weapons_g_auto_reload">
+		<text>Automatically reload weapon when ammo is depleted (g_auto_reload)</text>
+	</string>
+	<string id="ui_mm_modded_exes_gameplay_weapons_scale_hud_motion_marks_by_speed">
+		<text>Scale Hud Motion Marks By Anim Speed (scale_hud_motion_marks_by_speed)</text>
 	</string>
 	
 	<string id="ui_mm_modded_exes_gameplay_weapons_g_fire_reloads_ubgl">

--- a/gamedata/configs/text/eng/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/eng/ui_mm_modded_exes.xml
@@ -737,6 +737,9 @@
 	<string id="ui_mm_modded_exes_gameplay_gameplay_general_disable_actor_body_rotation_delay">
 		<text>Disable Actor Body Rotation Delay (disable_actor_body_rotation_delay)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_allow_accel_during_lookout">
+		<text>Allow Acceleration During Lookout (allow_accel_during_lookout)</text>
+	</string>
 
 	<!-- Aim -->
 	<string id="ui_mm_menu_aim">

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -839,6 +839,9 @@
 	<string id="ui_mm_modded_exes_gameplay_weapons_g_decouple_horz_recoil">
 		<text>√оризонтальна€ отдача не зависит от вертикальной (g_decouple_horz_recoil)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_weapons_scale_hud_motion_marks_by_speed">
+		<text>Scale Hud Motion Marks By Anim Speed (scale_hud_motion_marks_by_speed)</text>
+	</string>
 	
 	<string id="ui_mm_modded_exes_gameplay_weapons_g_fire_reloads_ubgl">
 		<text>јвтоматически перезар€жать пустой подствольник при попытке выстрелить (g_fire_reloads_ubgl)</text>

--- a/gamedata/configs/text/rus/ui_mm_modded_exes.xml
+++ b/gamedata/configs/text/rus/ui_mm_modded_exes.xml
@@ -736,6 +736,9 @@
 	<string id="ui_mm_modded_exes_gameplay_gameplay_general_disable_actor_body_rotation_delay">
 		<text>ћгновенный поворот модели игрока (disable_actor_body_rotation_delay)</text>
 	</string>
+	<string id="ui_mm_modded_exes_gameplay_gameplay_general_allow_accel_during_lookout">
+		<text>Allow Acceleration During Lookout (allow_accel_during_lookout)</text>
+	</string>
 
 	<!-- Aim -->
 	<string id="ui_mm_menu_aim">

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -14,6 +14,8 @@
 
         allow_accel_during_lookout [0; 1] // flag to allow 'running' speed during left or right lookouts
 
+        scale_hud_motion_marks_by_speed [1; 0] // flag to scale motion marks by speed, default is on
+
         telekinetic_objects_include_corpses [0; 1] // Enable the ability for poltergeists and burers to throw corpses
         
         sds_enable [0; 1] // Enable shader based scopes

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -12,6 +12,8 @@
 
         pseudogiant_dodge_stomp_while_falling [0; 1] // Prevent pseudogiants stomp attack from damaging actor if they are falling
 
+        allow_accel_during_lookout [0; 1] // flag to allow 'running' speed during left or right lookouts
+
         telekinetic_objects_include_corpses [0; 1] // Enable the ability for poltergeists and burers to throw corpses
         
         sds_enable [0; 1] // Enable shader based scopes

--- a/gamedata/scripts/options_modded_exes_gameplay_general.script
+++ b/gamedata/scripts/options_modded_exes_gameplay_general.script
@@ -28,6 +28,7 @@ PAGE = page {
 	list_bool { id = "g_legs_render_attachments_shadow" },
 	list_bool { id = "g_legs_in_low_crouch" },
 	list_bool { id = "disable_actor_body_rotation_delay" },
+	list_bool { id = "allow_accel_during_lookout" },
 	track {
 		id = "g_legs_fwd_offset",
 		def = -0.55,

--- a/gamedata/scripts/options_modded_exes_weapons.script
+++ b/gamedata/scripts/options_modded_exes_weapons.script
@@ -7,6 +7,7 @@ PAGE = page {
 	{ id = "weapons" },
 	list_bool { id = "g_auto_reload" },
 	list_bool { id = "g_decouple_horz_recoil" },
+	list_bool { id = "scale_hud_motion_marks_by_speed" },
 	-- list_bool { id = "g_fire_reloads_ubgl" },
 	-- list_bool { id = "g_launcher_dynamic_range" },
 	-- list_bool { id = "g_launcher_dynamic_range_zoom" },

--- a/src/xrGame/Actor_Movement.cpp
+++ b/src/xrGame/Actor_Movement.cpp
@@ -21,6 +21,9 @@
 #include "phdebug.h"
 #endif
 BOOL disableActorBodyRotationDelay = TRUE;
+
+// verdatim: flag to allow 'running' speed during left or right lookouts
+BOOL AllowAccelDuringLookOut = FALSE; 
 static const float s_fLandingTime1 = 0.1f; // через сколько снять флаг Landing1 (т.е. включить следующую анимацию)
 static const float s_fLandingTime2 = 0.3f; // через сколько снять флаг Landing2 (т.е. включить следующую анимацию)
 static const float s_fJumpTime = 0.3f;
@@ -598,7 +601,7 @@ bool isActorAccelerated(u32 mstate, bool ZoomMode)
 
 	if (mstate & (mcCrouch | mcClimb | mcJump | mcLanding | mcLanding2))
 		return res;
-	if (mstate & mcLookout || ZoomMode)
+	if ((mstate & mcLookout && !AllowAccelDuringLookOut) || ZoomMode)
 		return false;
 	return res;
 }

--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "HudItem.h"
 #include "physic_item.h"
 #include "actor.h"
@@ -25,6 +25,9 @@
 ENGINE_API extern float psHUD_FOV_def;
 int g_nearwall = NW_FOV;
 int g_nearwall_trace = NT_CAM;
+
+// verdatim
+BOOL scale_hud_motion_marks_by_speed = false;
 
 CHudItem::CHudItem()
 {
@@ -555,6 +558,20 @@ void CHudItem::UpdateCL()
 			{
 				float motion_prev_time = ((float)m_dwMotionCurrTm - (float)m_dwMotionStartTm) / 1000.0f;
 				float motion_curr_time = ((float)Device.dwTimeGlobal - (float)m_dwMotionStartTm) / 1000.0f;
+
+                // verdatim, edits so motion marks shift their timings based on speed
+                if (scale_hud_motion_marks_by_speed) {
+                    CMotionDef def;
+                    u16 s = m_current_motion_def->speed;
+                    float speed = def.Dequantize(s);
+
+                    // get the final_anim_speed after the ltx speed changes / script changes from actor_on_hud_animation_play and scale the marks accordingly to the two timings
+                    float final_anim_speed = HudItemData()->final_anim_speed;
+
+                    motion_prev_time = (((float)m_dwMotionCurrTm - (float)m_dwMotionStartTm) / 1000.0f) * speed * final_anim_speed;
+                    motion_curr_time = (((float)Device.dwTimeGlobal - (float)m_dwMotionStartTm) / 1000.0f) * speed * final_anim_speed;
+                    
+                }
 
 				xr_vector<motion_marks>::const_iterator it = marks.begin();
 				xr_vector<motion_marks>::const_iterator it_e = marks.end();

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -137,6 +137,7 @@ extern int showActorBody; //leer
 extern BOOL disableActorBodyRotationDelay; //leer
 
 extern BOOL pseudogiantDodgeWhileFalling; // Verdatim
+extern BOOL AllowAccelDuringLookOut; // Verdatim
 
 //demonized: new console vars
 extern BOOL firstPersonDeath;
@@ -3072,6 +3073,8 @@ void CCC_RegisterCommands()
 	CMD4(CCC_Integer, "pseudogiant_can_damage_objects_on_stomp", &pseudogiantCanDamageObjects, 0, 1);
 
     CMD4(CCC_Integer, "pseudogiant_dodge_stomp_while_falling", &pseudogiantDodgeWhileFalling, 0, 1); // Verdatim
+
+    CMD4(CCC_Integer, "allow_accel_during_lookout", &AllowAccelDuringLookOut, 0, 1); // Verdatim
 
 	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -138,6 +138,7 @@ extern BOOL disableActorBodyRotationDelay; //leer
 
 extern BOOL pseudogiantDodgeWhileFalling; // Verdatim
 extern BOOL AllowAccelDuringLookOut; // Verdatim
+extern BOOL scale_hud_motion_marks_by_speed; // Verdatim
 
 //demonized: new console vars
 extern BOOL firstPersonDeath;
@@ -3075,6 +3076,8 @@ void CCC_RegisterCommands()
     CMD4(CCC_Integer, "pseudogiant_dodge_stomp_while_falling", &pseudogiantDodgeWhileFalling, 0, 1); // Verdatim
 
     CMD4(CCC_Integer, "allow_accel_during_lookout", &AllowAccelDuringLookOut, 0, 1); // Verdatim
+
+    CMD4(CCC_Integer, "scale_hud_motion_marks_by_speed", &scale_hud_motion_marks_by_speed, 0, 1); // Verdatim
 
 	CMD4(CCC_Integer, "telekinetic_objects_include_corpses", &g_telekinetic_objects_include_corpses, 0, 1); // Tosox
 

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -83,6 +83,11 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
 					xr_sprintf(buff, "%s%d", pm->m_base_name.c_str(), i);
 
 				motion_ID = model->ID_Cycle_Safe(buff);
+                //code to find hand anim names with speeds of not 1
+                //CMotionDef* def = model->LL_GetMotionDef(motion_ID);
+                //if (def->Speed() != 1) {
+                //    Msg("omf speed is %f, anim_name is %s", def->Speed(), buff);
+                //}
 				if (!motion_ID.valid() && i == 0)
 				{
 					motion_ID = model->ID_Cycle_Safe("hand_idle_doun");
@@ -625,6 +630,8 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
 	const motion_descr& M = anm->m_animations[rnd_idx];
 	if (speed == 1.f)
 		speed = anm->m_anim_speed != 0 ? anm->m_anim_speed : 1.f;
+        // Verdatim: store the final anim speed for use in motion mark timing scaling
+        final_anim_speed = speed;
 
 	u32 ret = 0;
 	if (m_attach_place_idx != SCOPE_ATTACH_IDX) {

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -309,6 +309,9 @@ struct attachable_hud_item
 	Fmatrix m_attach_offset;
 	Fmatrix m_item_transform;
 
+    // ver; final anim speed holder for use in motion mark timing scaling
+    float final_anim_speed;
+
 	player_hud_motion_container* m_hand_motions;
 
 	attachable_hud_item(player_hud* pparent) : m_parent(pparent), m_upd_firedeps_frame(u32(-1)), m_parent_hud_item(nullptr),


### PR DESCRIPTION
Adds two new console variables, scale_hud_motion_marks_by_speed and allow_accel_during_lookout.
scale_hud_motion_marks_by_speed is a boolean (default on) that scales motion marks based on the anim speed in the omf, "m_current_motion_def->speed", and speed by either ltx or script changes. I created a new "final_anim_speed" variable for the struct "attachable_hud_item" to store the final_anim_speed so we can use it later for motion mark scaling
allow_accel_during_lookout is a boolean (default off) that allows the actor to accelerate (run) while in the lookout (lean) states. It does not allow sprinting, but allows both walking and running during this state.
Both Cvars dont have russian translations yet, because i dont speak russian and the results i got from google translate were unsatisfactory. so sorry about that