### PR TITLE
fix: publish CFORM arrays before the async tree build

### DIFF
--- a/src/xrCDB/xrCDB.cpp
+++ b/src/xrCDB/xrCDB.cpp
@@ -65,15 +65,21 @@ MODEL::~MODEL()
 
 void MODEL::build(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc, void* bcp)
 {
-	R_ASSERT(S_INIT == status);
-	R_ASSERT((Vcnt>=4)&&(Tcnt>=2));
-
 	build_internal(V, Vcnt, T, Tcnt, bc, bcp);
 }
 
 void MODEL::build_internal(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc, void* bcp)
 {
+	build_arrays(V, Vcnt, T, Tcnt, bc, bcp);
+	build_tree();
+}
+
+void MODEL::build_arrays(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc, void* bcp)
+{
 	PROF_EVENT();
+
+	R_ASSERT(S_INIT == status);
+	R_ASSERT((Vcnt>=4)&&(Tcnt>=2));
 
 	// verts
 	status = S_BUILD;
@@ -88,15 +94,16 @@ void MODEL::build_internal(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callbac
 
 	// callback
 	if (bc) bc(verts, Vcnt, tris, Tcnt, bcp);
+}
+
+void MODEL::build_tree()
+{
+	PROF_EVENT();
 
 	// Allocate temporary "OPCODE" tris + convert tris to 'pointer' form
 	u32* temp_tris = CALLOC(u32, tris_count*3);
 	if (0 == temp_tris)
-	{
-		CFREE(verts);
-		CFREE(tris);
 		return;
-	}
 	u32* temp_ptr = temp_tris;
 	for (int i = 0; i < tris_count; i++)
 	{
@@ -119,8 +126,9 @@ void MODEL::build_internal(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callbac
 	tree = CNEW(OPCODE_Model)();
 	if (!tree->Build(OPCC))
 	{
-		CFREE(verts);
-		CFREE(tris);
+		// Do not free verts/tris here. build_arrays already handed them out and
+		// callers may hold pointers into them. status stays S_BUILD, so the query
+		// paths still refuse to use the tree.
 		CFREE(temp_tris);
 		return;
 	};

--- a/src/xrCDB/xrCDB.h
+++ b/src/xrCDB/xrCDB.h
@@ -72,7 +72,7 @@ namespace CDB
 
 	private:
 		Opcode::OPCODE_Model* tree;
-		xr_atomic_bool status; // 0=ready, 1=init, 2=building
+		xr_atomic_u32 status; // 0=ready, 1=init, 2=building
 
 		// tris
 		TRI* tris;
@@ -100,6 +100,13 @@ namespace CDB
 		}
 
 		static void build_thread(void*);
+		// Copies the geometry and runs the material remap callback. This is the cheap
+		// half, and it publishes verts/tris, so callers that only read the arrays
+		// need nothing else.
+		void build_arrays(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc = NULL, void* bcp = NULL);
+		// Builds the OPCODE tree over the arrays published by build_arrays. This is
+		// the expensive half and the only part worth moving to a background task.
+		void build_tree();
 		void build_internal(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc = NULL, void* bcp = NULL);
 		void build(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc = NULL, void* bcp = NULL);
 		u32 memory();

--- a/src/xrCDB/xr_area.cpp
+++ b/src/xrCDB/xr_area.cpp
@@ -99,11 +99,8 @@ void CObjectSpace::Load(LPCSTR path, LPCSTR fname, CDB::build_callback build_cal
 
 void CObjectSpace::Load(IReader* F, CDB::build_callback build_callback)
 {
-	static IReader* pReader = nullptr;
-	pReader = F;
-
 	hdrCFORM H;
-	pReader->r(&H, sizeof(hdrCFORM));
+	F->r(&H, sizeof(hdrCFORM));
 	R_ASSERT(CFORM_CURRENT_VERSION == H.version);
 	m_BoundingVolume.set(H.aabb);
 
@@ -111,16 +108,23 @@ void CObjectSpace::Load(IReader* F, CDB::build_callback build_callback)
 	g_SpatialSpacePhysic->initialize(m_BoundingVolume);
 	g_SpatialSpaceLights->initialize(m_BoundingVolume);
 
-	static DWORD this_thread_id = 0;
-	this_thread_id = GetCurrentThreadId();
-	Static.async_cform_load.run([=]()
+	// Copy the geometry out of the reader on this thread, so GetStaticVerts() and
+	// GetStaticTris() return usable arrays before Load returns. The reader can then
+	// be closed here instead of from the task.
+	Fvector* verts = (Fvector*)F->pointer();
+	CDB::TRI* tris = (CDB::TRI*)(verts + H.vertcount);
+	Static.build_arrays(verts, H.vertcount, tris, H.facecount, build_callback);
+	FS.r_close(F);
+
+	// Only the OPCODE tree build goes to the background. It is the expensive half,
+	// so the overlap with the rest of the level load is kept. The four syncronize()
+	// calls in the CDB query paths already cover the tree.
+	const DWORD this_thread_id = GetCurrentThreadId();
+	Static.async_cform_load.run([this, this_thread_id]()
 	{
 		if (this_thread_id != GetCurrentThreadId()) { PROF_THREAD("X-Ray PPL Thread") }
-		PROF_EVENT("Async cform loading");
-		Fvector* verts = (Fvector*)F->pointer();
-		CDB::TRI* tris = (CDB::TRI*)(verts + H.vertcount);
-		Create(verts, tris, H, build_callback, false);
-		FS.r_close(pReader);
+		PROF_EVENT("Async cform tree build");
+		Static.build_tree();
 	});
 }
 


### PR DESCRIPTION
## Problem

`CObjectSpace::Load` moves the whole CFORM build onto a background task group:

```cpp
Static.async_cform_load.run([=]()
{
    Fvector* verts = (Fvector*)F->pointer();
    CDB::TRI* tris = (CDB::TRI*)(verts + H.vertcount);
    Create(verts, tris, H, build_callback, false);
    FS.r_close(pReader);
});
```

Until that task runs, `CDB::MODEL::verts` and `::tris` hold the null values set in the `MODEL` constructor. `GetStaticVerts()` and `GetStaticTris()` hand those nulls to any caller that asks before the build finishes.

`syncronize()` covers the gap for the query paths (`xrCDB_box.cpp:253,319`, `xrCDB_ray.cpp:239`, `xrCDB_frustum.cpp:104`). Callers that read the raw arrays without running a query first are not covered.

## Where it crashes

`dSortTriPrimitiveCollide` reads both arrays at function entry, above the `XRC.box_query()` that would have synchronized, then indexes them further down:

```cpp
CDB::TRI*      T_array = inl_ph_world().ObjectSpace().GetStaticTris();   // null
const Fvector* V_array = inl_ph_world().ObjectSpace().GetStaticVerts();  // null
...
Point((dReal*)&V_array[T->verts[0]])                                     // reads address 0
```

Object spawn reaches it on the main thread during level load:

```
CRenderDevice::FrameMove              device.cpp:705
CLevel::OnFrame                       Level.cpp:1033
CLevel::cl_Process_Spawn              Level_network_spawn.cpp:53
CEatableItemObject::net_Spawn         eatable_item_object.cpp:104
CPhysicsShellHolder::setup_physic_shell  PhysicsShellHolder.cpp:304
CPhysicsShellHolder::correct_spawn_pos   PhysicsShellHolder.cpp:232
CPHActivationShape::Activate          PHActivationShape.cpp:253
CPHWorld::StepTouch                   PHWorld.cpp:471
CPHObject::Collide                    PHObject.cpp:132
dCollideBTL                           dTriList.cpp:72
dSortTriPrimitiveCollide<BoxTri>      dSortTriPrimitive.h:209
```

The faulting instruction confirms a null base rather than a bad index:

```asm
movss xmm15, dword ptr [rbx + 4*rcx]    ; rbx = 0 (V_array), rcx = 0
```

The exception record reports `EXCEPTION_ACCESS_VIOLATION`, read from address `0`. The vertex index in `rax` is a valid `0`, so only the array pointer is missing.

## Fix

`MODEL::build_internal` already does the cheap work first and the expensive work last:

```cpp
status = S_BUILD;
verts_count = Vcnt;  verts = CALLOC(...);  CopyMemory(verts, V, ...);   // cheap
tris_count  = Tcnt;  tris  = CALLOC(...);  CopyMemory(tris,  T, ...);   // cheap
if (bc) bc(verts, Vcnt, tris, Tcnt, bcp);                               // cheap
// ~50 lines later
tree->Build(OPCC);                                                      // expensive
status = S_READY;
```

Split it at that line. `build_arrays` copies the geometry and runs the material remap. `build_tree` builds the OPCODE tree. `build_internal` calls both, so every synchronous caller (`HOM.cpp:136`, `FStaticRender_Loader.cpp:352`, `CObjectSpace::Create`) behaves exactly as before.

`CObjectSpace::Load` then runs `build_arrays` on the loading thread and queues only `build_tree`:

```cpp
Fvector* verts = (Fvector*)F->pointer();
CDB::TRI* tris = (CDB::TRI*)(verts + H.vertcount);
Static.build_arrays(verts, H.vertcount, tris, H.facecount, build_callback);
FS.r_close(F);

const DWORD this_thread_id = GetCurrentThreadId();
Static.async_cform_load.run([this, this_thread_id]()
{
    if (this_thread_id != GetCurrentThreadId()) { PROF_THREAD("X-Ray PPL Thread") }
    PROF_EVENT("Async cform tree build");
    Static.build_tree();
});
```

`verts` and `tris` are now non-null before `Load` returns, so the two accessors cannot hand out a null and need no guard. The tree stays asynchronous, and the four existing `syncronize()` calls in the query paths already cover it.

## Cost

Nothing is added to any hot path. `GetStaticVerts()` and `GetStaticTris()` stay a single `mov`, which matters because roughly 60 call sites read them, including physics collision, bullet tracing, AI vision and wallmarks.

Level load gives up the overlap on two `CopyMemory` calls and one linear pass over the triangles in `Load_GameSpecific_CFORM`. `OPCODE_Model::Build` is where the time goes, and it still runs in the background. This is also what the non-MT branch does, so the loading thread is doing no more work there than it does today on `all-in-one-vs2022-wpo`.

## Also in this change

Three smaller items, each easy to drop if you would rather keep them separate.

`build_tree` no longer frees `verts` and `tris` when `tree->Build` fails. Both failure paths in the old `build_internal` did `CFREE(verts); CFREE(tris); return;` without setting `S_READY`. After the split those arrays are already published and callers may hold pointers into them, so freeing them is worse than leaving the tree missing. `status` stays `S_BUILD`, so the query paths still refuse to use the tree.

The reader closes in `Load` instead of from the task. `build_arrays` copies everything out, so nothing needs the mapping afterwards. This removes the `static IReader* pReader` that existed only to keep the reader alive across the task boundary. A static there is shared across every `CObjectSpace`.

`status` widens from `xr_atomic_bool` to `xr_atomic_u32`. It holds a three-valued enum, so `S_BUILD` (2) and `S_INIT` (1) both stored `true`. `if (S_BUILD == status)` in `MODEL::memory()` compared 2 against 1 and could never fire. The ready check worked only because `S_READY` is 0. `memory()` has no callers today, so this changes no behaviour, but the comment `// 0=ready, 1=init, 2=building` is now true.

## Relation to #656

#656 fixed the same crash by calling `syncronize()` inside the two accessors. That works for the reported stack, but it does not establish the invariant it claims. Both `build_internal` failure paths freed the arrays without setting `S_READY`, so `syncronize()` could return and still hand out a null. `wait()` on a task group before `run()` returns immediately, and PPL resets the group on `wait()`, so a second thread arriving while the build is outstanding also returns immediately. It also put an atomic load into two getters that around 58 call sites already reached through a synchronizing query.

Publishing the arrays before `Load` returns removes the window instead of narrowing it, and costs nothing at the call sites. I have closed #656 in favour of this.

## Notes

Timing decides whether this fires. The window is between queuing the CFORM task and the first physics collision during spawn. It shows up reliably wherever level data loads slowly, and it is easy to miss on fast local storage. The non-MT branch is unaffected, since `CObjectSpace::Load` there calls `Create` inline.

I could not build and run this, so the change is untested at runtime. Please give it a run before merging.
