### PR TITLE
feature(visibility-ui-to-actor): move visibility source of truth

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -653,11 +653,12 @@
         function get_talking_npc()
         function set_actor_position(vector pos, bool bskip_collision_correct, bool bkeep_speed)
         function set_movement_speed(vector)
-        function get_actor_ui_luminocity()
+        function get_actor_ui_luminosity() // Deprecated : Prefer using get_actor_visibility, which better describes what the value represents
+        function get_actor_visibility()
         function get_actor_object_looking_at()
         function get_actor_person_looking_at()
         function get_actor_default_action_for_object()
-		function set_actor_box_y_offset(u32 box_num, float offset) --box_num:0 for stand, 1 for crouch, 2 for prone;
+		function set_actor_box_y_offset(u32 box_num, float offset) -- box_num: 0 for stand, 1 for crouch, 2 for prone;
         function g_fireParams()
         function move_to_slot(game_object* pItem, number slot_id, bool doNotActivate)
 

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1263,7 +1263,7 @@ void CActor::UpdateCL()
 			g_pGamePersistent->m_pGShaderConstants->m_blender_mode.set(0.f, 0.f, 0.f, 0.f);
 
 			// Turn off SecondVP
-			Device.m_SecondViewport.SetSVPActive(false);			
+			Device.m_SecondViewport.SetSVPActive(false);
 		}
 	}
 
@@ -1377,7 +1377,7 @@ void CActor::UpdateCL()
 			//Survival Mode
 			else if (ai().script_engine().functor("_g.IsSurvivalMode", game_mode) && game_mode())
 				snprintf(discord_gameinfo.gamemode, 128, xr_ToUTF8(*CStringTable().translate("st_cap_check_survival")));
-			
+
 			//Freeplay Mode
 			else
 				snprintf(discord_gameinfo.gamemode, 128, xr_ToUTF8(*CStringTable().translate("st_cap_check_freeplay")));
@@ -1437,7 +1437,7 @@ void CActor::RPC_UpdateFaction()
 
 void CActor::RPC_UpdateRank()
 {
-	//Rank		
+	//Rank
 	::luabind::functor<LPCSTR> actor_rank;
 	if (ai().script_engine().functor("ranks.get_player_rank_name", actor_rank))
 	{
@@ -1453,7 +1453,7 @@ void CActor::RPC_UpdateRank()
 
 void CActor::RPC_UpdateReputation()
 {
-	//Reputation		
+	//Reputation
 	::luabind::functor<int> actor_rep_val;
 	if (ai().script_engine().functor("ranks.get_player_reputation", actor_rep_val))
 	{
@@ -2091,6 +2091,88 @@ void CActor::shedule_Update(u32 DT)
 	Check_for_AutoPickUp();
 };
 
+void SetActorVisibility(u16 who_id, float value)
+{
+    if (!IsGameTypeSingle())
+        return;
+
+    CActor* pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
+    pActor->SetVisibilityFromObject(who_id, value);
+}
+
+float GetActorVisibility()
+{
+    if (!IsGameTypeSingle())
+        return 0.f;
+
+    CActor* pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
+    float lum = pActor->GetVisibility();
+    clamp(lum, 0.f, 1.f);
+    return lum;
+}
+
+float CActor::GetVisibility()
+{
+    if (m_visibility_changed)
+    {
+        m_visibility_changed = false;
+        if (m_npc_visibility.size())
+        {
+            std::sort(m_npc_visibility.begin(), m_npc_visibility.end());
+            m_visibility_tgt = m_npc_visibility.back().value;
+        }
+        else
+        {
+            m_visibility_tgt = 0.f;
+        }
+    }
+
+    float _diff = _abs(m_visibility_tgt - m_visibility_cur);
+    if (m_visibility_tgt > m_visibility_cur)
+    {
+        m_visibility_cur += _diff * Device.fTimeDelta;
+    }
+    else
+    {
+        m_visibility_cur -= _diff * Device.fTimeDelta;
+    }
+
+    return m_visibility_cur;
+}
+
+void CActor::SetVisibilityValue(float value)
+{
+    m_visibility_tgt = value;
+}
+
+void CActor::SetVisibilityFromObject(u16 who_id, float value)
+{
+    clamp(value, 0.f, 1.f);
+
+    xr_vector<npc_visibility>::iterator it = std::find(m_npc_visibility.begin(),
+        m_npc_visibility.end(),
+        who_id);
+
+    if (it == m_npc_visibility.end() && value != 0)
+    {
+        m_npc_visibility.resize(m_npc_visibility.size() + 1);
+        npc_visibility& v = m_npc_visibility.back();
+        v.id = who_id;
+        v.value = value;
+    }
+    else if (fis_zero(value))
+    {
+        if (it != m_npc_visibility.end())
+            m_npc_visibility.erase(it);
+    }
+    else
+    {
+        (*it).value = value;
+    }
+
+    m_visibility_changed = true;
+}
+
 void CActor::RenderCamAttached()
 {
 	if (cam_active == eacFirstEye && ::Render->active_phase() == 0)
@@ -2179,7 +2261,7 @@ void CActor::renderable_Render()
                 }
             }
 
-			//if (fpBody) 
+			//if (fpBody)
 			//	inherited::renderable_Render();
 		}
 		else if (AllowActorShadow()) // render actor shadow
@@ -2193,7 +2275,7 @@ void CActor::renderable_Render()
                     renderFrame = Device.dwFrame;
                     needAdjust = true;
                 }
-                
+
                 if (canRenderLegs(this, m_holder))
                 {
                     Fvector diff(XFORMShadow.c);
@@ -2251,7 +2333,7 @@ void CActor::renderable_Render()
             {
                 inherited::renderable_Render();
                 CInventoryOwner::renderable_Render();
-            }			
+            }
 		}
 	}
 
@@ -2384,7 +2466,7 @@ void CActor::RenderIndicator(Fvector dpos, float r1, float r2, const ui_shader& 
 	//pv->set         (a.x+pos.x,a.y+pos.y,a.z+pos.z, 0xffffffff, 0.f,0.f);        pv++;
 	//pv->set         (c.x+pos.x,c.y+pos.y,c.z+pos.z, 0xffffffff, 1.f,1.f);        pv++;
 	//pv->set         (b.x+pos.x,b.y+pos.y,b.z+pos.z, 0xffffffff, 1.f,0.f);        pv++;
-	// render	
+	// render
 	//dwCount 				= u32(pv-pv_start);
 	//RCache.Vertex.Unlock	(dwCount,hFriendlyIndicator->vb_stride);
 
@@ -2421,7 +2503,7 @@ void CActor::RenderText(LPCSTR Text, Fvector dpos, float* pdup, u32 color)
 	float size = v1r.distance_to(v0r);
 	CGameFont* pFont = UI().Font().pFontArial14;
 	if (!pFont) return;
-	//	float OldFontSize = pFont->GetHeight	();	
+	//	float OldFontSize = pFont->GetHeight	();
 	float delta_up = 0.0f;
 	if (size < mid_size) delta_up = upsize;
 	else delta_up = upsize * (mid_size / size);
@@ -2734,37 +2816,6 @@ void CActor::AnimTorsoPlayCallBack(CBlend* B)
 	actor->m_bAnimTorsoPlayed = FALSE;
 }
 
-
-/*
-void CActor::UpdateMotionIcon(u32 mstate_rl)
-{
-CUIMotionIcon*	motion_icon=CurrentGameUI()->UIMainIngameWnd->MotionIcon();
-if(mstate_rl&mcClimb)
-{
-motion_icon->ShowState(CUIMotionIcon::stClimb);
-}
-else
-{
-if(mstate_rl&mcCrouch)
-{
-if (!isActorAccelerated(mstate_rl, IsZoomAimingMode()))
-motion_icon->ShowState(CUIMotionIcon::stCreep);
-else
-motion_icon->ShowState(CUIMotionIcon::stCrouch);
-}
-else
-if(mstate_rl&mcSprint)
-motion_icon->ShowState(CUIMotionIcon::stSprint);
-else
-if(mstate_rl&mcAnyMove && isActorAccelerated(mstate_rl, IsZoomAimingMode()))
-motion_icon->ShowState(CUIMotionIcon::stRun);
-else
-motion_icon->ShowState(CUIMotionIcon::stNormal);
-}
-}
-*/
-
-
 CPHDestroyable* CActor::ph_destroyable()
 {
 	return smart_cast<CPHDestroyable*>(character_physics_support());
@@ -2806,7 +2857,7 @@ bool CActor::can_attach(const CInventoryItem* inventory_item) const
 	                                              inventory_item->object().cNameSect()))
 		return false;
 
-	//åñëè óæå åñòü ïðèñîåäèííåíûé îáúåò òàêîãî òèïà 
+	//åñëè óæå åñòü ïðèñîåäèííåíûé îáúåò òàêîãî òèïà
 	if (attached(inventory_item->object().cNameSect()))
 		return false;
 
@@ -3059,7 +3110,7 @@ void CActor::initFPCam()
 	}
 }
 
-void CActor::removeFPCam() 
+void CActor::removeFPCam()
 {
 	if (m_FPCam) {
 		Cameras().RemoveCamEffector(m_FPCam);
@@ -3067,9 +3118,3 @@ void CActor::removeFPCam()
 	}
 }
 
-float GetActorLuminosity();
-float CActor::GetUILuminosity()
-{
-
-	return GetActorLuminosity();
-}

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -2097,6 +2097,10 @@ void SetActorVisibility(u16 who_id, float value)
         return;
 
     CActor* pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
+
+    if (!pActor)
+        return;
+
     pActor->SetVisibilityFromObject(who_id, value);
 }
 
@@ -2106,6 +2110,10 @@ float GetActorVisibility()
         return 0.f;
 
     CActor* pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
+
+    if (!pActor)
+        return 0.f;
+
     float lum = pActor->GetVisibility();
     clamp(lum, 0.f, 1.f);
     return lum;

--- a/src/xrGame/Actor.h
+++ b/src/xrGame/Actor.h
@@ -100,8 +100,6 @@ public:
 public:
 	virtual BOOL AlwaysTheCrow() { return TRUE; }
 
-	virtual float GetUILuminosity();
-
 	virtual CAttachmentOwner* cast_attachment_owner() { return this; }
 	virtual CInventoryOwner* cast_inventory_owner() { return this; }
 	virtual CActor* cast_actor() { return this; }
@@ -261,7 +259,7 @@ protected:
 	s32 m_ShotRndSeed;
 
 	bool m_bOutBorder;
-	//сохраняет счетчик объектов в feel_touch, для которых необходимо обновлять размер колижена с актером 
+	//сохраняет счетчик объектов в feel_touch, для которых необходимо обновлять размер колижена с актером
 	u32 m_feel_touch_characters;
 private:
 	void SwitchOutBorder(bool new_border_state);
@@ -339,7 +337,7 @@ public:
 	virtual void OnHUDDraw(CCustomHUD* hud);
 	BOOL HUDview() const;
 
-	//visiblity 
+	//visiblity
 	virtual float ffGetFov() const { return 90.f; }
 	virtual float ffGetRange() const { return 500.f; }
 
@@ -519,7 +517,7 @@ public:
 	virtual float MaxCarryWeight() const;
 	float MaxWalkWeight() const;
 	float get_additional_weight() const;
-	
+
 #ifdef STATIONARYMGUN_NEW
 	float GetWeaponAccuracyStm();
 #endif
@@ -535,7 +533,7 @@ protected:
 	float m_fDispBase;
 	float m_fDispAim;
 	//коэффициенты на сколько процентов увеличится базовая дисперсия
-	//учитывает скорость актера 
+	//учитывает скорость актера
 	float m_fDispVelFactor;
 	//если актер бежит
 	float m_fDispAccelFactor;
@@ -605,7 +603,7 @@ protected:
 	xr_deque<net_update_A> NET_A;
 
 	//---------------------------------------------
-	//	bool					m_bHasUpdate;	
+	//	bool					m_bHasUpdate;
 	/// spline coeff /////////////////////
 	float SCoeff[3][4]; //коэффициэнты для сплайна Бизье
 	float HCoeff[3][4]; //коэффициэнты для сплайна Эрмита
@@ -876,7 +874,36 @@ public:
 	void RPC_UpdateReputation();
 
 	CNightVisionEffector* m_night_vision;
-DECLARE_SCRIPT_REGISTER_FUNCTION
+
+private:
+    struct npc_visibility
+    {
+        u16 id;
+        float value;
+
+        bool operator ==(const u16& _id)
+        {
+            return id == _id;
+        }
+
+        bool operator <(const npc_visibility& m) const
+        {
+            return (value < m.value);
+        }
+    };
+
+    xr_vector<npc_visibility> m_npc_visibility;
+    float m_visibility_tgt = 0.0f;
+    float m_visibility_cur = 0.0f;
+    bool m_visibility_changed = false;
+
+public:
+    float GetVisibility();
+    void SetVisibilityValue(float value);
+    void SetVisibilityFromObject(u16 who_id, float value);
+
+public:
+    DECLARE_SCRIPT_REGISTER_FUNCTION
 };
 
 extern bool isActorAccelerated(u32 mstate, bool ZoomMode);

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -509,7 +509,7 @@ public:
 	CScriptGameObject * GetObjectById(u16 id) const;
 
 
-	// Callbacks			
+	// Callbacks
 	void SetCallback(GameObject::ECallbackType type, const ::luabind::functor<void>& functor);
 	void SetCallback(GameObject::ECallbackType type, const ::luabind::functor<void>& functor,
 	                 const ::luabind::object& object);
@@ -1117,8 +1117,8 @@ public:
     void SetBulletCheckVisual(bool value);
 #endif
 
-	bool IsBoneVisible(LPCSTR bone_name, bool bHud = false);	
-	void SetBoneVisible(LPCSTR bone_name, bool bVisibility, bool bRecursive = true, bool bHud = false);	
+	bool IsBoneVisible(LPCSTR bone_name, bool bHud = false);
+	void SetBoneVisible(LPCSTR bone_name, bool bVisibility, bool bRecursive = true, bool bHud = false);
 	//CAI_Stalker
 	void ResetBoneProtections(LPCSTR imm_sect, LPCSTR bone_sect);
 	//Anything with PPhysicShell (ie. car, actor, stalker, monster, heli)
@@ -1171,8 +1171,7 @@ public:
 
 	float Weight() const;
 
-	// demonized: get luminosity as displayed in ui
-	float GetActorUILuminosity();
+	float GetActorVisibility();
 
 	float GetActorJumpSpeed() const;
 	void SetActorJumpSpeed(float jump_speed);
@@ -1274,7 +1273,7 @@ struct SafeWrapBase
         ai().script_engine().lua_error_not_crash(ai().script_engine().lua());
     }
 
-    // This generic function accepts ANY instance type (const or non-const) 
+    // This generic function accepts ANY instance type (const or non-const)
     // and ANY member function pointer type.
     template <typename InstanceT, typename FuncT, typename... Args>
     static auto execute(InstanceT instance, FuncT memFunc, Args&&... args)

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -505,10 +505,10 @@ void CScriptGameObject::MoveItemToRuck(CScriptGameObject* pItem)
 			"CScriptGameObject::MoveItemToRuck non-CInventoryOwner object !!!");
 		return;
 	}
-	
+
 	if (!owner->inventory().CanPutInRuck(item))
 		return;
-	
+
 	NET_Packet P;
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2RUCK, owner->object_id());
 	P.w_u16(item->object().ID());
@@ -525,7 +525,7 @@ void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id, bo
 			"CScriptGameObject::MoveItemToSlot non-CInventoryOwner object !!!");
 		return;
 	}
-	
+
 	// Have a crash if you want
 	/*
 	if (!owner->inventory().CanPutInSlot(item, slot_id))
@@ -535,7 +535,7 @@ void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id, bo
 		return;
 	}
 	*/
-	
+
 	CInventoryItem* item_in_slot = owner->inventory().ItemFromSlot(slot_id);
 
 	NET_Packet P;
@@ -545,7 +545,7 @@ void CScriptGameObject::MoveItemToSlot(CScriptGameObject* pItem, u16 slot_id, bo
 		P.w_u16(item_in_slot->object().ID());
 		CGameObject::u_EventSend(P);
 	}
-	
+
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2SLOT, owner->object_id());
 	P.w_u16(item->object().ID());
 	P.w_u16(slot_id);
@@ -563,10 +563,10 @@ void CScriptGameObject::MoveItemToBelt(CScriptGameObject* pItem)
 			"CScriptGameObject::MoveItemToBelt non-CInventoryOwner object !!!");
 		return;
 	}
-	
+
 	if (!owner->inventory().CanPutInBelt(item))
 		return;
-	
+
 	NET_Packet P;
 	CGameObject::u_EventGen(P, GEG_PLAYER_ITEM2BELT, owner->object_id());
 	P.w_u16(item->object().ID());
@@ -2623,17 +2623,16 @@ void CScriptGameObject::SetWeight(float w)
 	inventory_item->SetWeight(w);
 }
 
-// demonized: get luminosity as displayed in ui
-float CScriptGameObject::GetActorUILuminosity()
+float CScriptGameObject::GetActorVisibility()
 {
 	CActor* pActor = smart_cast<CActor*>(&object());
 	if (!pActor)
 	{
 		ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeError,
-			"CScriptGameObject::GetActorLuminosity, object is not actor");
+			"CScriptGameObject::GetActorVisibility, object is not actor");
 		return 0.f;
 	}
-	return pActor->GetUILuminosity();
+	return pActor->GetVisibility();
 }
 
 float CScriptGameObject::GetActorJumpSpeed() const

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -274,7 +274,7 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 
 		.def("item_allow_trade", &CScriptGameObject::ItemAllowTrade)
 		.def("item_deny_trade", &CScriptGameObject::ItemDenyTrade)
-	
+
 		.def("switch_to_trade", &CScriptGameObject::SwitchToTrade)
 		.def("switch_to_upgrade", &CScriptGameObject::SwitchToUpgrade)
 		.def("switch_to_talk", &CScriptGameObject::SwitchToTalk)
@@ -632,8 +632,9 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("update_weight", SAFE_WRAP(&CScriptGameObject::UpdateWeight))
 		.def("get_total_weight_force_update", SAFE_WRAP(&CScriptGameObject::GetTotalWeightForceUpdate))
 
-		// demonized: get luminosity as displayed in ui
-		.def("get_actor_ui_luminosity", &CScriptGameObject::GetActorUILuminosity)
+        // NLTP_ASHES : get_actor_ui_luminosity deprecated. Prefer using get_actor_visibility, which better describes what the value represents
+		.def("get_actor_ui_luminosity", &CScriptGameObject::GetActorVisibility)
+        .def("get_actor_visibility", &CScriptGameObject::GetActorVisibility)
 
 		.def("weight", SAFE_WRAP(&CScriptGameObject::Weight))
 

--- a/src/xrGame/ui/UIMainIngameWnd.cpp
+++ b/src/xrGame/ui/UIMainIngameWnd.cpp
@@ -114,7 +114,7 @@ void CUIMainIngameWnd::Init()
 	/*	UIWeaponBack.AttachChild	(&UIWeaponSignAmmo);
 		xml_init.InitStatic			(uiXml, "static_ammo", 0, &UIWeaponSignAmmo);
 		UIWeaponSignAmmo.SetEllipsis	(CUIStatic::eepEnd, 2);
-	
+
 		UIWeaponBack.AttachChild	(&UIWeaponIcon);
 		xml_init.InitStatic			(uiXml, "static_wpn_icon", 0, &UIWeaponIcon);
 		UIWeaponIcon.SetShader		(GetEquipmentIconsShader());
@@ -129,7 +129,7 @@ void CUIMainIngameWnd::Init()
 	m_iPickUpItemIconY = UIPickUpItemIcon->GetWndRect().top;
 	//---------------------------------------------------------
 
-	//индикаторы 
+	//индикаторы
 	UIZoneMap->Init();
 
 	// Подсказки, которые возникают при наведении прицела на объект
@@ -167,12 +167,12 @@ void CUIMainIngameWnd::Init()
 	m_ind_boost_power->Show(false);
 	m_ind_boost_rad->Show(false);
 
-	// Загружаем иконки 
+	// Загружаем иконки
 	/*	if ( IsGameTypeSingle() )
 		{
 			xml_init.InitStatic		(uiXml, "starvation_static", 0, &UIStarvationIcon);
 			UIStarvationIcon.Show	(false);
-	
+
 	//		xml_init.InitStatic		(uiXml, "psy_health_static", 0, &UIPsyHealthIcon);
 	//		UIPsyHealthIcon.Show	(false);
 		}
@@ -286,16 +286,17 @@ void CUIMainIngameWnd::Draw()
 	}
 	FS.dwOpenCounter = 0;
 
-	if (!IsGameTypeSingle())
-	{
-		float luminocity = smart_cast<CGameObject*>(Level().CurrentEntity())->ROS()->get_luminocity();
-		float power = log(luminocity > .001f ? luminocity : .001f) * (1.f/*luminocity_factor*/);
-		luminocity = exp(power);
+    if (!IsGameTypeSingle())
+    {
+        CActor* pActor = smart_cast<CActor*>(Level().CurrentViewEntity());
+        float luminocity = pActor->ROS()->get_luminocity();
+        float power = log(luminocity > .001f ? luminocity : .001f) * (1.f);
+        luminocity = exp(power);
 
-		static float cur_lum = luminocity;
-		cur_lum = luminocity * 0.01f + cur_lum * 0.99f;
-		UIMotionIcon->SetLuminosity((s16)iFloor(cur_lum * 100.0f));
-	}
+        static float cur_lum = luminocity;
+        cur_lum = luminocity * 0.01f + cur_lum * 0.99f;
+        pActor->SetVisibilityValue((s16)iFloor(cur_lum * 100.0f));
+    }
 	if (!pActor || !pActor->g_Alive()) return;
 
 	UIMotionIcon->SetNoise((s16)(0xffff & iFloor(pActor->m_snd_noise * 100)));
@@ -477,10 +478,10 @@ void CUIMainIngameWnd::SetWarningIconColor(EWarningIcons icon, const u32 cl)
 			case ewiWound:
 				SetWarningIconColorUI	(&UIWoundIcon, cl);
 				if (bMagicFlag) break;
-		
+
 			case ewiStarvation:
 				SetWarningIconColorUI	(&UIStarvationIcon, cl);
-				if (bMagicFlag) break;	
+				if (bMagicFlag) break;
 			case ewiPsyHealth:
 				SetWarningIconColorUI	(&UIPsyHealthIcon, cl);
 				if (bMagicFlag) break;
@@ -649,7 +650,6 @@ void CUIMainIngameWnd::OnSectorChanged(int sector)
 void CUIMainIngameWnd::reset_ui()
 {
 	m_pPickUpItem = NULL;
-	UIMotionIcon->ResetVisibility();
 	if (m_ui_hud_states)
 	{
 		m_ui_hud_states->reset_ui();
@@ -1089,7 +1089,7 @@ void CUIMainIngameWnd::UpdateBoosterIndicators(const xr_map<EBoostParams, SBoost
 ::luabind::object CUIMainIngameWnd::GetQuickSlotIconsScript()
 {
 	::luabind::object table = ::luabind::newtable(ai().script_engine().lua());
-	
+
 	for (int i = 0; i < m_quick_slots_icons.size(); i++)
 	{
 		table[i + 1] = m_quick_slots_icons[i];

--- a/src/xrGame/ui/UIMotionIcon.cpp
+++ b/src/xrGame/ui/UIMotionIcon.cpp
@@ -2,27 +2,16 @@
 #include "UIMainIngameWnd.h"
 #include "UIMotionIcon.h"
 #include "UIXmlInit.h"
-const LPCSTR MOTION_ICON_XML = "motion_icon.xml";
+#include "../actor.cpp"
 
-CUIMotionIcon* g_pMotionIcon = NULL;
+const LPCSTR MOTION_ICON_XML = "motion_icon.xml";
 
 CUIMotionIcon::CUIMotionIcon()
 {
-	g_pMotionIcon = this;
-	m_bchanged = true;
-	m_luminosity = 0.0f;
-	cur_pos = 0.f;
 }
 
 CUIMotionIcon::~CUIMotionIcon()
 {
-	g_pMotionIcon = NULL;
-}
-
-void CUIMotionIcon::ResetVisibility()
-{
-	m_npc_visibility.clear();
-	m_bchanged = true;
 }
 
 void CUIMotionIcon::Init(Frect const& zonemap_rect)
@@ -45,9 +34,6 @@ void CUIMotionIcon::Init(Frect const& zonemap_rect)
 	float k = UI().get_current_kx();
 	sz.mul(rel_sz * k);
 
-
-	//float h = Device.dwHeight;
-	//float w = Device.dwWidth;
 	AttachChild(&m_luminosity_progress);
 	xml_init.InitProgressShape(uiXml, "luminosity_progress", 0, &m_luminosity_progress);
 	m_luminosity_progress.SetWndSize(sz);
@@ -59,7 +45,7 @@ void CUIMotionIcon::Init(Frect const& zonemap_rect)
 	m_noise_progress.SetWndPos(pos);
 }
 
-void CUIMotionIcon::SetNoise(float Pos)
+void CUIMotionIcon::SetNoise(float pos)
 {
 	if (!IsGameTypeSingle())
 		return;
@@ -67,19 +53,8 @@ void CUIMotionIcon::SetNoise(float Pos)
 	if (!IsShown())
 		return;
 
-	Pos = clampr(Pos, 0.f, 100.f);
-	m_noise_progress.SetPos(Pos / 100.f);
-}
-
-void CUIMotionIcon::SetLuminosity(float Pos)
-{
-	if (!IsGameTypeSingle())
-		return;
-
-	if (!IsShown())
-		return;
-
-	m_luminosity = Pos;
+	pos = clampr(pos, 0.f, 100.f);
+	m_noise_progress.SetPos(pos / 100.f);
 }
 
 void CUIMotionIcon::Draw()
@@ -101,92 +76,8 @@ void CUIMotionIcon::Update()
 	if (!IsShown())
 		return;
 
-	if (m_bchanged)
-	{
-		m_bchanged = false;
-		if (m_npc_visibility.size())
-		{
-			std::sort(m_npc_visibility.begin(), m_npc_visibility.end());
-			SetLuminosity(m_npc_visibility.back().value);
-		}
-		else
-			SetLuminosity(0.f);
-	}
 	inherited::Update();
 
-	//m_luminosity_progress 
-	if (cur_pos != m_luminosity)
-	{
-		float _diff = _abs(m_luminosity - cur_pos);
-		if (m_luminosity > cur_pos)
-		{
-			cur_pos += _diff * Device.fTimeDelta;
-		}
-		else
-		{
-			cur_pos -= _diff * Device.fTimeDelta;
-		}
-		clamp(cur_pos, 0.f, 100.f);
-		m_luminosity_progress.SetPos(cur_pos / 100.f);
-	}
-}
-
-float CUIMotionIcon::GetLuminosity()
-{
-	return m_luminosity_progress.m_stage;
-}
-
-void SetActorVisibility(u16 who_id, float value)
-{
-	if (!IsGameTypeSingle())
-		return;
-
-	if (g_pMotionIcon)
-		g_pMotionIcon->SetActorVisibility(who_id, value);
-}
-
-float GetActorLuminosity()
-{
-	if (!IsGameTypeSingle())
-		return 0.f;
-
-	if (g_pMotionIcon) {
-		float lum = g_pMotionIcon->GetLuminosity();
-		clamp(lum, 0.f, 1.f);
-		return lum;
-	}
-	return 0.f;
-}
-
-void CUIMotionIcon::SetActorVisibility(u16 who_id, float value)
-{
-	// demonized: commented out to always update 
-	/*if (!IsShown())
-		return;*/
-
-	clamp(value, 0.f, 1.f);
-	value *= 100.f;
-
-	xr_vector<_npc_visibility>::iterator it = std::find(m_npc_visibility.begin(),
-	                                                    m_npc_visibility.end(),
-	                                                    who_id);
-
-	if (it == m_npc_visibility.end() && value != 0)
-	{
-		m_npc_visibility.resize(m_npc_visibility.size() + 1);
-		_npc_visibility& v = m_npc_visibility.back();
-		v.id = who_id;
-		v.value = value;
-	}
-	else if (fis_zero(value))
-	{
-		if (it != m_npc_visibility.end())
-			m_npc_visibility.erase(it);
-	}
-	else
-	{
-		(*it).value = value;
-	}
-
-	m_bchanged = true;
+    float cur_vis = GetActorVisibility();
+    m_luminosity_progress.SetPos(cur_vis);
 }

--- a/src/xrGame/ui/UIMotionIcon.h
+++ b/src/xrGame/ui/UIMotionIcon.h
@@ -10,29 +10,6 @@ private:
 	CUIProgressShape m_luminosity_progress;
 	CUIProgressShape m_noise_progress;
 
-	struct _npc_visibility
-	{
-		u16 id;
-		float value;
-
-		bool operator ==(const u16& _id)
-		{
-			return id == _id;
-		}
-
-		bool operator <(const _npc_visibility& m) const
-		{
-			return (value < m.value);
-		}
-	};
-
-	xr_vector<_npc_visibility> m_npc_visibility;
-	bool m_bchanged;
-	float m_luminosity;
-	float cur_pos;
-
-public:
-	float GetLuminosity();
 
 public:
 	virtual ~CUIMotionIcon();
@@ -41,7 +18,4 @@ public:
 	virtual void Draw();
 	void Init(Frect const& rect);
 	void SetNoise(float Pos);
-	void SetLuminosity(float Pos);
-	void SetActorVisibility(u16 who_id, float value);
-	void ResetVisibility();
 };


### PR DESCRIPTION
- Moved visibility source of truth from UIMotionIcon.cpp to Actor.cpp;
- Fixed visibility value not updating when player has minimap hidden;
- Fixed typo in get_actor_ui_luminosity in lua_help_ex.script;
- Created new engine export get_actor_visibility to read this value;
- Deprecated get_actor_ui_luminosity due to its bad naming;