### PR TITLE
fix: wait for async CFORM build before returning static geometry

### DIFF
--- a/src/xrCDB/xr_area.h
+++ b/src/xrCDB/xr_area.h
@@ -79,8 +79,11 @@ public:
 	int GetNearest(xr_vector<ISpatialShared>& q_spatial, xr_vector<CObject*>& q_nearest, const Fvector& point, float range,
 	               CObject* ignore_object);
 
-	CDB::TRI* GetStaticTris() { return Static.get_tris(); }
-	Fvector* GetStaticVerts() { return Static.get_verts(); }
+	// CFORM is built on a background task, so the arrays are null until it finishes.
+	// Wait for the build before handing out the pointers, the same way the CDB query
+	// paths do. When the model is ready this costs one atomic compare.
+	CDB::TRI* GetStaticTris() { Static.syncronize(); return Static.get_tris(); }
+	Fvector* GetStaticVerts() { Static.syncronize(); return Static.get_verts(); }
 	CDB::MODEL* GetStaticModel() { return &Static; }
 
 	const Fbox& GetBoundingVolume() { return m_BoundingVolume; }


### PR DESCRIPTION
## Problem

`CObjectSpace::Load` builds the CFORM on a background task group:

```cpp
Static.async_cform_load.run([=]()
{
    Fvector* verts = (Fvector*)F->pointer();
    CDB::TRI* tris = (CDB::TRI*)(verts + H.vertcount);
    Create(verts, tris, H, build_callback, false);
    FS.r_close(pReader);
});
```

Until that task runs, `CDB::MODEL::verts` and `::tris` hold the null values set in the `MODEL` constructor.

`CDB::MODEL::syncronize()` exists to cover that gap, and the query paths call it (`xrCDB_box.cpp:253,319`, `xrCDB_ray.cpp:239`, `xrCDB_frustum.cpp:104`). The two raw accessors did not:

```cpp
CDB::TRI* GetStaticTris() { return Static.get_tris(); }
Fvector* GetStaticVerts() { return Static.get_verts(); }
```

So any caller could take the pointers before the build finished.

## Where it crashes

`dSortTriPrimitiveCollide` reads both arrays at function entry, before the `XRC.box_query()` that would have synchronized, then indexes them further down:

```cpp
CDB::TRI*      T_array = inl_ph_world().ObjectSpace().GetStaticTris();   // null
const Fvector* V_array = inl_ph_world().ObjectSpace().GetStaticVerts();  // null
...
Point((dReal*)&V_array[T->verts[0]])                                     // reads address 0
```

Object spawn reaches it on the main thread during level load:

```
CRenderDevice::FrameMove              device.cpp:705
CLevel::OnFrame                       Level.cpp:1033
CLevel::cl_Process_Spawn              Level_network_spawn.cpp:53
CEatableItemObject::net_Spawn         eatable_item_object.cpp:104
CPhysicsShellHolder::setup_physic_shell  PhysicsShellHolder.cpp:304
CPhysicsShellHolder::correct_spawn_pos   PhysicsShellHolder.cpp:232
CPHActivationShape::Activate          PHActivationShape.cpp:253
CPHWorld::StepTouch                   PHWorld.cpp:471
CPHObject::Collide                    PHObject.cpp:132
dCollideBTL                           dTriList.cpp:72
dSortTriPrimitiveCollide<BoxTri>      dSortTriPrimitive.h:209
```

The faulting instruction confirms a null base rather than a bad index:

```asm
movss xmm15, dword ptr [rbx + 4*rcx]    ; rbx = 0 (V_array), rcx = 0
```

The exception record reports `EXCEPTION_ACCESS_VIOLATION`, read from address `0`. The vertex index in `rax` is a valid `0`, so only the array pointer is missing.

## Fix

Synchronize inside the accessors so every caller is covered, instead of patching each of the ~60 call sites:

```cpp
CDB::TRI* GetStaticTris() { Static.syncronize(); return Static.get_tris(); }
Fvector* GetStaticVerts() { Static.syncronize(); return Static.get_verts(); }
```

## Cost

This puts a call into two accessors that are read from around 60 places, some of them hot: every physics collision, bullet tracing, AI vision, wallmarks. The fair objection is that it adds a function call to a hot path. In practice it does not. Here is the whole body:

```cpp
IC void syncronize()
{
    if (S_READY != status)
    {
        Log ("! WARNING: syncronized CDB::query");
        async_cform_load.wait();
    }
}
```

When the model is ready, that is one load of `status`, one compare against zero, and a branch that always predicts correctly. `xr_atomic_bool` is `std::atomic_bool` (`_thread_types.h:15`), and an atomic load on x86-64 compiles to a plain `mov`. No lock prefix and no fence, because x86 loads already give acquire ordering. `syncronize()` is marked `IC`, so it inlines. The cost is a byte read from a cache line the caller is about to touch anyway.

`wait()` sits inside the `if`, so it runs only when `status` is not ready. The background task sets `status = S_READY` at the end of the build (`xrCDB.cpp:131`), and after that the branch is never taken again for that level. The worst case is one wait per level load, and only when something asks for the geometry before the CFORM build finished. Blocking there is the intent rather than a side effect. Waiting a few milliseconds for real geometry beats reading a null pointer.

## Notes

Timing decides whether this fires. The window is between queuing the CFORM task and the first physics collision during spawn. It shows up reliably wherever level data loads slowly, and it is easy to miss on fast local storage. The non-MT branch is unaffected, since `CObjectSpace::Load` there calls `Create` inline.

I could not build and run this to verify, so the change is untested at runtime. It is small and matches what the query paths already do, but please give it a run before merging.

