### PR TITLE
Allow configuring speeds of script cam anims

### DIFF
--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -402,6 +402,9 @@
         // Scripted effectors added via add_cam_effector are not touched.
         void remove_hud_motion_cam_effectors()
 
+        // level.add_cam_effector, but contains one more variable that dictates the speed of the cam effector, returns anim length
+        float add_cam_effector(LPCSTR fn, int id, bool cyclic, LPCSTR cb_func, float cam_fov, bool b_hud, float power, float speed)
+
         game_object get_target_obj(ETraceTarget)
         game_object get_target_obj()
         number get_target_dist(ETraceTarget)

--- a/src/xrGame/ActorEffector.cpp
+++ b/src/xrGame/ActorEffector.cpp
@@ -164,6 +164,7 @@ CAnimatorCamEffector::CAnimatorCamEffector()
 	m_bAbsolutePositioning = false;
 	m_fov = -1.0f;
 	m_power = 1.f;
+    m_speed = 1.f;
 }
 
 CAnimatorCamEffector::~CAnimatorCamEffector()
@@ -174,6 +175,7 @@ CAnimatorCamEffector::~CAnimatorCamEffector()
 void CAnimatorCamEffector::Start(LPCSTR fn)
 {
 	m_objectAnimator->Load(fn);
+    m_objectAnimator->Speed() = m_speed;
 	m_objectAnimator->Play(Cyclic());
 	fLifeTime = m_objectAnimator->GetLength();
 }

--- a/src/xrGame/ActorEffector.h
+++ b/src/xrGame/ActorEffector.h
@@ -72,6 +72,8 @@ public:
 	bool m_bAbsolutePositioning;
 	float m_fov;
 	float m_power;
+    // ver, allow setting speed of a camera anim
+    float m_speed;
 
 	CAnimatorCamEffector();
 	virtual ~CAnimatorCamEffector();
@@ -79,6 +81,8 @@ public:
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
 	void SetCyclic(bool b) { m_bCyclic = b; }
 	void SetPower(float p) { m_power = p; }
+    // ver, allow setting speed of a camera anim
+    void SetSpeed(float s) {m_speed = s;}
 	float GetPower() { return m_power; }
 	virtual BOOL Valid();
 	float GetAnimatorLength() { return fLifeTime; };

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -819,6 +819,30 @@ float add_cam_effector(LPCSTR fn, int id, bool cyclic, LPCSTR cb_func, float cam
 	return e->GetAnimatorLength();
 }
 
+float add_cam_effector(LPCSTR fn, int id, bool cyclic, LPCSTR cb_func, float cam_fov, bool b_hud, float power, float speed)
+{
+    CAnimatorCamEffectorScriptCB* e = xr_new<CAnimatorCamEffectorScriptCB>(cb_func);
+    if (cam_fov)
+    {
+        e->m_bAbsolutePositioning = true;
+        e->m_fov = cam_fov;
+    }
+    if (power)
+    {
+        e->SetPower(power);
+    }
+    if (speed)
+    {
+        e->SetSpeed(speed);
+    }
+    e->SetHudAffect(b_hud);
+    e->SetType((ECamEffectorType)id);
+    e->SetCyclic(cyclic);
+    e->Start(fn);
+    Actor()->Cameras().AddCamEffector(e);
+    return e->GetAnimatorLength();
+}
+
 // demonized: Get cam effector transform data from "*.anm" file
 #include "../xrEngine/motion.h"
 #include "../xrEngine/envelope.h"
@@ -2582,6 +2606,8 @@ void CLevel::script_register(lua_State* L)
 			def("add_cam_effector", ((float (*)(LPCSTR, int, bool, LPCSTR, float))&add_cam_effector)),
 			def("add_cam_effector", ((float (*)(LPCSTR, int, bool, LPCSTR, float, bool))&add_cam_effector)),
 			def("add_cam_effector", ((float (*)(LPCSTR, int, bool, LPCSTR, float, bool, float))&add_cam_effector)),
+            // ver; allow changing the speed of cam effectors
+            def("add_cam_effector", ((float (*)(LPCSTR, int, bool, LPCSTR, float, bool, float, float))& add_cam_effector)),
 
 			// demonized: Set custom camera position and direction with movement smoothing (for cutscenes, etc)
 			def("set_cam_custom_position_direction", ((void (*)(Fvector&, Fvector&, unsigned int, bool, bool))& set_cam_position_direction)),


### PR DESCRIPTION
Add one extra overload to add_cam_effector to allow the configuration of camera anim speeds in script via level.add_cam_effector(path, id, cyclic, cb_func, cam_fov, b_hud, power, speed)