### PR TITLE
Fix/thread safety bullet particle

### DIFF
--- a/src/Layers/xrRender/ParticleGroup.cpp
+++ b/src/Layers/xrRender/ParticleGroup.cpp
@@ -188,6 +188,7 @@ PS::CParticleGroup::SItem::~SItem()
 		return;
 
 	auto Callback = xr_make_delegate(this, &PS::CParticleGroup::SItem::DelayDeleteChilds);
+	xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
 	auto Iter = std::find(Device.seqParallelBeforRender.begin(), Device.seqParallelBeforRender.end(), Callback);
 	if (Iter != Device.seqParallelBeforRender.end())
 	{
@@ -467,6 +468,7 @@ void CParticleGroup::SItem::OnFrame(u32 u_dt, const CPGDef::SEffect& def, Fbox& 
 		if (!_children_destroy.empty())
 		{
 			auto Callback = xr_make_delegate(this, &PS::CParticleGroup::SItem::DelayDeleteChilds);
+			xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
 			if (std::find(Device.seqParallelBeforRender.begin(), Device.seqParallelBeforRender.end(), Callback) == Device.seqParallelBeforRender.end())
 			{
 				Device.seqParallelBeforRender.emplace_back(std::move(Callback));

--- a/src/Layers/xrRender/ParticleGroup.cpp
+++ b/src/Layers/xrRender/ParticleGroup.cpp
@@ -192,7 +192,15 @@ PS::CParticleGroup::SItem::~SItem()
 	auto Iter = std::find(Device.seqParallelBeforRender.begin(), Device.seqParallelBeforRender.end(), Callback);
 	if (Iter != Device.seqParallelBeforRender.end())
 	{
-		Device.seqParallelBeforRender.erase(Iter);
+		// Cancel in place rather than erasing. This destructor can run from
+		// inside the main thread's drain loop in CRenderDevice::on_idle, when
+		// an invoked callback destroys an object owning this particle group
+		// (CObjectList::ProcessDestroyQueue is registered in the same vector).
+		// Erasing there would invalidate the loop's iteration; clearing the
+		// entry leaves the size untouched. The drain skips cleared entries and
+		// clear()s the whole vector once it finishes, so the callback is never
+		// invoked on a destroyed SItem either way.
+		Iter->clear();
 	}
 }
 

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -385,8 +385,20 @@ void CRenderDevice::on_idle()
 	{
 		PROF_EVENT("seqParallelBeforRender");
 		xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
-		for (auto& it : Device.seqParallelBeforRender)
-			it();
+
+		// A callback invoked here can destroy an object that owns a particle
+		// group, and PS::CParticleGroup::SItem::~SItem cancels its own pending
+		// entry in this very vector. That cancellation clears the entry in
+		// place instead of erasing it, so the vector never changes size while
+		// we walk it. Skip the cleared entries; the clear() below drops them.
+		// Index by position and copy each delegate before invoking it, so an
+		// entry appended by a callback is still handled safely.
+		for (size_t it = 0; it < Device.seqParallelBeforRender.size(); ++it)
+		{
+			auto Callback = Device.seqParallelBeforRender[it];
+			if (Callback)
+				Callback();
+		}
 
 		Device.seqParallelBeforRender.clear();
 	}

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -384,6 +384,7 @@ void CRenderDevice::on_idle()
 
 	{
 		PROF_EVENT("seqParallelBeforRender");
+		xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
 		for (auto& it : Device.seqParallelBeforRender)
 			it();
 

--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -8,6 +8,7 @@
 //class ENGINE_API CGammaControl;
 
 #include "pure.h"
+#include "../xrCore/xrSyncronize.h"
 //#include "hw.h"
 #include "../xrcore/ftimer.h"
 #include "stats.h"
@@ -230,6 +231,12 @@ public:
 	// ForserX: Pre-Render sequence
 	xr_vector<xr_delegate<void()>> seqParallelRender;
 	xr_vector<xr_delegate<void()>> seqParallelBeforRender;
+
+	// seqParallelBeforRender is filled from the particle worker thread
+	// (CParticleGroup::SItem::OnFrame) and drained on the main thread in
+	// CRenderDevice::on_idle(). Guard every access with this section.
+	// Same pattern as CEventAPI::CS and CEffect_Rain::rainCS.
+	xrCriticalSection seqParallelBeforRenderCS;
 
 	xr_delegate<void()> ParticleWorkerCallback;
 	xr_delegate<void()> ModelDefferClear;

--- a/src/xrEngine/xr_object_list.cpp
+++ b/src/xrEngine/xr_object_list.cpp
@@ -266,7 +266,10 @@ void CObjectList::Update(bool bForce)
 	// Destroy
     ProcessDestroyQueueImpl(force_destroy_queue);
     if (mt_Scheduler)
+    {
+        xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
         Device.seqParallelBeforRender.push_back(xr_make_delegate(this, &CObjectList::ProcessDestroyQueue));
+    }
     else
         ProcessDestroyQueue();
 }
@@ -430,6 +433,7 @@ void CObjectList::Load()
 void CObjectList::ClearProcessDestroyQueueFromDevice()
 {
     auto Callback = xr_make_delegate(this, &CObjectList::ProcessDestroyQueue);
+    xrCriticalSectionGuard guard(&Device.seqParallelBeforRenderCS);
     Device.seqParallelBeforRender.erase(
         std::remove(
             Device.seqParallelBeforRender.begin(),

--- a/src/xrGame/Level_Bullet_Manager.cpp
+++ b/src/xrGame/Level_Bullet_Manager.cpp
@@ -247,6 +247,7 @@ void CBulletManager::PlayWhineSound(SBullet* bullet, CObject* object, const Fvec
 
 void CBulletManager::Clear()
 {
+	xrCriticalSectionGuard guard(&m_Lock);
 	m_Bullets.clear();
 	m_Events.clear();
 }
@@ -267,10 +268,6 @@ void CBulletManager::AddBullet(const Fvector& position,
                                bool AimBullet,
                                int iShotNum)
 {
-#ifdef DEBUG
-	VERIFY(m_thread_id == GetCurrentThreadId());
-#endif
-
 	VERIFY(u16(-1)!=cartridge.bullet_material_idx);
 	//	u32 CurID					= Level().CurrentControlEntity()->ID();
 	//	u32 OwnerID					= sender_id;


### PR DESCRIPTION
Fix unsynchronized concurrent access: bullet manager and particle system

Found while investigating thread safety in the engine's multithreaded
render/game-logic split. Both fixes are self-contained. Neither depends
on or relates to any TBB work.

    CBulletManager::Clear() took no lock. UpdateWorkload, Render, and
    AddBullet in the same class all correctly guard m_Bullets with m_Lock.
    UpdateWorkload runs on GameThread. Render runs on the main thread. This
    is genuine concurrent access, on by default via mtBullets. Clear() only
    runs on level load or disconnect, so it's not on the hot path, but it
    was the one unguarded member of an otherwise consistent trio. Added the
    same lock.

Also removed a stale DEBUG-only thread assertion in AddBullet. It
claimed AddBullet is main-thread-only. It isn't: several weapon/explosive
paths and a Lua binding call it off-main today. The matching assertion
in UpdateWorkload was already removed. This restores consistency.

    Three sites touch Device.seqParallelBeforRender with no lock:
    SItem::OnFrame and SItem::~SItem write to it from a worker thread, and
    CRenderDevice::on_idle drains it on the main thread every frame. The
    existing onframe_lock doesn't cover this, since it's a per-particle-group
    member and can't protect a shared, device-level vector. Added a new
    lock on CRenderDevice, following the same pattern already used elsewhere
    in the codebase for this exact producer/drainer shape.

Found but not fixed: SItem's destructor has a separate, pre-existing,
same-thread hazard if a deferred callback ever destroys an SItem
mid-drain. Not currently reachable and unrelated to the race above.
Flagging it rather than expanding scope here.

Tested across multiple sessions, including firefights with active
particle effects. No crashes, hangs, or behavior changes observed. This
confirms the new locking doesn't break anything. It doesn't prove the
original race ever caused a specific crash. Both were unsynchronized
shared-state access regardless of whether either was ever observed to
fail.

Edit: Upon closer inspection, it seems that the SItem iterator hazard is reachable. Second commit addresses it.