### PR TITLE
Extended ps_ssfx_gloss_minmax for "Glossy Puddles" addon

### DIFF
--- a/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
+++ b/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
@@ -781,7 +781,7 @@ extern Fvector4 ps_ssfx_florafixes_1;
 extern Fvector4 ps_ssfx_florafixes_2;
 
 extern float ps_ssfx_gloss_factor;
-extern Fvector3 ps_ssfx_gloss_minmax;
+extern Fvector4 ps_ssfx_gloss_minmax;
 
 extern Fvector4 ps_ssfx_wetsurfaces_1;
 extern Fvector4 ps_ssfx_wetsurfaces_2;
@@ -944,7 +944,7 @@ static class ssfx_gloss : public R_constant_setup
 {
 	virtual void setup(R_constant* C)
 	{
-		RCache.set_c(C, ps_ssfx_gloss_minmax.x, ps_ssfx_gloss_minmax.y, ps_ssfx_gloss_factor, 0);
+		RCache.set_c(C, ps_ssfx_gloss_minmax.x, ps_ssfx_gloss_minmax.y, ps_ssfx_gloss_factor, ps_ssfx_gloss_minmax.w);
 	}
 }    ssfx_gloss;
 

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -447,7 +447,7 @@ Fvector4 ps_ssfx_wetsurfaces_2 = { 1.0f, 1.0f, 1.0f, 1.0f }; // Wet surfaces 2
 int ps_ssfx_is_underground = 0;
 int ps_ssfx_gloss_method = 0;
 float ps_ssfx_gloss_factor = 0.5f;
-Fvector4 ps_ssfx_gloss_minmax = { 0.0f,0.92f,0.0f,0.0f }; // Gloss
+Fvector4  = { 0.0f,0.92f,0.0f,0.0f }; // Gloss
 
 Fvector4 ps_ssfx_lightsetup_1 = { 0.35f, 0.5f, 0.0f, 0.0f }; // Spec intensity
 
@@ -1402,7 +1402,7 @@ void xrRender_initconsole()
 
 	CMD4(CCC_Integer, "ssfx_is_underground", &ps_ssfx_is_underground, 0, 1);
 	CMD4(CCC_Integer, "ssfx_gloss_method", &ps_ssfx_gloss_method, 0, 1);
-	CMD4(CCC_Vector4, "ssfx_gloss_minmax", &ps_ssfx_gloss_minmax, Fvector4().set(0, 0, 0, 0), Fvector3().set(1.0, 1.0, 1.0, 1.0));
+	CMD4(CCC_Vector4, "ssfx_gloss_minmax", &ps_ssfx_gloss_minmax, Fvector4().set(0, 0, 0, 0), Fvector4().set(1.0, 1.0, 1.0, 1.0));
 	CMD4(CCC_Float, "ssfx_gloss_factor", &ps_ssfx_gloss_factor, 0.0f, 1.0f);
 
 	CMD4(CCC_Vector4, "ssfx_lightsetup_1", &ps_ssfx_lightsetup_1, Fvector4().set(0, 0, 0, 0), Fvector4().set(1.0, 1.0, 1.0, 1.0));

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -447,7 +447,7 @@ Fvector4 ps_ssfx_wetsurfaces_2 = { 1.0f, 1.0f, 1.0f, 1.0f }; // Wet surfaces 2
 int ps_ssfx_is_underground = 0;
 int ps_ssfx_gloss_method = 0;
 float ps_ssfx_gloss_factor = 0.5f;
-Fvector3 ps_ssfx_gloss_minmax = { 0.0f,0.92f,0.0f }; // Gloss
+Fvector4 ps_ssfx_gloss_minmax = { 0.0f,0.92f,0.0f,0.0f }; // Gloss
 
 Fvector4 ps_ssfx_lightsetup_1 = { 0.35f, 0.5f, 0.0f, 0.0f }; // Spec intensity
 
@@ -1402,7 +1402,7 @@ void xrRender_initconsole()
 
 	CMD4(CCC_Integer, "ssfx_is_underground", &ps_ssfx_is_underground, 0, 1);
 	CMD4(CCC_Integer, "ssfx_gloss_method", &ps_ssfx_gloss_method, 0, 1);
-	CMD4(CCC_Vector3, "ssfx_gloss_minmax", &ps_ssfx_gloss_minmax, Fvector3().set(0, 0, 0), Fvector3().set(1.0, 1.0, 1.0));
+	CMD4(CCC_Vector4, "ssfx_gloss_minmax", &ps_ssfx_gloss_minmax, Fvector4().set(0, 0, 0, 0), Fvector3().set(1.0, 1.0, 1.0, 1.0));
 	CMD4(CCC_Float, "ssfx_gloss_factor", &ps_ssfx_gloss_factor, 0.0f, 1.0f);
 
 	CMD4(CCC_Vector4, "ssfx_lightsetup_1", &ps_ssfx_lightsetup_1, Fvector4().set(0, 0, 0, 0), Fvector4().set(1.0, 1.0, 1.0, 1.0));

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -447,7 +447,7 @@ Fvector4 ps_ssfx_wetsurfaces_2 = { 1.0f, 1.0f, 1.0f, 1.0f }; // Wet surfaces 2
 int ps_ssfx_is_underground = 0;
 int ps_ssfx_gloss_method = 0;
 float ps_ssfx_gloss_factor = 0.5f;
-Fvector4  = { 0.0f,0.92f,0.0f,0.0f }; // Gloss
+Fvector4 ps_ssfx_gloss_minmax = { 0.0f,0.92f,0.0f,0.0f }; // Gloss
 
 Fvector4 ps_ssfx_lightsetup_1 = { 0.35f, 0.5f, 0.0f, 0.0f }; // Spec intensity
 

--- a/src/Layers/xrRenderPC_R4/r2_types.h
+++ b/src/Layers/xrRenderPC_R4/r2_types.h
@@ -172,7 +172,7 @@ extern float ps_r2_gloss_min;
 
 extern int ps_ssfx_gloss_method;
 extern float ps_ssfx_gloss_factor;
-extern Fvector3 ps_ssfx_gloss_minmax;
+extern Fvector4 ps_ssfx_gloss_minmax;
 
 IC float u_diffuse2s(float x, float y, float z)
 {


### PR DESCRIPTION
The Glossy Puddles addon uses shader_param_5 to change reflectivity of the puddles. Many addons shares the same shader_param_N constants, and that can lead into compability issues.

So, I decided to reuse ps_ssfx_gloss_minmax. Originally, it was an FVec3, so I changed it to FVec4 in order to store an additional value for Glossy Puddles addon.

Note:
This requires the author to swap **shader_param_5.w** for **ssfx_gloss.w** in the terrain shaders.
Variable has min value of 0.0 and max of 1.0 - which should be sufficient.

<img width="236" height="236" alt="2d01c9cb7a9aef494d9a33dddb87abdd" src="https://github.com/user-attachments/assets/c9928a20-64ab-4143-9004-f9f18929916a" />
