### PR TITLE
Fix a race on the UI caption statics

### DIFF
--- a/src/xrGame/UIGameCustom.cpp
+++ b/src/xrGame/UIGameCustom.cpp
@@ -59,22 +59,25 @@ void CUIGameCustom::OnFrame()
 {
 	PROF_EVENT("CUIGameCustom::OnFrame");
 	CDialogHolder::OnFrame();
-	for (auto item : CustomStatics)
-		item->Update();
-	auto comparer = [](const StaticDrawableWrapper* s1, const StaticDrawableWrapper* s2)
 	{
-		return s1->IsActual() > s2->IsActual();
-	};
-	std::sort(CustomStatics.begin(), CustomStatics.end(), comparer);
-	while (!CustomStatics.empty() && !CustomStatics.back()->IsActual())
-	{
-		delete_data(CustomStatics.back());
-		CustomStatics.pop_back();
-	}
-	if (g_b_ClearGameCaptions)
-	{
-		delete_data(CustomStatics);
-		g_b_ClearGameCaptions = false;
+		std::scoped_lock lock(m_customs_lock);
+		for (auto item : CustomStatics)
+			item->Update();
+		auto comparer = [](const StaticDrawableWrapper* s1, const StaticDrawableWrapper* s2)
+		{
+			return s1->IsActual() > s2->IsActual();
+		};
+		std::sort(CustomStatics.begin(), CustomStatics.end(), comparer);
+		while (!CustomStatics.empty() && !CustomStatics.back()->IsActual())
+		{
+			delete_data(CustomStatics.back());
+			CustomStatics.pop_back();
+		}
+		if (g_b_ClearGameCaptions)
+		{
+			delete_data(CustomStatics);
+			g_b_ClearGameCaptions = false;
+		}
 	}
 	Window->Update();
 	//update windows
@@ -86,8 +89,11 @@ void CUIGameCustom::OnFrame()
 void CUIGameCustom::Render()
 {
 	PROF_EVENT("CUIGameCustom::Render");
-	for (StaticDrawableWrapper* item : CustomStatics)
-		item->Draw();
+	{
+		std::scoped_lock lock(m_customs_lock);
+		for (StaticDrawableWrapper* item : CustomStatics)
+			item->Draw();
+	}
 	Window->Draw();
 	CEntity* pEntity = smart_cast<CEntity*>(Level().CurrentEntity());
 	if (pEntity)
@@ -114,6 +120,7 @@ void CUIGameCustom::Render()
 
 StaticDrawableWrapper* CUIGameCustom::AddCustomStatic(const char* id, bool singleInstance)
 {
+	std::scoped_lock lock(m_customs_lock);
 	if (singleInstance)
 	{
 		auto it = std::find_if(CustomStatics.begin(), CustomStatics.end(), predicate_find_stat(id));
@@ -134,6 +141,7 @@ StaticDrawableWrapper* CUIGameCustom::AddCustomStatic(const char* id, bool singl
 
 StaticDrawableWrapper* CUIGameCustom::GetCustomStatic(const char* id)
 {
+	std::scoped_lock lock(m_customs_lock);
 	auto it = std::find_if(CustomStatics.begin(), CustomStatics.end(), predicate_find_stat(id));
 	if (it != CustomStatics.end())
 		return *it;
@@ -142,6 +150,7 @@ StaticDrawableWrapper* CUIGameCustom::GetCustomStatic(const char* id)
 
 void CUIGameCustom::RemoveCustomStatic(const char* id)
 {
+	std::scoped_lock lock(m_customs_lock);
 	auto it = std::find_if(CustomStatics.begin(), CustomStatics.end(), predicate_find_stat(id));
 	if (it != CustomStatics.end())
 	{

--- a/src/xrGame/UIGameCustom.h
+++ b/src/xrGame/UIGameCustom.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include "script_export_space.h"
 #include "object_interfaces.h"
 #include "inventory_space.h"
@@ -85,6 +86,8 @@ protected:
 	CUIWindow* Window;
 	CUIXml* MsgConfig;
 	xr_vector<StaticDrawableWrapper*> CustomStatics;
+	// captions are mutated by game logic and drawn by the render thread, guard every access
+	std::mutex m_customs_lock;
 	CUIActorMenu* ActorMenu;
 	CUIPdaWnd* PdaMenu;
 	bool showGameIndicators;


### PR DESCRIPTION
`CUIGameCustom::OnFrame` (game logic thread) sorts and expires `CustomStatics` while
`CUIGameCustom::Render` (render thread) iterates the same vector. With a caption/tooltip on
screen this intermittently dereferences a freed wrapper or its caption text, 
access violations in `StaticDrawableWrapper::Draw` and `CUILines::ParseText`, both
landing at `UIGameCustom.cpp:90`. Easy to reproduce by spawning items through the
debug menu. **

Fix consists of a mutex around the five places that touch the vector.

** Apparently this might be due to some weird interaction with certain UI mods? Either way this is the safer workaround considering the concurrent use.