### PR TITLE
feat(luajit): low-overhead CPU and allocation profilers (jit.profile, jit.allocprof)

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -133,6 +133,21 @@
         table.random(t)
     }
 
+    jit.profile { // profiler-enabled build only; backported LuaJIT 2.1 timer sampler, GC64-free so saves stay compatible
+        jit.profile.start(string mode, function(thread, int samples, string vmstate)) // mode "iN" = sample every N ms; vmstate one of N/I/C/G/J; errors if jit.allocprof is running
+        jit.profile.stop()
+        string jit.profile.dumpstack(thread, string fmt, int depth) // "name@src:line;..." leaf-first; fmt accepted but ignored (fixed format)
+    }
+
+    jit.allocprof { // profiler-enabled build only; per-function allocation attribution, jit.off() recommended for exact attribution
+        jit.allocprof.start(int depth = 1) // byte-sampled (Poisson interval); depth>1 also captures full stacks for a flamegraph; errors if jit.profile is running
+        jit.allocprof.stop()
+        table jit.allocprof.dump(bool stacks, bool reset) // {{key=,bytes=},...} + dropped/pending/drains/seen; reset clears tables but keeps capturing
+        int jit.allocprof.usage() // 0..100 fill of the fullest aggregation table, snapshot before it reaches 100
+        jit.allocprof.pause() // disarm the hook to build a snapshot report at full speed
+        jit.allocprof.resume() // re-arm and continue capturing
+    }
+
     globals {
         string dik_to_keyname(number dik, boolean localize)
         int get_modded_exes_version() // Returns modded exes version in integer format

--- a/src/3rd party/luajit-2/src/lib_jit.c
+++ b/src/3rd party/luajit-2/src/lib_jit.c
@@ -28,6 +28,12 @@
 #include "lj_vm.h"
 #include "lj_vmevent.h"
 #include "lj_lib.h"
+#if LJ_HASPROFILE
+#include "lj_gc.h"
+#include "lj_trace.h"
+#include "lj_profile.h"
+#include "lj_allocprof.h"
+#endif
 
 #include "luajit.h"
 
@@ -513,6 +519,169 @@ LJLIB_CF(jit_opt_start)
 
 #endif
 
+/* -- jit.profile module (backported from LuaJIT 2.1) --------------------- */
+
+#if LJ_HASPROFILE
+
+#define LJLIB_MODULE_jit_profile
+
+#define KEY_PROFILE_THREAD	(U64x(81000000,00000000)|'t')
+#define KEY_PROFILE_FUNC	(U64x(81000000,00000000)|'f')
+
+static void jit_profile_callback(lua_State *L2, lua_State *L, int samples,
+				 int vmstate)
+{
+  TValue key;
+  cTValue *tv;
+  key.u64 = KEY_PROFILE_FUNC;
+  tv = lj_tab_get(L, tabV(registry(L)), &key);
+  if (tvisfunc(tv)) {
+    char vmst = (char)vmstate;
+    int status;
+    setfuncV(L2, L2->top++, funcV(tv));
+    setthreadV(L2, L2->top++, L);
+    setintV(L2->top++, samples);
+    setstrV(L2, L2->top++, lj_str_new(L2, &vmst, 1));
+    status = lua_pcall(L2, 3, 0, 0);  /* callback(thread, samples, vmstate) */
+    if (status) {
+      if (G(L2)->panic) G(L2)->panic(L2);
+      exit(EXIT_FAILURE);
+    }
+    lj_trace_abort(G(L2));
+  }
+}
+
+/* profile.start(mode, cb) */
+LJLIB_CF(jit_profile_start)
+{
+  GCtab *registry = tabV(registry(L));
+  GCstr *mode = lj_lib_optstr(L, 1);
+  GCfunc *func = lj_lib_checkfunc(L, 2);
+  lua_State *L2;
+  TValue key;
+  if (lj_allocprof_active)
+    lj_err_callermsg(L, "jit.profile cannot start while jit.allocprof is running");
+  L2 = lua_newthread(L);  /* Thread that runs profiler callback. */
+  /* Anchor thread and function in registry. */
+  key.u64 = KEY_PROFILE_THREAD;
+  setthreadV(L, lj_tab_set(L, registry, &key), L2);
+  key.u64 = KEY_PROFILE_FUNC;
+  setfuncV(L, lj_tab_set(L, registry, &key), func);
+  lj_gc_anybarriert(L, registry);
+  luaJIT_profile_start(L, mode ? strdata(mode) : "",
+		       (luaJIT_profile_callback)jit_profile_callback, L2);
+  return 0;
+}
+
+/* profile.stop() */
+LJLIB_CF(jit_profile_stop)
+{
+  GCtab *registry;
+  TValue key;
+  luaJIT_profile_stop(L);
+  registry = tabV(registry(L));
+  key.u64 = KEY_PROFILE_THREAD;
+  setnilV(lj_tab_set(L, registry, &key));
+  key.u64 = KEY_PROFILE_FUNC;
+  setnilV(lj_tab_set(L, registry, &key));
+  lj_gc_anybarriert(L, registry);
+  return 0;
+}
+
+/* dump = profile.dumpstack([thread,] fmt, depth) */
+LJLIB_CF(jit_profile_dumpstack)
+{
+  lua_State *L2 = L;
+  int arg = 0;
+  size_t len;
+  int depth;
+  GCstr *fmt;
+  const char *p;
+  if (L->top > L->base && tvisthread(L->base)) {
+    L2 = threadV(L->base);
+    arg = 1;
+  }
+  fmt = lj_lib_checkstr(L, arg+1);
+  depth = lj_lib_checkint(L, arg+2);
+  p = luaJIT_profile_dumpstack(L2, strdata(fmt), depth, &len);
+  lua_pushlstring(L, p, len);
+  return 1;
+}
+
+#include "lj_libdef.h"
+
+#endif
+
+/* -- jit.allocprof module (allocation profiler) ------------------------- */
+
+#if LJ_HASPROFILE
+
+#define LJLIB_MODULE_jit_allocprof
+
+/* allocprof.start([depth]) -- jit.off() recommended for exact attribution; depth>1 also builds full stacks */
+LJLIB_CF(jit_allocprof_start)
+{
+  if (lj_profile_active())
+    lj_err_callermsg(L, "jit.allocprof cannot start while jit.profile is running");
+  lj_allocprof_start(L, lj_lib_optint(L, 1, 1));
+  return 0;
+}
+
+/* allocprof.stop() */
+LJLIB_CF(jit_allocprof_stop)
+{
+  lj_allocprof_stop(L);
+  return 0;
+}
+
+/* results = allocprof.dump([stacks[, reset]]) -- reset clears tables but keeps capturing */
+LJLIB_CF(jit_allocprof_dump)
+{
+  int stacks = (L->top > L->base) && lua_toboolean(L, 1);
+  int reset = (L->top > L->base + 1) && lua_toboolean(L, 2);
+  int slots = lj_allocprof_slots(stacks);
+  int k, i = 0;
+  lua_createtable(L, lj_allocprof_count(stacks), 4);
+  for (k = 0; k < slots; k++) {
+    const AllocProfEntry *e = lj_allocprof_slot(stacks, k);
+    if (!e) continue;
+    lua_createtable(L, 0, 2);
+    lua_pushstring(L, e->key);                lua_setfield(L, -2, "key");
+    lua_pushnumber(L, (lua_Number)e->bytes);  lua_setfield(L, -2, "bytes");
+    lua_rawseti(L, -2, ++i);
+  }
+  lua_pushnumber(L, (lua_Number)lj_allocprof_dropped);  lua_setfield(L, -2, "dropped");
+  lua_pushnumber(L, (lua_Number)lj_allocprof_pending);  lua_setfield(L, -2, "pending");
+  lua_pushnumber(L, (lua_Number)lj_allocprof_drains);   lua_setfield(L, -2, "drains");
+  lua_pushnumber(L, (lua_Number)lj_allocprof_seen);     lua_setfield(L, -2, "seen");
+  if (reset) lj_allocprof_reset();
+  return 1;
+}
+
+/* pct = allocprof.usage() -- 0..100, fullest table */
+LJLIB_CF(jit_allocprof_usage)
+{
+  lua_pushinteger(L, lj_allocprof_usage());
+  return 1;
+}
+
+/* allocprof.pause() / allocprof.resume() -- around a snapshot report build */
+LJLIB_CF(jit_allocprof_pause)
+{
+  lj_allocprof_pause();
+  return 0;
+}
+
+LJLIB_CF(jit_allocprof_resume)
+{
+  lj_allocprof_resume();
+  return 0;
+}
+
+#include "lj_libdef.h"
+
+#endif
+
 /* -- JIT compiler initialization ----------------------------------------- */
 
 #if LJ_HASJIT
@@ -637,7 +806,7 @@ static void jit_init(lua_State *L)
 #endif
     J->flags = flags | JIT_F_ON | JIT_F_OPT_DEFAULT;
   memcpy(J->param, jit_param_default, sizeof(J->param));
-  lj_dispatch_update(G(L));
+  lj_dispatch_update(G(L), 0);
 #else
   UNUSED(flags);
 #endif
@@ -655,6 +824,10 @@ LUALIB_API int luaopen_jit(lua_State *L)
 #endif
 #if LJ_HASJIT
   LJ_LIB_REG(L, "jit.opt", jit_opt);
+#endif
+#if LJ_HASPROFILE
+  LJ_LIB_REG(L, "jit.profile", jit_profile);
+  LJ_LIB_REG(L, "jit.allocprof", jit_allocprof);
 #endif
   L->top -= 2;
   jit_init(L);

--- a/src/3rd party/luajit-2/src/lj_allocprof.c
+++ b/src/3rd party/luajit-2/src/lj_allocprof.c
@@ -1,0 +1,214 @@
+/*
+** Allocation profiler: byte-sampled per-function attribution (jit.allocprof).
+*/
+
+#define lj_allocprof_c
+#define LUA_CORE
+
+#include "lj_obj.h"
+
+#if LJ_HASPROFILE
+
+#include "lj_allocprof.h"
+#include "lj_dispatch.h"
+#include "lj_profile.h"
+#include "lj_trace.h"
+#include "luajit.h"
+
+#include <string.h>
+#include <math.h>
+
+#define ALLOCPROF_LEAF_SLOTS	4096
+#define ALLOCPROF_STACK_SLOTS	16384
+#define ALLOCPROF_MAX_DEPTH	64
+#define ALLOCPROF_SAMPLE_MEAN	8192
+
+int lj_allocprof_active = 0;
+uint64_t lj_allocprof_pending = 0;
+uint64_t lj_allocprof_dropped = 0;
+uint64_t lj_allocprof_drains = 0;
+uint64_t lj_allocprof_seen = 0;
+
+static struct {
+  global_State *g;
+  int depth;
+  int leaf_used;
+  int stack_used;
+  uint8_t saved_mask;
+  int32_t saved_count;
+  int32_t saved_cstart;
+  AllocProfEntry leaf[ALLOCPROF_LEAF_SLOTS];
+  AllocProfEntry stack[ALLOCPROF_STACK_SLOTS];
+} AS;
+
+static uint32_t allocprof_hash(const char *s, size_t n)
+{
+  uint32_t h = 2166136261u;
+  while (n--) { h ^= (uint8_t)*s++; h *= 16777619u; }
+  return h;
+}
+
+/* Keys longer than the entry buffer are truncated BEFORE hash and compare, so a long stack aggregates into one entry instead of flooding the table. */
+static void allocprof_record(AllocProfEntry *tab, int slots, int *used,
+			     const char *key, uint64_t bytes)
+{
+  size_t n = strlen(key);
+  uint32_t h, i;
+  if (n >= sizeof(tab->key)) n = sizeof(tab->key) - 1;
+  h = allocprof_hash(key, n) & (uint32_t)(slots - 1);
+  for (i = 0; i < (uint32_t)slots; i++) {
+    AllocProfEntry *e = &tab[(h + i) & (uint32_t)(slots - 1)];
+    if (e->bytes == 0) {
+      memcpy(e->key, key, n);
+      e->key[n] = '\0';
+      e->bytes = bytes;
+      (*used)++;
+      return;
+    }
+    if (e->key[n] == '\0' && memcmp(e->key, key, n) == 0) {
+      e->bytes += bytes;
+      return;
+    }
+  }
+  lj_allocprof_dropped += bytes;
+}
+
+static uint64_t allocprof_rng = 0x9e3779b97f4a7c15ull;
+static uint64_t allocprof_next = 0;
+
+/* Next sample distance from exp(mean): randomized to avoid fixed-interval aliasing. */
+static uint64_t allocprof_sample_dist(void)
+{
+  uint64_t x = allocprof_rng;
+  double u, d;
+  x ^= x << 13; x ^= x >> 7; x ^= x << 17;
+  allocprof_rng = x;
+  u = ((double)(x >> 11) + 1.0) / 9007199254740993.0;
+  d = -(double)ALLOCPROF_SAMPLE_MEAN * log(u);
+  return d < 1.0 ? 1u : (uint64_t)d;
+}
+
+LJ_NOINLINE void LJ_FASTCALL lj_allocprof_interpreter(lua_State *L)
+{
+  uint64_t bytes = lj_allocprof_pending;
+  size_t len;
+  const char *st;
+  lj_allocprof_drains++;
+  if (bytes < allocprof_next) return;
+  lj_allocprof_pending = 0;
+  lj_allocprof_seen += bytes;
+  allocprof_next = allocprof_sample_dist();
+  st = luaJIT_profile_dumpstack(L, "", AS.depth, &len);
+  if (!st || !st[0]) return;
+  {
+    const char *semi = strchr(st, ';');
+    size_t llen = semi ? (size_t)(semi - st) : len;
+    char leafkey[192];
+    if (llen >= sizeof(leafkey)) llen = sizeof(leafkey) - 1;
+    memcpy(leafkey, st, llen);
+    leafkey[llen] = '\0';
+    allocprof_record(AS.leaf, ALLOCPROF_LEAF_SLOTS, &AS.leaf_used, leafkey, bytes);
+  }
+  if (AS.depth > 1)
+    allocprof_record(AS.stack, ALLOCPROF_STACK_SLOTS, &AS.stack_used, st, bytes);
+}
+
+void lj_allocprof_start(lua_State *L, int depth)
+{
+  global_State *g = G(L);
+  if (lj_profile_active()) return;
+  if (AS.g) {
+    lj_allocprof_stop(L);
+    if (AS.g) return;
+  }
+  if (depth < 1) depth = 1;
+  if (depth > ALLOCPROF_MAX_DEPTH) depth = ALLOCPROF_MAX_DEPTH;
+  memset(&AS, 0, sizeof(AS));
+  AS.g = g;
+  AS.depth = depth;
+  AS.saved_mask = g->hookmask;
+  AS.saved_count = g->hookcount;
+  AS.saved_cstart = g->hookcstart;
+  lj_allocprof_pending = 0;
+  lj_allocprof_dropped = 0;
+  lj_allocprof_drains = 0;
+  lj_allocprof_seen = 0;
+  allocprof_next = allocprof_sample_dist();
+  lj_allocprof_active = 1;
+  lj_trace_abort(g);  /* The drain bypasses lj_trace_ins; abort any in-progress recording. */
+  /* LUA_MASKLINE forces the per-instruction trap the drain uses (JIT traces bypass it). */
+  g->hookmask = (uint8_t)(g->hookmask | HOOK_PROFILE | LUA_MASKLINE);
+  lj_dispatch_update(g, 0);
+}
+
+void lj_allocprof_stop(lua_State *L)
+{
+  global_State *g = AS.g;
+  if (G(L) == g) {
+    lj_allocprof_active = 0;
+    AS.g = NULL;
+    g->hookmask = (uint8_t)((g->hookmask & ~(HOOK_PROFILE | LUA_MASKLINE)) |
+			    (AS.saved_mask & (HOOK_PROFILE | LUA_MASKLINE)));
+    g->hookcount = AS.saved_count;
+    g->hookcstart = AS.saved_cstart;
+    lj_dispatch_update(g, 0);
+  }
+}
+
+void lj_allocprof_reset(void)
+{
+  if (!AS.g) return;
+  memset(AS.leaf, 0, sizeof(AS.leaf));
+  memset(AS.stack, 0, sizeof(AS.stack));
+  AS.leaf_used = 0;
+  AS.stack_used = 0;
+  lj_allocprof_dropped = 0;
+  lj_allocprof_drains = 0;
+  lj_allocprof_seen = 0;
+}
+
+void lj_allocprof_pause(void)
+{
+  global_State *g = AS.g;
+  if (!g || !lj_allocprof_active) return;
+  lj_allocprof_active = 0;
+  g->hookmask &= (uint8_t)~(HOOK_PROFILE | LUA_MASKLINE);
+  lj_dispatch_update(g, 0);
+}
+
+void lj_allocprof_resume(void)
+{
+  global_State *g = AS.g;
+  if (!g || lj_allocprof_active) return;
+  lj_allocprof_pending = 0;
+  lj_allocprof_active = 1;
+  lj_trace_abort(g);
+  g->hookmask = (uint8_t)(g->hookmask | HOOK_PROFILE | LUA_MASKLINE);
+  lj_dispatch_update(g, 0);
+}
+
+int lj_allocprof_count(int stacks)
+{
+  return stacks ? AS.stack_used : AS.leaf_used;
+}
+
+int lj_allocprof_usage(void)
+{
+  int leaf_pct = (int)((int64_t)AS.leaf_used * 100 / ALLOCPROF_LEAF_SLOTS);
+  int stack_pct = (AS.depth > 1)
+    ? (int)((int64_t)AS.stack_used * 100 / ALLOCPROF_STACK_SLOTS) : 0;
+  return leaf_pct > stack_pct ? leaf_pct : stack_pct;
+}
+
+int lj_allocprof_slots(int stacks)
+{
+  return stacks ? ALLOCPROF_STACK_SLOTS : ALLOCPROF_LEAF_SLOTS;
+}
+
+const AllocProfEntry *lj_allocprof_slot(int stacks, int k)
+{
+  AllocProfEntry *tab = stacks ? AS.stack : AS.leaf;
+  return tab[k].bytes ? &tab[k] : NULL;
+}
+
+#endif

--- a/src/3rd party/luajit-2/src/lj_allocprof.h
+++ b/src/3rd party/luajit-2/src/lj_allocprof.h
@@ -1,0 +1,36 @@
+/*
+** Allocation profiler: byte-sampled per-function attribution (jit.allocprof).
+*/
+
+#ifndef _LJ_ALLOCPROF_H
+#define _LJ_ALLOCPROF_H
+
+#include "lj_obj.h"
+
+#if LJ_HASPROFILE
+
+typedef struct AllocProfEntry {
+  char key[512];
+  uint64_t bytes;
+} AllocProfEntry;
+
+extern int lj_allocprof_active;
+extern uint64_t lj_allocprof_pending;
+extern uint64_t lj_allocprof_dropped;
+extern uint64_t lj_allocprof_drains;
+extern uint64_t lj_allocprof_seen;
+
+LJ_FUNC LJ_NOINLINE void LJ_FASTCALL lj_allocprof_interpreter(lua_State *L);
+LJ_FUNC void lj_allocprof_start(lua_State *L, int depth);
+LJ_FUNC void lj_allocprof_stop(lua_State *L);
+LJ_FUNC void lj_allocprof_reset(void);
+LJ_FUNC void lj_allocprof_pause(void);
+LJ_FUNC void lj_allocprof_resume(void);
+LJ_FUNC int lj_allocprof_count(int stacks);
+LJ_FUNC int lj_allocprof_slots(int stacks);
+LJ_FUNC const AllocProfEntry *lj_allocprof_slot(int stacks, int k);
+LJ_FUNC int lj_allocprof_usage(void);
+
+#endif
+
+#endif

--- a/src/3rd party/luajit-2/src/lj_arch.h
+++ b/src/3rd party/luajit-2/src/lj_arch.h
@@ -383,6 +383,22 @@
 #define LJ_HASFFI		1
 #endif
 
+/* Disable or enable the low-overhead profiler (backported from 2.1). */
+#if defined(LUAJIT_DISABLE_PROFILE)
+#define LJ_HASPROFILE		0
+#elif LJ_TARGET_POSIX
+#define LJ_HASPROFILE		1
+#define LJ_PROFILE_SIGPROF	1
+#elif LJ_TARGET_PS3
+#define LJ_HASPROFILE		1
+#define LJ_PROFILE_PTHREAD	1
+#elif LJ_TARGET_WINDOWS || LJ_TARGET_XBOX360
+#define LJ_HASPROFILE		1
+#define LJ_PROFILE_WTHREAD	1
+#else
+#define LJ_HASPROFILE		0
+#endif
+
 #ifndef LJ_ARCH_HASFPU
 #define LJ_ARCH_HASFPU		1
 #endif

--- a/src/3rd party/luajit-2/src/lj_dispatch.c
+++ b/src/3rd party/luajit-2/src/lj_dispatch.c
@@ -27,6 +27,9 @@
 #include "lj_dispatch.h"
 #include "lj_vm.h"
 #include "luajit.h"
+#if LJ_HASPROFILE
+#include "lj_profile.h"
+#endif
 
 /* Bump GG_NUM_ASMFF in lj_dispatch.h as needed. Ugly. */
 LJ_STATIC_ASSERT(GG_NUM_ASMFF == FF_NUM_ASMFUNC);
@@ -89,14 +92,22 @@ void lj_dispatch_init_hotcount(global_State *g)
 #define DISPMODE_RET	0x10	/* Override return dispatch. */
 
 /* Update dispatch table depending on various flags. */
-void lj_dispatch_update(global_State *g)
+void lj_dispatch_update(global_State *g, int nolock)
 {
   uint8_t oldmode = g->dispatchmode;
   uint8_t mode = 0;
+#if LJ_HASPROFILE && !LJ_PROFILE_SIGPROF
+  int profile_locked = nolock ? 0 : lj_profile_lock();
+#else
+  UNUSED(nolock);
+#endif
 #if LJ_HASJIT
   mode |= (G2J(g)->flags & JIT_F_ON) ? DISPMODE_JIT : 0;
   mode |= G2J(g)->state != LJ_TRACE_IDLE ?
 	    (DISPMODE_REC|DISPMODE_INS|DISPMODE_CALL) : 0;
+#endif
+#if LJ_HASPROFILE
+  mode |= (g->hookmask & HOOK_PROFILE) ? DISPMODE_INS : 0;
 #endif
   mode |= (g->hookmask & (LUA_MASKLINE|LUA_MASKCOUNT)) ? DISPMODE_INS : 0;
   mode |= (g->hookmask & LUA_MASKCALL) ? DISPMODE_CALL : 0;
@@ -186,6 +197,9 @@ void lj_dispatch_update(global_State *g)
       lj_dispatch_init_hotcount(g);
 #endif
   }
+#if LJ_HASPROFILE && !LJ_PROFILE_SIGPROF
+  if (profile_locked) lj_profile_unlock();
+#endif
 }
 
 /* -- JIT mode setting ---------------------------------------------------- */
@@ -245,7 +259,7 @@ int luaJIT_setmode(lua_State *L, int idx, int mode)
       else
 	G2J(g)->flags |= (uint32_t)JIT_F_ON;
 #endif
-      lj_dispatch_update(g);
+      lj_dispatch_update(g, 0);
     }
     break;
   case LUAJIT_MODE_FUNC:
@@ -320,7 +334,7 @@ LUA_API int lua_sethook(lua_State *L, lua_Hook func, int mask, int count)
   g->hookcount = g->hookcstart = (int32_t)count;
   g->hookmask = (uint8_t)((g->hookmask & ~HOOK_EVENTMASK) | mask);
   lj_trace_abort(g);  /* Abort recording on any hook change. */
-  lj_dispatch_update(g);
+  lj_dispatch_update(g, 0);
   return 1;
 }
 
@@ -352,10 +366,18 @@ static void callhook(lua_State *L, int event, BCLine line)
     /* Top frame, nextframe = NULL. */
     ar.i_ci = (int)((L->base-1) - tvref(L->stack));
     lj_state_checkstack(L, 1+LUA_MINSTACK);
+#if LJ_HASPROFILE && !LJ_PROFILE_SIGPROF
+    lj_profile_hook_enter(g);
+#else
     hook_enter(g);
+#endif
     hookf(L, &ar);
     lua_assert(hook_active(g));
+#if LJ_HASPROFILE && !LJ_PROFILE_SIGPROF
+    lj_profile_hook_leave(g);
+#else
     hook_leave(g);
+#endif
   }
 }
 
@@ -388,6 +410,14 @@ void LJ_FASTCALL lj_dispatch_ins(lua_State *L, const BCIns *pc)
   setcframe_pc(cf, pc);
   slots = cur_topslot(pt, pc, cframe_multres_n(cf));
   L->top = L->base + slots;  /* Fix top. */
+#if LJ_HASPROFILE
+  if (g->hookmask & HOOK_PROFILE) {
+    lj_profile_interpreter(L);
+    L->top = L->base + slots;
+    ERRNO_RESTORE
+    return;
+  }
+#endif
 #if LJ_HASJIT
   {
     jit_State *J = G2J(g);

--- a/src/3rd party/luajit-2/src/lj_dispatch.h
+++ b/src/3rd party/luajit-2/src/lj_dispatch.h
@@ -104,7 +104,7 @@ LJ_FUNC void lj_dispatch_init(GG_State *GG);
 #if LJ_HASJIT
 LJ_FUNC void lj_dispatch_init_hotcount(global_State *g);
 #endif
-LJ_FUNC void lj_dispatch_update(global_State *g);
+LJ_FUNC void lj_dispatch_update(global_State *g, int nolock);
 
 /* Instruction dispatch callback for hooks or when recording. */
 LJ_FUNCA void LJ_FASTCALL lj_dispatch_ins(lua_State *L, const BCIns *pc);

--- a/src/3rd party/luajit-2/src/lj_gc.c
+++ b/src/3rd party/luajit-2/src/lj_gc.c
@@ -25,6 +25,9 @@
 #endif
 #include "lj_trace.h"
 #include "lj_vm.h"
+#if LJ_HASPROFILE
+#include "lj_allocprof.h"
+#endif
 
 #define GCSTEPSIZE	1024u
 #define GCSWEEPMAX	40
@@ -816,6 +819,10 @@ void *lj_mem_realloc(lua_State *L, void *p, MSize osz, MSize nsz)
   lua_assert((nsz == 0) == (p == NULL));
   lua_assert(checkptr32(p));
   g->gc.total = (g->gc.total - osz) + nsz;
+#if LJ_HASPROFILE
+  if (lj_allocprof_active && nsz > osz)
+    lj_allocprof_pending += (uint64_t)(nsz - osz);
+#endif
   return p;
 }
 
@@ -831,6 +838,10 @@ void * LJ_FASTCALL lj_mem_newgco(lua_State *L, MSize size)
   setgcrefr(o->gch.nextgc, g->gc.root);
   setgcref(g->gc.root, o);
   newwhite(g, o);
+#if LJ_HASPROFILE
+  if (lj_allocprof_active)
+    lj_allocprof_pending += (uint64_t)size;
+#endif
   return o;
 }
 

--- a/src/3rd party/luajit-2/src/lj_obj.h
+++ b/src/3rd party/luajit-2/src/lj_obj.h
@@ -553,6 +553,7 @@ typedef struct global_State {
 #define HOOK_ACTIVE_SHIFT	4
 #define HOOK_VMEVENT		0x20
 #define HOOK_GC			0x40
+#define HOOK_PROFILE		0x80
 #define hook_active(g)		((g)->hookmask & HOOK_ACTIVE)
 #define hook_enter(g)		((g)->hookmask |= HOOK_ACTIVE)
 #define hook_entergc(g)		((g)->hookmask |= (HOOK_ACTIVE|HOOK_GC))

--- a/src/3rd party/luajit-2/src/lj_profile.c
+++ b/src/3rd party/luajit-2/src/lj_profile.c
@@ -1,0 +1,387 @@
+/*
+** Low-overhead profiling.
+** Copyright (C) 2005-2016 Mike Pall. See Copyright Notice in luajit.h
+**
+** Backported from LuaJIT 2.1 to this 2.0.4 fork: native dumpstack (no lj_buf),
+** no prof_mode. Arming rides LUA_MASKLINE, so a sample resolves at the next
+** interpreted bytecode; inside a JIT trace, at the next trace exit (the
+** JIT-compiled (N) share reads as a floor). prof_mode needs JIT-backend codegen.
+*/
+
+#define lj_profile_c
+#define LUA_CORE
+
+#include "lj_obj.h"
+
+#if LJ_HASPROFILE
+
+#include "lj_dispatch.h"
+#include "lj_profile.h"
+#include "lj_allocprof.h"
+
+#include "luajit.h"
+#include "lua.h"
+
+#include <stdio.h>
+
+#if LJ_PROFILE_SIGPROF
+
+#include <sys/time.h>
+#include <signal.h>
+#define profile_lock(ps)	UNUSED(ps)
+#define profile_unlock(ps)	UNUSED(ps)
+
+#elif LJ_PROFILE_PTHREAD
+
+#include <pthread.h>
+#include <time.h>
+#define profile_lock(ps)	pthread_mutex_lock(&ps->lock)
+#define profile_unlock(ps)	pthread_mutex_unlock(&ps->lock)
+
+#elif LJ_PROFILE_WTHREAD
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+typedef unsigned int (WINAPI *WMM_TPFUNC)(unsigned int);
+#define profile_lock(ps)	EnterCriticalSection(&ps->lock)
+#define profile_unlock(ps)	LeaveCriticalSection(&ps->lock)
+
+#endif
+
+/* Profiler state. */
+typedef struct ProfileState {
+  global_State *g;		/* VM state that started the profiler. */
+  luaJIT_profile_callback cb;	/* Profiler callback. */
+  void *data;			/* Profiler callback data. */
+  int interval;			/* Sample interval in milliseconds. */
+  int samples;			/* Number of samples for next callback. */
+  int vmstate;			/* VM state when profile timer triggered. */
+  int added_maskline;		/* Profiler owns the LUA_MASKLINE trap bit. */
+  int32_t saved_count;		/* Saved hookcount, restored on stop. */
+  int32_t saved_cstart;		/* Saved hookcstart, restored on stop. */
+#if LJ_PROFILE_SIGPROF
+  struct sigaction oldsa;	/* Previous SIGPROF state. */
+#elif LJ_PROFILE_PTHREAD
+  pthread_mutex_t lock;		/* g->hookmask update lock. */
+  pthread_t thread;		/* Timer thread. */
+  int abort;			/* Abort timer thread. */
+#elif LJ_PROFILE_WTHREAD
+  HINSTANCE wmm;		/* WinMM library handle. */
+  WMM_TPFUNC wmm_tbp;		/* WinMM timeBeginPeriod function. */
+  WMM_TPFUNC wmm_tep;		/* WinMM timeEndPeriod function. */
+  CRITICAL_SECTION lock;	/* g->hookmask update lock. */
+  HANDLE thread;		/* Timer thread. */
+  int abort;			/* Abort timer thread. */
+#endif
+} ProfileState;
+
+/* Sadly, we have to use a static profiler state. Only one VM at a time. */
+static ProfileState profile_state;
+
+/* Default sample interval in milliseconds. */
+#define LJ_PROFILE_INTERVAL_DEFAULT	10
+
+/* -- Profiler/hook interaction ------------------------------------------- */
+
+#if !LJ_PROFILE_SIGPROF
+void LJ_FASTCALL lj_profile_hook_enter(global_State *g)
+{
+  ProfileState *ps = &profile_state;
+  if (ps->g) {
+    profile_lock(ps);
+    hook_enter(g);
+    profile_unlock(ps);
+  } else {
+    hook_enter(g);
+  }
+}
+
+void LJ_FASTCALL lj_profile_hook_leave(global_State *g)
+{
+  ProfileState *ps = &profile_state;
+  if (ps->g) {
+    profile_lock(ps);
+    hook_leave(g);
+    profile_unlock(ps);
+  } else {
+    hook_leave(g);
+  }
+}
+
+int lj_profile_lock(void)
+{
+  ProfileState *ps = &profile_state;
+  if (ps->g) {
+    profile_lock(ps);
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+void lj_profile_unlock(void)
+{
+  ProfileState *ps = &profile_state;
+  profile_unlock(ps);
+}
+#endif
+
+/* -- Profile callbacks --------------------------------------------------- */
+
+/* Callback from profile hook (HOOK_PROFILE already cleared). */
+void LJ_FASTCALL lj_profile_interpreter(lua_State *L)
+{
+  ProfileState *ps = &profile_state;
+  global_State *g = G(L);
+  uint8_t mask, armbits;
+  if (lj_allocprof_active) {
+    lj_allocprof_interpreter(L);
+    return;
+  }
+  armbits = (uint8_t)(HOOK_PROFILE |
+		      (ps->added_maskline ? LUA_MASKLINE : 0));
+  profile_lock(ps);
+  mask = (uint8_t)(g->hookmask & ~armbits);
+  if (!(mask & HOOK_VMEVENT)) {
+    int samples = ps->samples;
+    ps->samples = 0;
+    g->hookmask = HOOK_VMEVENT;
+    lj_dispatch_update(g, 1);
+    profile_unlock(ps);
+    ps->cb(ps->data, L, samples, ps->vmstate);  /* Invoke user callback. */
+    profile_lock(ps);
+    mask |= (uint8_t)(g->hookmask & armbits);
+  }
+  g->hookmask = mask;
+  lj_dispatch_update(g, 1);
+  profile_unlock(ps);
+}
+
+/* Trigger profile hook. Asynchronous call from OS-specific profile timer. */
+static void profile_trigger(ProfileState *ps)
+{
+  global_State *g = ps->g;
+  uint8_t mask;
+  profile_lock(ps);
+  ps->samples++;  /* Always increment number of samples. */
+  mask = g->hookmask;
+  if (!(mask & (HOOK_PROFILE|HOOK_VMEVENT|HOOK_GC))) {  /* Set profile hook. */
+    int st = g->vmstate;
+    ps->vmstate = st >= 0 ? 'N' :
+		  st == ~LJ_VMST_INTERP ? 'I' :
+		  st == ~LJ_VMST_C ? 'C' :
+		  st == ~LJ_VMST_GC ? 'G' : 'J';
+    g->hookmask = (uint8_t)(mask | HOOK_PROFILE |
+			    (ps->added_maskline ? LUA_MASKLINE : 0));
+    lj_dispatch_update(g, 1);
+  }
+  profile_unlock(ps);
+}
+
+/* -- OS-specific profile timer handling ---------------------------------- */
+
+#if LJ_PROFILE_SIGPROF
+
+/* SIGPROF handler. */
+static void profile_signal(int sig)
+{
+  UNUSED(sig);
+  profile_trigger(&profile_state);
+}
+
+/* Start profiling timer. */
+static void profile_timer_start(ProfileState *ps)
+{
+  int interval = ps->interval;
+  struct itimerval tm;
+  struct sigaction sa;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = interval / 1000;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = (interval % 1000) * 1000;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sa.sa_flags = SA_RESTART;
+  sa.sa_handler = profile_signal;
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGPROF, &sa, &ps->oldsa);
+}
+
+/* Stop profiling timer. */
+static void profile_timer_stop(ProfileState *ps)
+{
+  struct itimerval tm;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = 0;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = 0;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sigaction(SIGPROF, &ps->oldsa, NULL);
+}
+
+#elif LJ_PROFILE_PTHREAD
+
+/* POSIX timer thread. */
+static void *profile_thread(ProfileState *ps)
+{
+  int interval = ps->interval;
+  struct timespec ts;
+  ts.tv_sec = interval / 1000;
+  ts.tv_nsec = (interval % 1000) * 1000000;
+  while (1) {
+    nanosleep(&ts, NULL);
+    if (ps->abort) break;
+    profile_trigger(ps);
+  }
+  return NULL;
+}
+
+/* Start profiling timer thread. */
+static void profile_timer_start(ProfileState *ps)
+{
+  pthread_mutex_init(&ps->lock, 0);
+  ps->abort = 0;
+  pthread_create(&ps->thread, NULL, (void *(*)(void *))profile_thread, ps);
+}
+
+/* Stop profiling timer thread. */
+static void profile_timer_stop(ProfileState *ps)
+{
+  ps->abort = 1;
+  pthread_join(ps->thread, NULL);
+  pthread_mutex_destroy(&ps->lock);
+}
+
+#elif LJ_PROFILE_WTHREAD
+
+/* Windows timer thread. */
+static DWORD WINAPI profile_thread(void *psx)
+{
+  ProfileState *ps = (ProfileState *)psx;
+  int interval = ps->interval;
+  if (ps->wmm_tbp) ps->wmm_tbp(interval);
+  while (1) {
+    Sleep(interval);
+    if (ps->abort) break;
+    profile_trigger(ps);
+  }
+  if (ps->wmm_tep) ps->wmm_tep(interval);
+  return 0;
+}
+
+/* Start profiling timer thread. */
+static void profile_timer_start(ProfileState *ps)
+{
+  if (!ps->wmm) {  /* Load WinMM library on-demand. */
+    ps->wmm = LoadLibraryExA("winmm.dll", NULL, 0);
+    if (ps->wmm) {
+      ps->wmm_tbp = (WMM_TPFUNC)GetProcAddress(ps->wmm, "timeBeginPeriod");
+      ps->wmm_tep = (WMM_TPFUNC)GetProcAddress(ps->wmm, "timeEndPeriod");
+      if (!ps->wmm_tbp || !ps->wmm_tep) {
+	ps->wmm = NULL;
+	ps->wmm_tbp = ps->wmm_tep = NULL;
+      }
+    }
+  }
+  InitializeCriticalSection(&ps->lock);
+  ps->abort = 0;
+  ps->thread = CreateThread(NULL, 0, profile_thread, ps, 0, NULL);
+}
+
+/* Stop profiling timer thread. */
+static void profile_timer_stop(ProfileState *ps)
+{
+  ps->abort = 1;
+  WaitForSingleObject(ps->thread, INFINITE);
+  DeleteCriticalSection(&ps->lock);
+}
+
+#endif
+
+/* -- Public profiling API ------------------------------------------------ */
+
+int lj_profile_active(void)
+{
+  return profile_state.g != NULL;
+}
+
+/* Start profiling. */
+LUA_API void luaJIT_profile_start(lua_State *L, const char *mode,
+				  luaJIT_profile_callback cb, void *data)
+{
+  ProfileState *ps = &profile_state;
+  int interval = LJ_PROFILE_INTERVAL_DEFAULT;
+  if (lj_allocprof_active) return;
+  while (*mode) {
+    int m = *mode++;
+    switch (m) {
+    case 'i':
+      interval = 0;
+      while (*mode >= '0' && *mode <= '9')
+	interval = interval * 10 + (*mode++ - '0');
+      if (interval <= 0) interval = 1;
+      break;
+    /* 'l'/'f' (JIT line/func granularity) are no-op in phase 1: no prof_mode. */
+    default:  /* Ignore unknown mode chars. */
+      break;
+    }
+  }
+  if (ps->g) {
+    luaJIT_profile_stop(L);
+    if (ps->g) return;  /* Profiler in use by another VM. */
+  }
+  ps->g = G(L);
+  ps->interval = interval;
+  ps->cb = cb;
+  ps->data = data;
+  ps->samples = 0;
+  ps->added_maskline = !(G(L)->hookmask & LUA_MASKLINE);
+  ps->saved_count = G(L)->hookcount;
+  ps->saved_cstart = G(L)->hookcstart;
+  profile_timer_start(ps);
+}
+
+/* Stop profiling. */
+LUA_API void luaJIT_profile_stop(lua_State *L)
+{
+  ProfileState *ps = &profile_state;
+  global_State *g = ps->g;
+  if (G(L) == g) {  /* Only stop profiler if started by this VM. */
+    ps->g = NULL;
+    profile_timer_stop(ps);
+    g->hookmask &= (uint8_t)~(HOOK_PROFILE |
+			      (ps->added_maskline ? LUA_MASKLINE : 0));
+    g->hookcount = ps->saved_count;
+    g->hookcstart = ps->saved_cstart;
+    lj_dispatch_update(g, 0);
+  }
+}
+
+/* Native stack dump: "name@short_src:linedefined" per frame, ';'-separated, top first. fmt ignored. */
+LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
+					     int depth, size_t *len)
+{
+  static char buf[2048];
+  size_t n = 0;
+  int level;
+  int maxd = depth < 0 ? -depth : depth;
+  lua_Debug ar;
+  UNUSED(fmt);
+  if (maxd <= 0) maxd = 1;
+  for (level = 0; level < maxd; level++) {
+    const char *src;
+    int w;
+    if (n >= sizeof(buf) - 64) break;
+    if (!lua_getstack(L, level, &ar)) break;
+    lua_getinfo(L, "Sln", &ar);
+    if (n) buf[n++] = ';';
+    src = ar.short_src[0] ? ar.short_src : "?";
+    if (ar.name && ar.name[0])
+      w = snprintf(buf + n, sizeof(buf) - n, "%s@%s:%d", ar.name, src, ar.linedefined);
+    else
+      w = snprintf(buf + n, sizeof(buf) - n, "%s:%d", src, ar.linedefined);
+    if (w < 0) break;
+    n += (size_t)w;
+    if (n >= sizeof(buf)) { n = sizeof(buf) - 1; break; }
+  }
+  buf[n] = '\0';
+  *len = n;
+  return buf;
+}
+
+#endif

--- a/src/3rd party/luajit-2/src/lj_profile.h
+++ b/src/3rd party/luajit-2/src/lj_profile.h
@@ -1,0 +1,24 @@
+/*
+** Low-overhead profiling.
+** Copyright (C) 2005-2016 Mike Pall. See Copyright Notice in luajit.h
+*/
+
+#ifndef _LJ_PROFILE_H
+#define _LJ_PROFILE_H
+
+#include "lj_obj.h"
+
+#if LJ_HASPROFILE
+
+LJ_FUNC void LJ_FASTCALL lj_profile_interpreter(lua_State *L);
+LJ_FUNC int lj_profile_active(void);
+#if !LJ_PROFILE_SIGPROF
+LJ_FUNC void LJ_FASTCALL lj_profile_hook_enter(global_State *g);
+LJ_FUNC void LJ_FASTCALL lj_profile_hook_leave(global_State *g);
+LJ_FUNC int lj_profile_lock(void);
+LJ_FUNC void lj_profile_unlock(void);
+#endif
+
+#endif
+
+#endif

--- a/src/3rd party/luajit-2/src/lj_state.c
+++ b/src/3rd party/luajit-2/src/lj_state.c
@@ -26,6 +26,10 @@
 #include "lj_vm.h"
 #include "lj_lex.h"
 #include "lj_alloc.h"
+#if LJ_HASPROFILE
+#include "lj_allocprof.h"
+#include "luajit.h"
+#endif
 
 /* -- Stack handling ------------------------------------------------------ */
 
@@ -236,12 +240,16 @@ LUA_API void lua_close(lua_State *L)
   global_State *g = G(L);
   int i;
   L = mainthread(g);  /* Only the main thread can be closed. */
+#if LJ_HASPROFILE
+  luaJIT_profile_stop(L);  /* Stop the timer thread before the VM goes away. */
+  lj_allocprof_stop(L);
+#endif
   lj_func_closeuv(L, tvref(L->stack));
   lj_gc_separateudata(g, 1);  /* Separate udata which have GC metamethods. */
 #if LJ_HASJIT
   G2J(g)->flags &= ~JIT_F_ON;
   G2J(g)->state = LJ_TRACE_IDLE;
-  lj_dispatch_update(g);
+  lj_dispatch_update(g, 0);
 #endif
   for (i = 0;;) {
     hook_enter(g);

--- a/src/3rd party/luajit-2/src/lj_trace.c
+++ b/src/3rd party/luajit-2/src/lj_trace.c
@@ -568,7 +568,7 @@ static TValue *trace_state(lua_State *L, lua_CFunction dummy, void *ud)
     case LJ_TRACE_START:
       J->state = LJ_TRACE_RECORD;  /* trace_start() may change state. */
       trace_start(J);
-      lj_dispatch_update(J2G(J));
+      lj_dispatch_update(J2G(J), 0);
       break;
 
     case LJ_TRACE_RECORD:
@@ -617,7 +617,7 @@ static TValue *trace_state(lua_State *L, lua_CFunction dummy, void *ud)
       trace_stop(J);
       setvmstate(J2G(J), INTERP);
       J->state = LJ_TRACE_IDLE;
-      lj_dispatch_update(J2G(J));
+      lj_dispatch_update(J2G(J), 0);
       return NULL;
 
     default:  /* Trace aborted asynchronously. */
@@ -629,7 +629,7 @@ static TValue *trace_state(lua_State *L, lua_CFunction dummy, void *ud)
 	goto retry;
       setvmstate(J2G(J), INTERP);
       J->state = LJ_TRACE_IDLE;
-      lj_dispatch_update(J2G(J));
+      lj_dispatch_update(J2G(J), 0);
       return NULL;
     }
   } while (J->state > LJ_TRACE_RECORD);
@@ -656,9 +656,9 @@ void LJ_FASTCALL lj_trace_hot(jit_State *J, const BCIns *pc)
   ERRNO_SAVE
   /* Reset hotcount. */
   hotcount_set(J2GG(J), pc, J->param[JIT_P_hotloop]*HOTCOUNT_LOOP);
-  /* Only start a new trace if not recording or inside __gc call or vmevent. */
+  /* No new trace while recording, in __gc, in vmevent, or with a profiler hook armed (its drain bypasses lj_trace_ins). */
   if (J->state == LJ_TRACE_IDLE &&
-      !(J2G(J)->hookmask & (HOOK_GC|HOOK_VMEVENT))) {
+      !(J2G(J)->hookmask & (HOOK_GC|HOOK_VMEVENT|HOOK_PROFILE))) {
     J->parent = 0;  /* Root trace. */
     J->exitno = 0;
     J->state = LJ_TRACE_START;
@@ -671,7 +671,7 @@ void LJ_FASTCALL lj_trace_hot(jit_State *J, const BCIns *pc)
 static void trace_hotside(jit_State *J, const BCIns *pc)
 {
   SnapShot *snap = &traceref(J, J->parent)->snap[J->exitno];
-  if (!(J2G(J)->hookmask & (HOOK_GC|HOOK_VMEVENT)) &&
+  if (!(J2G(J)->hookmask & (HOOK_GC|HOOK_VMEVENT|HOOK_PROFILE)) &&
       snap->count != SNAPCOUNT_DONE &&
       ++snap->count >= J->param[JIT_P_hotexit]) {
     lua_assert(J->state == LJ_TRACE_IDLE);

--- a/src/3rd party/luajit-2/src/ljamalg.c
+++ b/src/3rd party/luajit-2/src/ljamalg.c
@@ -41,6 +41,8 @@
 #include "lj_debug.c"
 #include "lj_state.c"
 #include "lj_dispatch.c"
+#include "lj_profile.c"
+#include "lj_allocprof.c"
 #include "lj_vmevent.c"
 #include "lj_vmmath.c"
 #include "lj_strscan.c"

--- a/src/3rd party/luajit-2/src/luajit.h
+++ b/src/3rd party/luajit-2/src/luajit.h
@@ -64,6 +64,15 @@ enum {
 /* Control the JIT engine. */
 LUA_API int luaJIT_setmode(lua_State *L, int idx, int mode);
 
+/* Low-overhead profiling API (backported from LuaJIT 2.1). */
+typedef void (*luaJIT_profile_callback)(void *data, lua_State *L,
+					int samples, int vmstate);
+LUA_API void luaJIT_profile_start(lua_State *L, const char *mode,
+				  luaJIT_profile_callback cb, void *data);
+LUA_API void luaJIT_profile_stop(lua_State *L);
+LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
+					     int depth, size_t *len);
+
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 

--- a/src/3rd party/luajit-2/src/luajit.vcxproj
+++ b/src/3rd party/luajit-2/src/luajit.vcxproj
@@ -200,6 +200,8 @@
     <ClCompile Include="lj_ctype.c" />
     <ClCompile Include="lj_debug.c" />
     <ClCompile Include="lj_dispatch.c" />
+    <ClCompile Include="lj_profile.c" />
+    <ClCompile Include="lj_allocprof.c" />
     <ClCompile Include="lj_err.c" />
     <ClCompile Include="lj_ffrecord.c" />
     <ClCompile Include="lj_func.c" />


### PR DESCRIPTION
## Summary

Backports the LuaJIT 2.1 jit.profile timer sampler into this 2.0.4 build and adds jit.allocprof, an allocation profiler built on the same stack walk. Both sample the running Lua stack, on a timer for CPU and on a byte interval for allocation, instead of instrumenting calls. One capture attributes cost across the entire script layer with the JIT on, at the sample rate, with no per-function wrapper and no module selection.

jit.profile (CPU): start(mode, cb) arms a timer on a dedicated thread. Each tick latches the VM state and sets the profile hook together with LUA_MASKLINE, so the sample resolves at the next interpreted bytecode, or at the next trace exit if a JIT trace is running (lj_profile.c). dumpstack returns "name@short_src:linedefined" per frame, starting at the executing frame. The module is the upstream 2.1 jit.profile with one structural adaptation for 2.0.4: the stack dump writes into a fixed buffer instead of lj_buf, which 2.0.4 lacks, and there is no prof_mode.

jit.allocprof (allocation): the allocator funnels lj_mem_realloc and lj_mem_newgco add allocated bytes to a counter (lj_gc.c, two integer adds behind an active flag). At the instruction dispatch boundary the drain walks the same stack jit.profile uses and credits the accumulated bytes to the leaf function and the full stack (lj_allocprof.c). Each sampling interval is drawn from an exponential distribution with an 8 KB mean, the method Go's and jemalloc's heap profilers use for unbiased allocation sampling, so a periodic allocation pattern cannot align with the interval.

## Use cases

Anomaly runs hundreds of mods in one shared Lua state. It had no engine-level profiler: CPU cost and allocation were not attributable to a function, script, or callback without instrumenting every call, which taxes the paths it measures and cannot measure allocation at all.

These two modules make script cost measurable. One capture attributes CPU time and allocated bytes to the function, script, and callback that produced them, across every loaded mod, with the JIT on. A modpack maintainer can locate the real cost drivers and optimize by measurement. The allocation axis is new to the platform: GC churn is a primary source of frame-time stutter, and no existing script-side tool could measure it.

## Save compatibility

The full LuaJIT 2.1 upgrade is on hold in this fork because GC64 changes the save and bytecode byte format (#445). jit.profile does not depend on GC64. This backport takes that module alone: no 64-bit GC pointers, no change to the save or bytecode layout. A save written before the change loads after it, and the reverse. The profiler the 2.1 upgrade would bring is available here without the save-format change that put the upgrade on hold.

## Design

Both profilers are inert until a script calls start. When off, the allocator path reads one flag under LJ_HASPROFILE and continues. The engine holds no state and takes no gameplay action. Aggregation, policy, and reporting live in Lua.

Trace recording never starts while a profiler hook is armed (the profiler dispatch branch bypasses the recorder feed), and jit.allocprof aborts any in-progress recording when it starts or resumes. This makes both profilers safe to run with the JIT on: existing compiled traces keep running, and the recorder can never ingest an instruction stream with profiler-induced gaps.

One profiler runs at a time. Both drive the HOOK_PROFILE dispatch bit, so starting one while the other runs raises a Lua error.

## Performance

jit.profile samples on a timer thread at the mode interval, default 10 ms, with the JIT on. The cost is set by the sample rate. There is no per-call instrumentation tax. It is suitable for a long capture during normal play.

jit.allocprof is a session mode: it traps every bytecode instruction while active. Per instruction the drain reads a counter and compares it against the next sample distance. The stack walk runs once per 8 KB allocated on average. It is heavier than jit.profile and intended for a focused capture.

The aggregation tables are static engine memory: 10.65 MB, resident after the first capture of a session.

## Limitations

- Interpreter-anchored, no prof_mode. A CPU sample taken while a JIT trace runs resolves at the next trace exit, so the JIT-compiled share of the VM-state split is a floor. prof_mode requires JIT-backend codegen and is out of scope here.
- No new traces compile while a capture runs (recording is blocked while a profiler hook is armed). Traces compiled before the capture keep running.
- jit.allocprof with the JIT on is safe but coarser: allocations inside compiled traces are credited to the next interpreted frame. Run jit.off() for exact attribution. Total bytes are exact either way.
- jit.allocprof attributes at the instruction dispatch boundary, not the allocation call site. Bytes allocated inside a C call are credited to the next Lua frame, so a high-frequency function absorbs some ambient allocation. The by-root and by-script aggregations carry the reliable magnitude.
- A Lua error inside the profile callback is fatal, matching upstream: the panic handler runs and the process exits.
- debug.sethook line and count hooks are starved while a capture runs. Their hook state is saved on start and restored on stop.

## Files changed

New:

| File | Lines | Purpose |
|---|---|---|
| lj_profile.c | 387 | the 2.1 timer sampler, native dumpstack |
| lj_profile.h | 24 | declarations |
| lj_allocprof.c | 214 | allocation counter, drain, aggregation |
| lj_allocprof.h | 36 | declarations |

Edited:

| File | Change |
|---|---|
| lib_jit.c | jit.profile and jit.allocprof module bindings (+174/-1) |
| lj_arch.h | LJ_HASPROFILE, per-target profile timer selection (+16) |
| lj_dispatch.c | 2-arg lj_dispatch_update, HOOK_PROFILE dispatch branch, profiler-locked hook transitions in callhook (+33/-3) |
| lj_dispatch.h | lj_dispatch_update signature (+1/-1) |
| lj_gc.c | two allocator-funnel byte adds (+11) |
| lj_obj.h | HOOK_PROFILE = 0x80 (+1) |
| lj_state.c | profiler stop on lua_close, call-site ripple (+9/-1) |
| lj_trace.c | no recording start while a profiler hook is armed, call-site ripple (+6/-6) |
| luajit.h | profiling API declarations (+9) |
| ljamalg.c, luajit.vcxproj | build wiring (+4) |
| gamedata/scripts/lua_help_ex.script | manifest entries (+15) |

## Lua usage

```lua
-- CPU: sample every 5 ms
local profile = require("jit.profile")
profile.start("i5", function(thread, samples, vmstate)
    local stack = profile.dumpstack(thread, "", 12)
    -- aggregate stack by count
end)
-- run the scene
profile.stop()

-- Allocation: jit.off() recommended for exact attribution
local allocprof = require("jit.allocprof")
jit.off()
allocprof.start(12)
-- run the scene
allocprof.stop()
jit.on()
local rows = allocprof.dump(true)   -- { {key="leaf;..;root", bytes=N}, ... }
```

## Testing

Built locally on DX11, 0 errors. Deployed to a GAMMA install, demonized MT-based local build, and exercised in play. Also exercised with captures on clean Anomaly 1.5.3 and an EFP install.

jit.profile: a 132 s capture on a live GAMMA session produced 22062 samples across 1138 distinct stacks. VM-state split: JIT-compiled 0.6%, interpreter 6.2%, C and engine calls 63.9%, GC 28.6%, JIT compiler 0.6%. Frame rate during the capture matched play without it, since the JIT stays on. The top cost driver by root frame was the per-frame actor update dispatch at bind_stalker.script:207 at 40.5% of samples, which is also the top leaf at 35.1%.

jit.allocprof: a 139 s capture attributed 1597.5 MB across 1851 stacks with no overflow (the dropped-bytes counter stayed at 0). Top allocators by leaf: the time_global wrapper at _g.script:760 (295 MB, a high-frequency function absorbing ambient allocation per the dispatch-boundary limitation), an item-attachment script (229 MB), and the sorted-iteration helper spairs at _g_patches.script:802 (136 MB). No crash across multi-minute captures.

Extended play: the profiler-enabled exe has run as the normal GAMMA build for two weeks, across many sessions, level transitions, and save-load cycles. With both profilers off it matches the stock exe in play. No crash and no save-load failure over the period.

Save compatibility, both directions: existing stock-exe saves load and continue on the profiler build (two weeks of play). A save written on the profiler build loads and plays on the stock exe (demonized single-thread, profiler removed, same base). The save and bytecode format is unchanged.

Attached: SpeedScope Left Heavy and Sandwich views of the CPU and allocation captures above, and a console shot of a capture session showing the second profiler refused while the first runs.


<img width="891" height="1271" alt="02-cpu-sandwich" src="https://github.com/user-attachments/assets/5da136da-7067-4b7b-b6cd-6d05ea017a4c" />
<img width="2560" height="495" alt="03-alloc-left-heavy" src="https://github.com/user-attachments/assets/1e1dfd9b-553e-4a72-8145-512971b9d53d" />
<img width="867" height="1275" alt="04-alloc-sandwich" src="https://github.com/user-attachments/assets/2db9cd9b-942e-48a3-8223-1b6fe471dbd5" />
<img width="1605" height="647" alt="05-console-session" src="https://github.com/user-attachments/assets/d92048ce-f42a-4c3c-8263-75cacbd11f92" />
<img width="2555" height="419" alt="01-cpu-left-heavy" src="https://github.com/user-attachments/assets/46145e2c-8dc9-42e2-a161-fcf68b4aa1dd" />
