### PR TITLE
Lua trace/veto hooks for the ambient bed and level music

### DIFF
--- a/gamedata/scripts/callbacks_gameobject.script
+++ b/gamedata/scripts/callbacks_gameobject.script
@@ -651,6 +651,43 @@ _G.COnBeforePlayHudSound = function(alias, parent)
 	end
 end
 
+--[[
+on_before_play_ambient_bed callback, scale or veto the per-weather ambient background bed.
+Fired from CGamePersistent::WeathersUpdate (GamePersistent.cpp) at each bed play site.
+Return via result.volume_mult: 0 vetoes the play, <1 attenuates, nil leaves vanilla.
+
+Arguments
+	section: weather ambient section the bed loads from
+	file: resolved sound file name, "" when the handle is not ready yet
+	pos: Fvector world position the bed plays at
+--]]
+AddScriptCallback("on_before_play_ambient_bed")
+_G.COnAmbientBed = function(section, file, pos)
+	local result = { volume_mult = nil }
+	SendScriptCallback("on_before_play_ambient_bed", section, file, pos, result)
+	if result.volume_mult then
+		return result
+	end
+end
+
+--[[
+on_before_play_level_music callback, scale or silence the level music track.
+Fired from SMusicTrack::Play (level_sounds.cpp). Volume-only: a skip would make the
+manager re-select every frame, so 0 silences rather than stops the track.
+Return via result.volume_mult: 0 silences, <1 attenuates, nil leaves vanilla.
+
+Arguments
+	file: resolved music track file name, "" when the handle is not ready yet
+--]]
+AddScriptCallback("on_before_play_level_music")
+_G.COnLevelMusic = function(file)
+	local result = { volume_mult = nil }
+	SendScriptCallback("on_before_play_level_music", file, result)
+	if result.volume_mult then
+		return result
+	end
+end
+
 -- NLTP_ASHES & demonized : Actor on death callback
 AddScriptCallback("actor_on_death")
 function actor_on_first_update()

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -155,12 +155,6 @@
         ClrSetB(number argb, number b)
     }
 
-    engine callbacks (Lua defines the _G function; the engine calls it only if present) {
-        -- Each returns { volume_mult = number } to scale the play (0 vetoes/silences, <1 attenuates), or nil for vanilla. Zero cost when undefined. Mirror _G.COnBeforePlayHudSound.
-        table COnAmbientBed(string section, string file, Fvector pos) -- System A per-weather background bed play site (CGamePersistent::WeathersUpdate, GamePersistent.cpp). 0 vetoes the play.
-        table COnLevelMusic(string file) -- level music track in SMusicTrack::Play (level_sounds.cpp). Volume-only (0 silences the track).
-    }
-
     get_console() {
         table get_variable_bounds(cmd)   
     }

--- a/gamedata/scripts/lua_help_ex.script
+++ b/gamedata/scripts/lua_help_ex.script
@@ -155,6 +155,12 @@
         ClrSetB(number argb, number b)
     }
 
+    engine callbacks (Lua defines the _G function; the engine calls it only if present) {
+        -- Each returns { volume_mult = number } to scale the play (0 vetoes/silences, <1 attenuates), or nil for vanilla. Zero cost when undefined. Mirror _G.COnBeforePlayHudSound.
+        table COnAmbientBed(string section, string file, Fvector pos) -- System A per-weather background bed play site (CGamePersistent::WeathersUpdate, GamePersistent.cpp). 0 vetoes the play.
+        table COnLevelMusic(string file) -- level music track in SMusicTrack::Play (level_sounds.cpp). Volume-only (0 silences the track).
+    }
+
     get_console() {
         table get_variable_bounds(cmd)   
     }

--- a/src/xrGame/GamePersistent.cpp
+++ b/src/xrGame/GamePersistent.cpp
@@ -276,6 +276,18 @@ void CGamePersistent::OnGameEnd()
 	xr_delete(g_stalker_velocity_holder);
 }
 
+// { volume_mult = number } from a sound hook's return; 1.0 (vanilla) when nil, not a table, or not a number
+static float ambient_hook_volume_mult(const ::luabind::object& output)
+{
+	if (output && output.type() == LUA_TTABLE)
+	{
+		auto volume_mult_obj = output["volume_mult"];
+		if (volume_mult_obj.type() == LUA_TNUMBER)
+			return ::luabind::object_cast<float>(volume_mult_obj);
+	}
+	return 1.0f;
+}
+
 void CGamePersistent::WeathersUpdate()
 {
 	if (g_pGameLevel && !g_dedicated_server)
@@ -315,7 +327,22 @@ void CGamePersistent::WeathersUpdate()
 					pos.z = _sin(angle);
 					pos.normalize().mul(ch.get_rnd_sound_dist()).add(Device.vCameraPosition);
 					pos.y += 10.f;
-					snd.play_at_pos(0, pos);
+
+					// Ambient bed hook, mirrors COnBeforePlayHudSound: Lua may veto (0) or attenuate; absent global = exact vanilla
+					float bed_volume_mult = 1.0f;
+					::luabind::functor<::luabind::object> bed_funct;
+					if (ai().script_engine().functor("_G.COnAmbientBed", bed_funct))
+					{
+						LPCSTR bed_file = snd._handle() ? snd._handle()->file_name() : "";
+						bed_volume_mult = ambient_hook_volume_mult(bed_funct(ch.m_load_section.c_str(), bed_file, pos));
+					}
+
+					if (bed_volume_mult > EPS_S)
+					{
+						snd.play_at_pos(0, pos);
+						if (bed_volume_mult < 1.0f)
+							snd.set_volume(bed_volume_mult);
+					}
 
 #ifdef DEBUG
                     if (!snd._handle() && strstr(Core.Params, "-nosound"))

--- a/src/xrGame/level_sounds.cpp
+++ b/src/xrGame/level_sounds.cpp
@@ -5,6 +5,20 @@
 
 #include "level.h"
 #include "level_sounds.h"
+#include "ai_space.h"
+#include "../xrServerEntities/script_engine.h"
+
+// { volume_mult = number } from a sound hook's return; 1.0 (vanilla) when nil, not a table, or not a number
+static float ambient_hook_volume_mult(const ::luabind::object& output)
+{
+	if (output && output.type() == LUA_TTABLE)
+	{
+		auto volume_mult_obj = output["volume_mult"];
+		if (volume_mult_obj.type() == LUA_TNUMBER)
+			return ::luabind::object_cast<float>(volume_mult_obj);
+	}
+	return 1.0f;
+}
 
 //-----------------------------------------------------------------------------
 // static level sounds
@@ -129,7 +143,16 @@ BOOL SMusicTrack::in(u32 game_time)
 void SMusicTrack::Play()
 {
 	m_SourceStereo.play_at_pos(0, Fvector().set(0.0f, 0.0f, 0.0f), sm_Intro);
-	SetVolume(1.0f);
+
+	// Level-music hook: volume-only (a skip would make the manager re-select every frame); absent global = vanilla
+	float music_volume_mult = 1.0f;
+	::luabind::functor<::luabind::object> music_funct;
+	if (ai().script_engine().functor("_G.COnLevelMusic", music_funct))
+	{
+		LPCSTR music_file = m_SourceStereo._handle() ? m_SourceStereo._handle()->file_name() : "";
+		music_volume_mult = ambient_hook_volume_mult(music_funct(music_file));
+	}
+	SetVolume(music_volume_mult);
 }
 
 BOOL SMusicTrack::IsPlaying()


### PR DESCRIPTION
## Summary

Only HUD sounds have a Lua seam (`COnBeforePlayHudSound`). Mods driving atmosphere can neither trace nor suppress the engine's own ambient plays. This adds a named `_G` callback at two ambient sound play sites, same pattern: the engine calls it only when the global is set (zero cost when absent) and applies `{ volume_mult }` from the return - `0` vetoes/silences, `<1` attenuates, `nil` = vanilla. Neutral lever, no engine-side condition.

## Hooks

- `COnAmbientBed(section, file, pos)` - the per-weather background bed play site in `CGamePersistent::WeathersUpdate` (the `sound_channels` static bed, the one ambient path scripts cannot reach: `sound_ambient.script` owns only `sound_channels_dynamic`). Skip on veto, `set_volume` on attenuate; the channel reschedules on its own period either way.
- `COnLevelMusic(file)` - level music track in `SMusicTrack::Play` (`level_sounds.cpp`). Volume-only: applied via `SetVolume` (0 silences the track), since skipping the play would make `IsPlaying()` false and the manager would re-select every frame.

## Use cases

- Ambient/atmosphere mods that trace what the engine bed is playing (section, file, position) to coordinate their own layers with it.
- Suppressing or ducking the engine bed for a clean listen window (e.g. auditioning a sound in true silence) or replacing it wholesale with a script-driven soundscape.
- Music-replacement mods silencing the built-in level tracks without touching level configs.

## Files changed

- `src/xrGame/GamePersistent.cpp` (+28) - bed hook + shared `ambient_hook_volume_mult` helper.
- `src/xrGame/level_sounds.cpp` (+24) - music hook (same helper, static linkage).
- `gamedata/scripts/lua_help_ex.script` (+6) - manifest entries for both callbacks.

## Lua usage

```lua
-- trace + veto the background bed
_G.COnAmbientBed = function(section, file, pos)
    printf("bed: [%s] %s at %.0f,%.0f,%.0f", section, file, pos.x, pos.y, pos.z)
    if my_mod.bed_muted then return { volume_mult = 0 } end
    return nil -- vanilla
end
```

## Testing

Built locally (DX11, 0 errors) and deployed to a live install; a Lua consumer registered both callbacks and returned `{ volume_mult = 0 }`. Verified engine-side via a temporary `Msg` at both branches (removed for this commit):

- Bed: trace + veto confirmed across levels and channels - Cordon `background_forest_day`, Agroprom Underground `ugrnd_ambient` + `ugrnd_bkg_1` (multi-channel bed). 400+ veto events logged: `play_at_pos` skipped, channel cadence intact (~26s period unchanged).
- Music: callback fired with the real track file (`music\level\day_normal\music_05`, `music_06`).
- Passthrough (`nil` return / no global defined): bed plays vanilla (`PLAYED vol[1.00]` observed before the consumer registered).
- The attenuate branch (`0 < volume_mult < 1`) reuses the veto-tested return-parse and the same `set_volume` call `sound_ambient.script` makes; not separately exercised in-game.
