### PR TITLE
RenderDoc Integration

### DIFF
--- a/src/Layers/xrRenderDX10/dx10DebugName.h
+++ b/src/Layers/xrRenderDX10/dx10DebugName.h
@@ -1,0 +1,14 @@
+#pragma once
+
+template <class T>
+IC void dx10_set_debug_name(T* resource, const char* name)
+{
+	if (!resource || !name || !name[0])
+		return;
+
+	// WKPDID_D3DDebugObjectName, spelled out so no dxguid import is needed
+	static const GUID debug_object_name =
+		{0x429b8c22, 0x9188, 0x4b0c, {0x87, 0x42, 0xac, 0xb0, 0xbf, 0x85, 0xc2, 0x00}};
+
+	resource->SetPrivateData(debug_object_name, UINT(xr_strlen(name)), name);
+}

--- a/src/Layers/xrRenderDX10/dx10EventWrapper.cpp
+++ b/src/Layers/xrRenderDX10/dx10EventWrapper.cpp
@@ -94,3 +94,23 @@ dxPixEventWrapper::~dxPixEventWrapper()
     else if (annotation)
         annotation->EndEvent();
 }
+
+extern Fvector4 ps_dev_param_1;
+extern Fvector4 ps_dev_param_2;
+extern Fvector4 ps_dev_param_3;
+extern Fvector4 ps_dev_param_4;
+extern Fvector4 ps_dev_param_5;
+extern Fvector4 ps_dev_param_6;
+extern Fvector4 ps_dev_param_7;
+extern Fvector4 ps_dev_param_8;
+
+void dx10_annotate_frame()
+{
+    if (!renderdoc_api_live())
+        return;
+
+    const Fvector4 shader_params[] = {ps_dev_param_1, ps_dev_param_2, ps_dev_param_3, ps_dev_param_4,
+        ps_dev_param_5, ps_dev_param_6, ps_dev_param_7, ps_dev_param_8};
+
+    renderdoc_annotate_frame(shader_params, u32(std::size(shader_params)));
+}

--- a/src/Layers/xrRenderDX10/dx10EventWrapper.cpp
+++ b/src/Layers/xrRenderDX10/dx10EventWrapper.cpp
@@ -2,15 +2,95 @@
 #pragma hdrstop
 #include "dx10EventWrapper.h"
 #include "../xrRender/HW.h"
+#include "../../xrEngine/renderdoc_integration.h"
 
-dxPixEventWrapper::dxPixEventWrapper(LPCWSTR wszName)
+namespace
 {
-    if (HW.pAnnotation)
-        HW.pAnnotation->BeginEvent(wszName);
+    typedef int(WINAPI* pfn_perf_begin_event)(DWORD color, LPCWSTR name);
+    typedef int(WINAPI* pfn_perf_end_event)(void);
+    typedef DWORD(WINAPI* pfn_perf_get_status)(void);
+
+    struct dx10_perf_markers
+    {
+        pfn_perf_begin_event begin;
+        pfn_perf_end_event end;
+        pfn_perf_get_status status;
+
+        dx10_perf_markers() : begin(nullptr), end(nullptr), status(nullptr)
+        {
+            // RenderDoc hooks d3d9 by module name so the system copy is the right one
+            const HMODULE d3d9 = LoadLibraryExW(L"d3d9.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (!d3d9)
+                return;
+
+            begin = reinterpret_cast<pfn_perf_begin_event>(GetProcAddress(d3d9, "D3DPERF_BeginEvent"));
+            end = reinterpret_cast<pfn_perf_end_event>(GetProcAddress(d3d9, "D3DPERF_EndEvent"));
+            status = reinterpret_cast<pfn_perf_get_status>(GetProcAddress(d3d9, "D3DPERF_GetStatus"));
+        }
+
+        bool hooked() const { return begin && end && status && status() != 0; }
+    };
+
+    const dx10_perf_markers& dx10_perf()
+    {
+        static const dx10_perf_markers markers;
+        return markers;
+    }
+
+    enum dx10_marker_sink
+    {
+        dx10_sink_none,
+        dx10_sink_annotation,
+        dx10_sink_perf,
+    };
+
+    dx10_marker_sink dx10_sink(ID3DUserDefinedAnnotation* annotation)
+    {
+        static thread_local ID3DUserDefinedAnnotation* cached_annotation = nullptr;
+        static thread_local u32 cached_frame = u32(-1);
+        static thread_local dx10_marker_sink cached_sink = dx10_sink_none;
+
+        if (cached_annotation != annotation || cached_frame != Device.dwFrame)
+        {
+            cached_annotation = annotation;
+            cached_frame = Device.dwFrame;
+
+            // RenderDoc leaves the annotation status clear until a capture starts
+            const bool listening = renderdoc_api_live() || annotation->GetStatus() != FALSE;
+
+            cached_sink = dx10_sink_none;
+            if (listening)
+                cached_sink = dx10_perf().hooked() ? dx10_sink_perf : dx10_sink_annotation;
+        }
+
+        return cached_sink;
+    }
+}
+
+dxPixEventWrapper::dxPixEventWrapper(LPCWSTR wszName, u32 color) : annotation(nullptr), perf_event(false)
+{
+    ID3DUserDefinedAnnotation* const listener = HW.pAnnotation;
+    if (!listener)
+        return;
+
+    const dx10_marker_sink sink = dx10_sink(listener);
+    if (sink == dx10_sink_none)
+        return;
+
+    if (color && sink == dx10_sink_perf && dx10_perf().begin(color, wszName) >= 0)
+    {
+        perf_event = true;
+        return;
+    }
+
+    if (listener->BeginEvent(wszName) >= 0)
+        annotation = listener;
 }
 
 dxPixEventWrapper::~dxPixEventWrapper()
 {
-    if (HW.pAnnotation)
-        HW.pAnnotation->EndEvent();
-} 
+    if (perf_event)
+        dx10_perf().end();
+    else if (annotation)
+        annotation->EndEvent();
+}

--- a/src/Layers/xrRenderDX10/dx10EventWrapper.h
+++ b/src/Layers/xrRenderDX10/dx10EventWrapper.h
@@ -15,6 +15,8 @@ enum dx10_marker_color : u32
 #define PIX_EVENT(Name) dxPixEventWrapper pixEvent##Name(L#Name)
 #define PIX_EVENT_C(Name, Color) dxPixEventWrapper pixEvent##Name(L#Name, Color)
 
+void dx10_annotate_frame();
+
 class dxPixEventWrapper
 {
     ID3DUserDefinedAnnotation* annotation;

--- a/src/Layers/xrRenderDX10/dx10EventWrapper.h
+++ b/src/Layers/xrRenderDX10/dx10EventWrapper.h
@@ -1,10 +1,26 @@
 #pragma once
 
+struct ID3DUserDefinedAnnotation;
+
+// The Event Browser tints a region only on the D3DPERF path
+enum dx10_marker_color : u32
+{
+    dx10_marker_frame = 0xff8a8f98,
+    dx10_marker_gbuffer = 0xff4c8bf5,
+    dx10_marker_lights = 0xfff5b74c,
+    dx10_marker_combine = 0xff5fc27e,
+    dx10_marker_post = 0xffb06fd6,
+};
+
 #define PIX_EVENT(Name) dxPixEventWrapper pixEvent##Name(L#Name)
+#define PIX_EVENT_C(Name, Color) dxPixEventWrapper pixEvent##Name(L#Name, Color)
 
 class dxPixEventWrapper
 {
+    ID3DUserDefinedAnnotation* annotation;
+    bool perf_event;
+
 public:
-    dxPixEventWrapper(LPCWSTR wszName);
+    dxPixEventWrapper(LPCWSTR wszName, u32 color = 0);
     ~dxPixEventWrapper();
-}; 
+};

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -13,6 +13,7 @@
 #pragma warning(default:4995)
 #include "../xrRender/HW.h"
 #include "../../xrEngine/XR_IOConsole.h"
+#include "../../xrEngine/renderdoc_integration.h"
 #include "../../Include/xrAPI/xrAPI.h"
 #include "../xrRender/xrRender_console.h"
 
@@ -609,6 +610,8 @@ void CHW::CreateDevice(HWND hwnd, bool move_window)
     _RELEASE(swapchain3);
 
     R_CHK(pContext->QueryInterface(__uuidof(ID3DUserDefinedAnnotation), (void**)&pAnnotation));
+
+    renderdoc_set_active_window(pDevice, m_hWnd);
 
 #else
 	R = D3DX10CreateDeviceAndSwapChain(m_pAdapter,

--- a/src/Layers/xrRenderDX10/dx10SH_RT.cpp
+++ b/src/Layers/xrRenderDX10/dx10SH_RT.cpp
@@ -6,6 +6,7 @@
 #include "../xrRender/dxRenderDeviceRender.h"
 
 #include "dx10TextureUtils.h"
+#include "dx10DebugName.h"
 
 CRT::CRT()
 {
@@ -136,6 +137,7 @@ void CRT::create(LPCSTR Name, u32 w, u32 h, D3DFORMAT f, u32 SampleCount)
 
 	CHK_DX(HW.pDevice->CreateTexture2D( &desc, NULL, &pSurface ));
 	HW.stats_manager.increment_stats_rtarget(pSurface);
+	dx10_set_debug_name(pSurface, Name);
 	// OK
 #ifdef DEBUG
 	Msg			("* created RT(%s), %dx%d, format = %d samples = %d",Name,w,h, dx10FMT, SampleCount );

--- a/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj
+++ b/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj
@@ -405,6 +405,7 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer_impl.h" />
+    <ClInclude Include="..\xrRenderDX10\dx10DebugName.h" />
     <ClInclude Include="..\xrRenderDX10\dx10R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX10\dx10r_constants_cache.h" />
     <ClInclude Include="..\xrRenderDX10\dx10StateUtils.h" />

--- a/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj.filters
@@ -657,6 +657,9 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h">
       <Filter>dx9 to dx10 Utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\xrRenderDX10\dx10DebugName.h">
+      <Filter>dx9 to dx10 Utils</Filter>
+    </ClInclude>
     <ClInclude Include="..\xrRenderDX10\dx10StateUtils.h">
       <Filter>dx9 to dx10 Utils</Filter>
     </ClInclude>

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -65,6 +65,7 @@ extern u32 g_r;
 void CRender::Render()
 {
 	PIX_EVENT_C(CRender_Render, dx10_marker_frame);
+	dx10_annotate_frame();
 
 	rmNormal();
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -64,7 +64,7 @@ extern u32 g_r;
 
 void CRender::Render()
 {
-	PIX_EVENT(CRender_Render);
+	PIX_EVENT_C(CRender_Render, dx10_marker_frame);
 
 	rmNormal();
 
@@ -156,7 +156,7 @@ void CRender::Render()
 
 	//******* Main render :: PART-0	-- first
 	{
-		PIX_EVENT(DEFER_PART0_SPLIT);
+		PIX_EVENT_C(DEFER_PART0_SPLIT, dx10_marker_gbuffer);
 		// level, SPLIT
 		Target->phase_scene_begin();
 		GMBase.r_dsgraph_render_static(0);
@@ -186,7 +186,7 @@ void CRender::Render()
 
 	//******* Main render :: PART-1 (second)
 	{
-		PIX_EVENT(DEFER_PART1_SPLIT);
+		PIX_EVENT_C(DEFER_PART1_SPLIT, dx10_marker_gbuffer);
 		// level
 		Target->phase_scene_begin();
 		GMBase.r_dsgraph_capture_hud();
@@ -273,7 +273,7 @@ void CRender::Render()
 	// Directional light - fucking sun
 	if (bSUN) //bSUN && Device.dwFrame & 1 --Delayed sun update. Worth to check it in future
 	{
-		PIX_EVENT(DEFER_SUN);
+		PIX_EVENT_C(DEFER_SUN, dx10_marker_lights);
 		RImplementation.stats.l_visible ++;
 		render_sun_cascades();
 		Target->increment_light_marker();
@@ -283,7 +283,7 @@ void CRender::Render()
 	phase = PHASE_NORMAL;
 
 	{
-		PIX_EVENT(DEFER_SELF_ILLUM);
+		PIX_EVENT_C(DEFER_SELF_ILLUM, dx10_marker_lights);
 		Target->phase_accumulator();
 		// Render emissive geometry, stencil - write 0x0 at pixel pos
 		RCache.set_xform_project(Device.mProject);
@@ -315,14 +315,14 @@ void CRender::Render()
 
 	// Lighting, non dependant on OCCQ
 	{
-		PIX_EVENT(DEFER_LIGHT_NO_OCCQ);
+		PIX_EVENT_C(DEFER_LIGHT_NO_OCCQ, dx10_marker_lights);
 		Target->phase_accumulator();
 		render_lights(LP_normal);
 	}
 
 	// Lighting, dependant on OCCQ
 	{
-		PIX_EVENT(DEFER_LIGHT_OCCQ);
+		PIX_EVENT_C(DEFER_LIGHT_OCCQ, dx10_marker_lights);
 		render_lights(LP_pending);
 	}
 
@@ -335,7 +335,7 @@ void CRender::Render()
 
 	// Postprocess
 	{
-		PIX_EVENT(DEFER_LIGHT_COMBINE);
+		PIX_EVENT_C(DEFER_LIGHT_COMBINE, dx10_marker_lights);
 		Target->phase_combine();
 	}
 

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_bloom.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_bloom.cpp
@@ -67,7 +67,7 @@ void CalcGauss_wave(
 
 void CRenderTarget::phase_bloom()
 {
-	PIX_EVENT(phase_bloom);
+	PIX_EVENT_C(phase_bloom, dx10_marker_post);
 	u32 Offset;
 
 	// Targets
@@ -382,6 +382,8 @@ void CRenderTarget::phase_bloom()
 
 void CRenderTarget::phase_ssfx_bloom()
 {
+	PIX_EVENT_C(phase_ssfx_bloom, dx10_marker_post);
+
 	//Constants
 	u32 Offset = 0;
 	u32 C = color_rgba(0, 0, 0, 0);

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -39,7 +39,7 @@ float hclip(float v, float dim) { return 2.f * v / dim - 1.f; }
 
 void CRenderTarget::phase_combine()
 {
-	PIX_EVENT(phase_combine);
+	PIX_EVENT_C(phase_combine, dx10_marker_combine);
     PROF_EVENT("phase_combine");
 	
 	bool ssfx_PrevPos_Requiered = false;
@@ -191,7 +191,7 @@ void CRenderTarget::phase_combine()
 	// Draw full-screen quad textured with our scene image
 	if (!_menu_pp)
 	{
-		PIX_EVENT(combine_1);
+		PIX_EVENT_C(combine_1, dx10_marker_combine);
 		// Compute params
 		CEnvDescriptorMixer& envdesc = *g_pGamePersistent->Environment().CurrentEnv;
 		const float minamb = 0.001f;
@@ -336,6 +336,7 @@ void CRenderTarget::phase_combine()
 
 	if (RImplementation.o.ssfx_ssr && !Device.m_SecondViewport.IsSVPFrame())
 	{
+		PIX_EVENT(phase_ssfx_ssr);
 		ssfx_PrevPos_Requiered = true;
 		phase_ssfx_ssr(); // [SSFX] - New SSR Phase
 	}
@@ -511,16 +512,21 @@ void CRenderTarget::phase_combine()
 	if (!_menu_pp)
 	{
 		if (ps_sunshafts_mode == R2SS_SCREEN_SPACE || ps_sunshafts_mode == R2SS_COMBINE_SUNSHAFTS)
+		{
+			PIX_EVENT(phase_sunshafts);
 			phase_sunshafts();
+		}
 	}
 
 	if (RImplementation.o.ssfx_fog && ps_ssfx_fog_scattering > 0)
 	{
+		PIX_EVENT(phase_ssfx_fog_scattering);
 		phase_ssfx_fog_scattering();
 	}
 
 	if (RImplementation.o.ssfx_motionblur && ps_ssfx_motionblur.y > 0)
 	{
+		PIX_EVENT(phase_ssfx_motion_blur);
 		phase_ssfx_motion_blur();
 	}
 
@@ -531,7 +537,10 @@ void CRenderTarget::phase_combine()
 
 	//Compute blur textures
 	if (!Device.m_SecondViewport.IsSVPFrame()) // Temp fix for blur buffer and SVP
+	{
+		PIX_EVENT(phase_blur);
 		phase_blur();
+	}
 
 	//Compute bloom (new)
 	if (RImplementation.o.ssfx_bloom)
@@ -547,11 +556,15 @@ void CRenderTarget::phase_combine()
 	}
 	
 	if (ps_r2_ls_flags.test(R2FLAG_DOF))
-	{	
+	{
+		PIX_EVENT(phase_dof);
 		phase_dof();
 	}
 
-	phase_lut();	
+	{
+		PIX_EVENT(phase_lut);
+		phase_lut();
+	}
 
 	if(ps_r2_mask_control.x > 0)
 	{
@@ -617,7 +630,7 @@ void CRenderTarget::phase_combine()
 
 	if (1)
 	{
-		PIX_EVENT(combine_2);
+		PIX_EVENT_C(combine_2, dx10_marker_combine);
 		// 
 		struct v_aa
 		{
@@ -742,7 +755,7 @@ void CRenderTarget::phase_combine()
 	//	PP-if required
 	if (PP_Complex)
 	{
-		PIX_EVENT(phase_pp);
+		PIX_EVENT_C(phase_pp, dx10_marker_post);
 		phase_pp();
 	}
 

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_scene.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_scene.cpp
@@ -3,7 +3,7 @@
 // startup
 void CRenderTarget::phase_scene_prepare()
 {
-	PIX_EVENT(phase_scene_prepare);
+	PIX_EVENT_C(phase_scene_prepare, dx10_marker_gbuffer);
 
 		//	TODO: DX10: Check if we need to set RT here.
 		if (!RImplementation.o.dx10_msaa)

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_ssao.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_ssao.cpp
@@ -164,6 +164,7 @@ void CRenderTarget::phase_downsamp()
 
 void CRenderTarget::phase_ssfx_ao()
 {
+	PIX_EVENT(phase_ssfx_ao);
 
 	//Constants
 	u32 Offset = 0;

--- a/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj
+++ b/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj
@@ -405,6 +405,7 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer_impl.h" />
+    <ClInclude Include="..\xrRenderDX10\dx10DebugName.h" />
     <ClInclude Include="..\xrRenderDX10\dx10R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX10\dx10r_constants_cache.h" />
     <ClInclude Include="..\xrRenderDX10\dx10StateUtils.h" />

--- a/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj.filters
@@ -675,6 +675,9 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h">
       <Filter>dx9 to dx10 Utils</Filter>
     </ClInclude>
+    <ClInclude Include="..\xrRenderDX10\dx10DebugName.h">
+      <Filter>dx9 to dx10 Utils</Filter>
+    </ClInclude>
     <ClInclude Include="..\xrRenderDX10\dx10StateUtils.h">
       <Filter>dx9 to dx10 Utils</Filter>
     </ClInclude>

--- a/src/xrCore/xrParams.h
+++ b/src/xrCore/xrParams.h
@@ -39,6 +39,8 @@ enum class ECoreParams : u8
 	
 	// API
 	renderdoc,
+	rdoc_refall,
+	rdoc_cmdlists,
 
 	// Anomaly
 	no_dialog_header,

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -19,6 +19,7 @@
 #include "x_ray.h"
 #include "discord\discord.h"
 #include "render.h"
+#include "renderdoc_integration.h"
 #include <chrono>
 
 // must be defined before include of FS_impl.h
@@ -659,6 +660,7 @@ void CRenderDevice::FrameMove()
 
 	dwFrame++;
 	Core.dwFrame = dwFrame;
+	renderdoc_poll_captures();
 	dwTimeContinual = TimerMM.GetElapsed_ms() - app_inactive_time;
 	if (psDeviceFlags.test(rsConstantFPS))
 	{

--- a/src/xrEngine/renderdoc_app.h
+++ b/src/xrEngine/renderdoc_app.h
@@ -1,0 +1,875 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Documentation for the API is available at https://renderdoc.org/docs/in_application_api.html
+//
+
+#if !defined(RENDERDOC_NO_STDINT)
+#include <stdint.h>
+#endif
+
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+#define RENDERDOC_CC __cdecl
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__sun__) || defined(__OpenBSD__)
+#define RENDERDOC_CC
+#elif defined(__APPLE__)
+#define RENDERDOC_CC
+#else
+#error "Unknown platform"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants not used directly in below API
+
+// This is a GUID/magic value used for when applications pass a path where shader debug
+// information can be found to match up with a stripped shader.
+// the define can be used like so: const GUID RENDERDOC_ShaderDebugMagicValue =
+// RENDERDOC_ShaderDebugMagicValue_value
+#define RENDERDOC_ShaderDebugMagicValue_struct                                \
+  {                                                                           \
+    0xeab25520, 0x6670, 0x4865, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// as an alternative when you want a byte array (assuming x86 endianness):
+#define RENDERDOC_ShaderDebugMagicValue_bytearray                                                 \
+  {                                                                                               \
+    0x20, 0x55, 0xb2, 0xea, 0x70, 0x66, 0x65, 0x48, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// truncated version when only a uint64_t is available (e.g. Vulkan tags):
+#define RENDERDOC_ShaderDebugMagicValue_truncated 0x48656670eab25520ULL
+
+// this is a magic value for vulkan user tags to indicate which dispatchable API objects are which
+// for object annotations
+#define RENDERDOC_APIObjectAnnotationHelper 0xfbb3b337b664d0adULL
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc capture options
+//
+
+typedef enum RENDERDOC_CaptureOption
+{
+  // Allow the application to enable vsync
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable vsync at will
+  // 0 - vsync is force disabled
+  eRENDERDOC_Option_AllowVSync = 0,
+
+  // Allow the application to enable fullscreen
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable fullscreen at will
+  // 0 - fullscreen is force disabled
+  eRENDERDOC_Option_AllowFullscreen = 1,
+
+  // Record API debugging events and messages
+  //
+  // Default - disabled
+  //
+  // 1 - Enable built-in API debugging features and records the results into
+  //     the capture, which is matched up with events on replay
+  // 0 - no API debugging is forcibly enabled
+  eRENDERDOC_Option_APIValidation = 2,
+  eRENDERDOC_Option_DebugDeviceMode = 2,    // deprecated name of this enum
+
+  // Capture CPU callstacks for API events
+  //
+  // Default - disabled
+  //
+  // 1 - Enables capturing of callstacks
+  // 0 - no callstacks are captured
+  eRENDERDOC_Option_CaptureCallstacks = 3,
+
+  // When capturing CPU callstacks, only capture them from actions.
+  // This option does nothing without the above option being enabled
+  //
+  // Default - disabled
+  //
+  // 1 - Only captures callstacks for actions.
+  //     Ignored if CaptureCallstacks is disabled
+  // 0 - Callstacks, if enabled, are captured for every event.
+  eRENDERDOC_Option_CaptureCallstacksOnlyDraws = 4,
+  eRENDERDOC_Option_CaptureCallstacksOnlyActions = 4,
+
+  // Specify a delay in seconds to wait for a debugger to attach, after
+  // creating or injecting into a process, before continuing to allow it to run.
+  //
+  // 0 indicates no delay, and the process will run immediately after injection
+  //
+  // Default - 0 seconds
+  //
+  eRENDERDOC_Option_DelayForDebugger = 5,
+
+  // Verify buffer access. This includes checking the memory returned by a Map() call to
+  // detect any out-of-bounds modification, as well as initialising buffers with undefined contents
+  // to a marker value to catch use of uninitialised memory.
+  //
+  // NOTE: This option is only valid for OpenGL and D3D11. Explicit APIs such as D3D12 and Vulkan do
+  // not do the same kind of interception & checking and undefined contents are really undefined.
+  //
+  // Default - disabled
+  //
+  // 1 - Verify buffer access
+  // 0 - No verification is performed, and overwriting bounds may cause crashes or corruption in
+  //     RenderDoc.
+  eRENDERDOC_Option_VerifyBufferAccess = 6,
+
+  // The old name for eRENDERDOC_Option_VerifyBufferAccess was eRENDERDOC_Option_VerifyMapWrites.
+  // This option now controls the filling of uninitialised buffers with 0xdddddddd which was
+  // previously always enabled
+  eRENDERDOC_Option_VerifyMapWrites = eRENDERDOC_Option_VerifyBufferAccess,
+
+  // Hooks any system API calls that create child processes, and injects
+  // RenderDoc into them recursively with the same options.
+  //
+  // Default - disabled
+  //
+  // 1 - Hooks into spawned child processes
+  // 0 - Child processes are not hooked by RenderDoc
+  eRENDERDOC_Option_HookIntoChildren = 7,
+
+  // By default RenderDoc only includes resources in the final capture necessary
+  // for that frame, this allows you to override that behaviour.
+  //
+  // Default - disabled
+  //
+  // 1 - all live resources at the time of capture are included in the capture
+  //     and available for inspection
+  // 0 - only the resources referenced by the captured frame are included
+  eRENDERDOC_Option_RefAllResources = 8,
+
+  // **NOTE**: As of RenderDoc v1.1 this option has been deprecated. Setting or
+  // getting it will be ignored, to allow compatibility with older versions.
+  // In v1.1 the option acts as if it's always enabled.
+  //
+  // By default RenderDoc skips saving initial states for resources where the
+  // previous contents don't appear to be used, assuming that writes before
+  // reads indicate previous contents aren't used.
+  //
+  // Default - disabled
+  //
+  // 1 - initial contents at the start of each captured frame are saved, even if
+  //     they are later overwritten or cleared before being used.
+  // 0 - unless a read is detected, initial contents will not be saved and will
+  //     appear as black or empty data.
+  eRENDERDOC_Option_SaveAllInitials = 9,
+
+  // In APIs that allow for the recording of command lists to be replayed later,
+  // RenderDoc may choose to not capture command lists before a frame capture is
+  // triggered, to reduce overheads. This means any command lists recorded once
+  // and replayed many times will not be available and may cause a failure to
+  // capture.
+  //
+  // NOTE: This is only true for APIs where multithreading is difficult or
+  // discouraged. Newer APIs like Vulkan and D3D12 will ignore this option
+  // and always capture all command lists since the API is heavily oriented
+  // around it and the overheads have been reduced by API design.
+  //
+  // 1 - All command lists are captured from the start of the application
+  // 0 - Command lists are only captured if their recording begins during
+  //     the period when a frame capture is in progress.
+  eRENDERDOC_Option_CaptureAllCmdLists = 10,
+
+  // Mute API debugging output when the API validation mode option is enabled
+  //
+  // Default - enabled
+  //
+  // 1 - Mute any API debug messages from being displayed or passed through
+  // 0 - API debugging is displayed as normal
+  eRENDERDOC_Option_DebugOutputMute = 11,
+
+  // Option to allow vendor extensions to be used even when they may be
+  // incompatible with RenderDoc and cause corrupted replays or crashes.
+  //
+  // Default - inactive
+  //
+  // No values are documented, this option should only be used when absolutely
+  // necessary as directed by a RenderDoc developer.
+  eRENDERDOC_Option_AllowUnsupportedVendorExtensions = 12,
+
+  // Define a soft memory limit which some APIs may aim to keep overhead under where
+  // possible. Anything above this limit will where possible be saved directly to disk during
+  // capture.
+  // This will cause increased disk space use (which may cause a capture to fail if disk space is
+  // exhausted) as well as slower capture times.
+  //
+  // Not all memory allocations may be deferred like this so it is not a guarantee of a memory
+  // limit.
+  //
+  // Units are in MBs, suggested values would range from 200MB to 1000MB.
+  //
+  // Default - 0 Megabytes
+  eRENDERDOC_Option_SoftMemoryLimit = 13,
+} RENDERDOC_CaptureOption;
+
+// Sets an option that controls how RenderDoc behaves on capture.
+//
+// Returns 1 if the option and value are valid
+// Returns 0 if either is invalid and the option is unchanged
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionU32)(RENDERDOC_CaptureOption opt, uint32_t val);
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionF32)(RENDERDOC_CaptureOption opt, float val);
+
+// Gets the current value of an option as a uint32_t
+//
+// If the option is invalid, 0xffffffff is returned
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionU32)(RENDERDOC_CaptureOption opt);
+
+// Gets the current value of an option as a float
+//
+// If the option is invalid, -FLT_MAX is returned
+typedef float(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionF32)(RENDERDOC_CaptureOption opt);
+
+typedef enum RENDERDOC_InputButton
+{
+  // '0' - '9' matches ASCII values
+  eRENDERDOC_Key_0 = 0x30,
+  eRENDERDOC_Key_1 = 0x31,
+  eRENDERDOC_Key_2 = 0x32,
+  eRENDERDOC_Key_3 = 0x33,
+  eRENDERDOC_Key_4 = 0x34,
+  eRENDERDOC_Key_5 = 0x35,
+  eRENDERDOC_Key_6 = 0x36,
+  eRENDERDOC_Key_7 = 0x37,
+  eRENDERDOC_Key_8 = 0x38,
+  eRENDERDOC_Key_9 = 0x39,
+
+  // 'A' - 'Z' matches ASCII values
+  eRENDERDOC_Key_A = 0x41,
+  eRENDERDOC_Key_B = 0x42,
+  eRENDERDOC_Key_C = 0x43,
+  eRENDERDOC_Key_D = 0x44,
+  eRENDERDOC_Key_E = 0x45,
+  eRENDERDOC_Key_F = 0x46,
+  eRENDERDOC_Key_G = 0x47,
+  eRENDERDOC_Key_H = 0x48,
+  eRENDERDOC_Key_I = 0x49,
+  eRENDERDOC_Key_J = 0x4A,
+  eRENDERDOC_Key_K = 0x4B,
+  eRENDERDOC_Key_L = 0x4C,
+  eRENDERDOC_Key_M = 0x4D,
+  eRENDERDOC_Key_N = 0x4E,
+  eRENDERDOC_Key_O = 0x4F,
+  eRENDERDOC_Key_P = 0x50,
+  eRENDERDOC_Key_Q = 0x51,
+  eRENDERDOC_Key_R = 0x52,
+  eRENDERDOC_Key_S = 0x53,
+  eRENDERDOC_Key_T = 0x54,
+  eRENDERDOC_Key_U = 0x55,
+  eRENDERDOC_Key_V = 0x56,
+  eRENDERDOC_Key_W = 0x57,
+  eRENDERDOC_Key_X = 0x58,
+  eRENDERDOC_Key_Y = 0x59,
+  eRENDERDOC_Key_Z = 0x5A,
+
+  // leave the rest of the ASCII range free
+  // in case we want to use it later
+  eRENDERDOC_Key_NonPrintable = 0x100,
+
+  eRENDERDOC_Key_Divide,
+  eRENDERDOC_Key_Multiply,
+  eRENDERDOC_Key_Subtract,
+  eRENDERDOC_Key_Plus,
+
+  eRENDERDOC_Key_F1,
+  eRENDERDOC_Key_F2,
+  eRENDERDOC_Key_F3,
+  eRENDERDOC_Key_F4,
+  eRENDERDOC_Key_F5,
+  eRENDERDOC_Key_F6,
+  eRENDERDOC_Key_F7,
+  eRENDERDOC_Key_F8,
+  eRENDERDOC_Key_F9,
+  eRENDERDOC_Key_F10,
+  eRENDERDOC_Key_F11,
+  eRENDERDOC_Key_F12,
+
+  eRENDERDOC_Key_Home,
+  eRENDERDOC_Key_End,
+  eRENDERDOC_Key_Insert,
+  eRENDERDOC_Key_Delete,
+  eRENDERDOC_Key_PageUp,
+  eRENDERDOC_Key_PageDn,
+
+  eRENDERDOC_Key_Backspace,
+  eRENDERDOC_Key_Tab,
+  eRENDERDOC_Key_PrtScrn,
+  eRENDERDOC_Key_Pause,
+
+  eRENDERDOC_Key_Max,
+} RENDERDOC_InputButton;
+
+// Sets which key or keys can be used to toggle focus between multiple windows
+//
+// If keys is NULL or num is 0, toggle keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetFocusToggleKeys)(RENDERDOC_InputButton *keys, int num);
+
+// Sets which key or keys can be used to capture the next frame
+//
+// If keys is NULL or num is 0, captures keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureKeys)(RENDERDOC_InputButton *keys, int num);
+
+typedef enum RENDERDOC_OverlayBits
+{
+  // This single bit controls whether the overlay is enabled or disabled globally
+  eRENDERDOC_Overlay_Enabled = 0x1,
+
+  // Show the average framerate over several seconds as well as min/max
+  eRENDERDOC_Overlay_FrameRate = 0x2,
+
+  // Show the current frame number
+  eRENDERDOC_Overlay_FrameNumber = 0x4,
+
+  // Show a list of recent captures, and how many captures have been made
+  eRENDERDOC_Overlay_CaptureList = 0x8,
+
+  // Default values for the overlay mask
+  eRENDERDOC_Overlay_Default = (eRENDERDOC_Overlay_Enabled | eRENDERDOC_Overlay_FrameRate |
+                                eRENDERDOC_Overlay_FrameNumber | eRENDERDOC_Overlay_CaptureList),
+
+  // Enable all bits
+  eRENDERDOC_Overlay_All = 0x7ffffff,
+
+  // Disable all bits
+  eRENDERDOC_Overlay_None = 0,
+} RENDERDOC_OverlayBits;
+
+// returns the overlay bits that have been set
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetOverlayBits)(void);
+// sets the overlay bits with an and & or mask
+typedef void(RENDERDOC_CC *pRENDERDOC_MaskOverlayBits)(uint32_t And, uint32_t Or);
+
+// this function will attempt to remove RenderDoc's hooks in the application.
+//
+// Note: that this can only work correctly if done immediately after
+// the module is loaded, before any API work happens. RenderDoc will remove its
+// injected hooks and shut down. Behaviour is undefined if this is called
+// after any API functions have been called, and there is still no guarantee of
+// success.
+typedef void(RENDERDOC_CC *pRENDERDOC_RemoveHooks)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.4.1 headers.
+typedef pRENDERDOC_RemoveHooks pRENDERDOC_Shutdown;
+
+// This function will unload RenderDoc's crash handler.
+//
+// If you use your own crash handler and don't want RenderDoc's handler to
+// intercede, you can call this function to unload it and any unhandled
+// exceptions will pass to the next handler.
+typedef void(RENDERDOC_CC *pRENDERDOC_UnloadCrashHandler)(void);
+
+// Sets the capture file path template
+//
+// pathtemplate is a UTF-8 string that gives a template for how captures will be named
+// and where they will be saved.
+//
+// Any extension is stripped off the path, and captures are saved in the directory
+// specified, and named with the filename and the frame number appended. If the
+// directory does not exist it will be created, including any parent directories.
+//
+// If pathtemplate is NULL, the template will remain unchanged
+//
+// Example:
+//
+// SetCaptureFilePathTemplate("my_captures/example");
+//
+// Capture #1 -> my_captures/example_frame123.rdc
+// Capture #2 -> my_captures/example_frame456.rdc
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureFilePathTemplate)(const char *pathtemplate);
+
+// returns the current capture path template, see SetCaptureFileTemplate above, as a UTF-8 string
+typedef const char *(RENDERDOC_CC *pRENDERDOC_GetCaptureFilePathTemplate)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.1.2 headers.
+typedef pRENDERDOC_SetCaptureFilePathTemplate pRENDERDOC_SetLogFilePathTemplate;
+typedef pRENDERDOC_GetCaptureFilePathTemplate pRENDERDOC_GetLogFilePathTemplate;
+
+// returns the number of captures that have been made
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetNumCaptures)(void);
+
+// This function returns the details of a capture, by index. New captures are added
+// to the end of the list.
+//
+// filename will be filled with the absolute path to the capture file, as a UTF-8 string
+// pathlength will be written with the length in bytes of the filename string
+// timestamp will be written with the time of the capture, in seconds since the Unix epoch
+//
+// Any of the parameters can be NULL and they'll be skipped.
+//
+// The function will return 1 if the capture index is valid, or 0 if the index is invalid
+// If the index is invalid, the values will be unchanged
+//
+// Note: when captures are deleted in the UI they will remain in this list, so the
+// capture path may not exist anymore.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCapture)(uint32_t idx, char *filename,
+                                                      uint32_t *pathlength, uint64_t *timestamp);
+
+// Sets the comments associated with a capture file. These comments are displayed in the
+// UI program when opening.
+//
+// filePath should be a path to the capture file to add comments to. If set to NULL or ""
+// the most recent capture file created made will be used instead.
+// comments should be a NULL-terminated UTF-8 string to add as comments.
+//
+// Any existing comments will be overwritten.
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureFileComments)(const char *filePath,
+                                                              const char *comments);
+
+// returns 1 if the RenderDoc UI is connected to this application, 0 otherwise
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsTargetControlConnected)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.1.1 headers.
+// This was renamed to IsTargetControlConnected in API 1.1.1, the old typedef is kept here for
+// backwards compatibility with old code, it is castable either way since it's ABI compatible
+// as the same function pointer type.
+typedef pRENDERDOC_IsTargetControlConnected pRENDERDOC_IsRemoteAccessConnected;
+
+// This function will launch the Replay UI associated with the RenderDoc library injected
+// into the running application.
+//
+// if connectTargetControl is 1, the Replay UI will be launched with a command line parameter
+// to connect to this application
+// cmdline is the rest of the command line, as a UTF-8 string. E.g. a captures to open
+// if cmdline is NULL, the command line will be empty.
+//
+// returns the PID of the replay UI if successful, 0 if not successful.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_LaunchReplayUI)(uint32_t connectTargetControl,
+                                                          const char *cmdline);
+
+// RenderDoc can return a higher version than requested if it's backwards compatible,
+// this function returns the actual version returned. If a parameter is NULL, it will be
+// ignored and the others will be filled out.
+typedef void(RENDERDOC_CC *pRENDERDOC_GetAPIVersion)(int *major, int *minor, int *patch);
+
+// Requests that the replay UI show itself (if hidden or not the current top window). This can be
+// used in conjunction with IsTargetControlConnected and LaunchReplayUI to intelligently handle
+// showing the UI after making a capture.
+//
+// This will return 1 if the request was successfully passed on, though it's not guaranteed that
+// the UI will be on top in all cases depending on OS rules. It will return 0 if there is no current
+// target control connection to make such a request, or if there was another error
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_ShowReplayUI)(void);
+
+//////////////////////////////////////////////////////////////////////////
+// Capturing functions
+//
+
+// A device pointer is a pointer to the API's root handle.
+//
+// This would be an ID3D11Device, HGLRC/GLXContext, ID3D12Device, etc
+typedef void *RENDERDOC_DevicePointer;
+
+// A window handle is the OS's native window handle
+//
+// This would be an HWND, GLXDrawable, etc
+typedef void *RENDERDOC_WindowHandle;
+
+// A helper macro for Vulkan, where the device handle cannot be used directly.
+//
+// Passing the VkInstance to this macro will return the RENDERDOC_DevicePointer to use.
+//
+// Specifically, the value needed is the dispatch table pointer, which sits as the first
+// pointer-sized object in the memory pointed to by the VkInstance. Thus we cast to a void** and
+// indirect once.
+#define RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE(inst) (*((void **)(inst)))
+
+// This sets the RenderDoc in-app overlay in the API/window pair as 'active' and it will
+// respond to keypresses. Neither parameter can be NULL
+typedef void(RENDERDOC_CC *pRENDERDOC_SetActiveWindow)(RENDERDOC_DevicePointer device,
+                                                       RENDERDOC_WindowHandle wndHandle);
+
+// capture the next frame on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerCapture)(void);
+
+// capture the next N frames on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerMultiFrameCapture)(uint32_t numFrames);
+
+// When choosing either a device pointer or a window handle to capture, you can pass NULL.
+// Passing NULL specifies a 'wildcard' match against anything. This allows you to specify
+// any API rendering to a specific window, or a specific API instance rendering to any window,
+// or in the simplest case of one window and one API, you can just pass NULL for both.
+//
+// In either case, if there are two or more possible matching (device,window) pairs it
+// is undefined which one will be captured.
+//
+// Note: for headless rendering you can pass NULL for the window handle and either specify
+// a device pointer or leave it NULL as above.
+
+// Immediately starts capturing API calls on the specified device pointer and window handle.
+//
+// If there is no matching thing to capture (e.g. no supported API has been initialised),
+// this will do nothing.
+//
+// The results are undefined (including crashes) if two captures are started overlapping,
+// even on separate devices and/oror windows.
+typedef void(RENDERDOC_CC *pRENDERDOC_StartFrameCapture)(RENDERDOC_DevicePointer device,
+                                                         RENDERDOC_WindowHandle wndHandle);
+
+// Returns whether or not a frame capture is currently ongoing anywhere.
+//
+// This will return 1 if a capture is ongoing, and 0 if there is no capture running
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsFrameCapturing)(void);
+
+// Ends capturing immediately.
+//
+// This will return 1 if the capture succeeded, and 0 if there was an error capturing.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_EndFrameCapture)(RENDERDOC_DevicePointer device,
+                                                           RENDERDOC_WindowHandle wndHandle);
+
+// Ends capturing immediately and discard any data stored without saving to disk.
+//
+// This will return 1 if the capture was discarded, and 0 if there was an error or no capture
+// was in progress
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_DiscardFrameCapture)(RENDERDOC_DevicePointer device,
+                                                               RENDERDOC_WindowHandle wndHandle);
+
+// Only valid to be called between a call to StartFrameCapture and EndFrameCapture. Gives a custom
+// title to the capture produced which will be displayed in the UI.
+//
+// If multiple captures are ongoing, this title will be applied to the first capture to end after
+// this call. The second capture to end will have no title, unless this function is called again.
+//
+// Calling this function has no effect if no capture is currently running, and if it is called
+// multiple times only the last title will be used.
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureTitle)(const char *title);
+
+// Annotations API:
+//
+// These functions allow you to specify annotations either on a per-command level, or a per-object
+// level.
+//
+// Basic types of annotations are supported, as well as vector versions and references to API objects.
+//
+// The annotations are stored as keys, with the key being a dot-separated path allowing arbitrary
+// nesting and user organisation. The keys are sorted in human order so `foo.2.bar` will be displayed
+// before `foo.10.bar` to allow creation of arrays if desired.
+//
+// Deleting an annotation can be done by assigning an empty value to it.
+
+// the type of an annotation value, or Empty to delete an annotation
+typedef enum RENDERDOC_AnnotationType
+{
+  eRENDERDOC_Empty,
+  eRENDERDOC_Bool,
+  eRENDERDOC_Int32,
+  eRENDERDOC_UInt32,
+  eRENDERDOC_Int64,
+  eRENDERDOC_UInt64,
+  eRENDERDOC_Float,
+  eRENDERDOC_Double,
+  eRENDERDOC_String,
+  eRENDERDOC_APIObject,
+  eRENDERDOC_AnnotationMax = 0x7FFFFFFF,
+} RENDERDOC_AnnotationType;
+
+// a union with vector annotation value data
+typedef union RENDERDOC_AnnotationVectorValue
+{
+  bool boolean[4];
+  int32_t int32[4];
+  int64_t int64[4];
+  uint32_t uint32[4];
+  uint64_t uint64[4];
+  float float32[4];
+  double float64[4];
+} RENDERDOC_AnnotationVectorValue;
+
+// a union with scalar annotation value data
+typedef union RENDERDOC_AnnotationValue
+{
+  bool boolean;
+  int32_t int32;
+  int64_t int64;
+  uint32_t uint32;
+  uint64_t uint64;
+  float float32;
+  double float64;
+
+  RENDERDOC_AnnotationVectorValue vector;
+
+  const char *string;
+  void *apiObject;
+} RENDERDOC_AnnotationValue;
+
+// a struct for specifying a GL object, as we don't have pointers we can use so instead we specify a
+// pointer to this struct giving both the type and the name
+typedef struct RENDERDOC_GLResourceReference
+{
+  // this is the same GLenum identifier as passed to glObjectLabel
+  uint32_t identifier;
+  uint32_t name;
+} GLResourceReference;
+
+// simple C++ helpers to avoid the need for a temporary objects for value passing and GL object specification
+#ifdef __cplusplus
+struct RDGLObjectHelper
+{
+  RENDERDOC_GLResourceReference gl;
+
+  RDGLObjectHelper(uint32_t identifier, uint32_t name)
+  {
+    gl.identifier = identifier;
+    gl.name = name;
+  }
+
+  operator RENDERDOC_GLResourceReference *() { return &gl; }
+};
+
+struct RDAnnotationHelper
+{
+  RENDERDOC_AnnotationValue val;
+
+  RDAnnotationHelper(bool b) { val.boolean = b; }
+  RDAnnotationHelper(int32_t i) { val.int32 = i; }
+  RDAnnotationHelper(int64_t i) { val.int64 = i; }
+  RDAnnotationHelper(uint32_t i) { val.uint32 = i; }
+  RDAnnotationHelper(uint64_t i) { val.uint64 = i; }
+  RDAnnotationHelper(float f) { val.float32 = f; }
+  RDAnnotationHelper(double d) { val.float64 = d; }
+  RDAnnotationHelper(const char *s) { val.string = s; }
+
+  operator RENDERDOC_AnnotationValue *() { return &val; }
+};
+#endif
+
+// The device is specified in the same way as other API calls that take a RENDERDOC_DevicePointer
+// to specify the device.
+//
+// The object or queue/commandbuffer will depend on the graphics API in question.
+//
+// Return value:
+// 0 - The annotation was applied successfully.
+// 1 - The device is unknown/invalid
+// 2 - The device is valid but the annotation is not supported for API-specific reasons, such as an
+//     unrecognised or invalid object or queue/commandbuffer
+// 3 - The call is ill-formed or invalid e.g. empty is specified with a value pointer, or non-empty
+//     is specified with a NULL value pointer
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_SetObjectAnnotation)(RENDERDOC_DevicePointer device,
+                                                               void *object, const char *key,
+                                                               RENDERDOC_AnnotationType valueType,
+                                                               uint32_t valueVectorWidth,
+                                                               const RENDERDOC_AnnotationValue *value);
+
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_SetCommandAnnotation)(
+    RENDERDOC_DevicePointer device, void *queueOrCommandBuffer, const char *key,
+    RENDERDOC_AnnotationType valueType, uint32_t valueVectorWidth,
+    const RENDERDOC_AnnotationValue *value);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API versions
+//
+
+// RenderDoc uses semantic versioning (http://semver.org/).
+//
+// MAJOR version is incremented when incompatible API changes happen.
+// MINOR version is incremented when functionality is added in a backwards-compatible manner.
+// PATCH version is incremented when backwards-compatible bug fixes happen.
+//
+// Note that this means the API returned can be higher than the one you might have requested.
+// e.g. if you are running against a newer RenderDoc that supports 1.0.1, it will be returned
+// instead of 1.0.0. You can check this with the GetAPIVersion entry point
+typedef enum RENDERDOC_Version
+{
+  eRENDERDOC_API_Version_1_0_0 = 10000,    // RENDERDOC_API_1_0_0 = 1 00 00
+  eRENDERDOC_API_Version_1_0_1 = 10001,    // RENDERDOC_API_1_0_1 = 1 00 01
+  eRENDERDOC_API_Version_1_0_2 = 10002,    // RENDERDOC_API_1_0_2 = 1 00 02
+  eRENDERDOC_API_Version_1_1_0 = 10100,    // RENDERDOC_API_1_1_0 = 1 01 00
+  eRENDERDOC_API_Version_1_1_1 = 10101,    // RENDERDOC_API_1_1_1 = 1 01 01
+  eRENDERDOC_API_Version_1_1_2 = 10102,    // RENDERDOC_API_1_1_2 = 1 01 02
+  eRENDERDOC_API_Version_1_2_0 = 10200,    // RENDERDOC_API_1_2_0 = 1 02 00
+  eRENDERDOC_API_Version_1_3_0 = 10300,    // RENDERDOC_API_1_3_0 = 1 03 00
+  eRENDERDOC_API_Version_1_4_0 = 10400,    // RENDERDOC_API_1_4_0 = 1 04 00
+  eRENDERDOC_API_Version_1_4_1 = 10401,    // RENDERDOC_API_1_4_1 = 1 04 01
+  eRENDERDOC_API_Version_1_4_2 = 10402,    // RENDERDOC_API_1_4_2 = 1 04 02
+  eRENDERDOC_API_Version_1_5_0 = 10500,    // RENDERDOC_API_1_5_0 = 1 05 00
+  eRENDERDOC_API_Version_1_6_0 = 10600,    // RENDERDOC_API_1_6_0 = 1 06 00
+  eRENDERDOC_API_Version_1_7_0 = 10700,    // RENDERDOC_API_1_7_0 = 1 07 00
+} RENDERDOC_Version;
+
+// API version changelog:
+//
+// 1.0.0 - initial release
+// 1.0.1 - Bugfix: IsFrameCapturing() was returning false for captures that were triggered
+//         by keypress or TriggerCapture, instead of Start/EndFrameCapture.
+// 1.0.2 - Refactor: Renamed eRENDERDOC_Option_DebugDeviceMode to eRENDERDOC_Option_APIValidation
+// 1.1.0 - Add feature: TriggerMultiFrameCapture(). Backwards compatible with 1.0.x since the new
+//         function pointer is added to the end of the struct, the original layout is identical
+// 1.1.1 - Refactor: Renamed remote access to target control (to better disambiguate from remote
+//         replay/remote server concept in replay UI)
+// 1.1.2 - Refactor: Renamed "log file" in function names to just capture, to clarify that these
+//         are captures and not debug logging files. This is the first API version in the v1.0
+//         branch.
+// 1.2.0 - Added feature: SetCaptureFileComments() to add comments to a capture file that will be
+//         displayed in the UI program on load.
+// 1.3.0 - Added feature: New capture option eRENDERDOC_Option_AllowUnsupportedVendorExtensions
+//         which allows users to opt-in to allowing unsupported vendor extensions to function.
+//         Should be used at the user's own risk.
+//         Refactor: Renamed eRENDERDOC_Option_VerifyMapWrites to
+//         eRENDERDOC_Option_VerifyBufferAccess, which now also controls initialisation to
+//         0xdddddddd of uninitialised buffer contents.
+// 1.4.0 - Added feature: DiscardFrameCapture() to discard a frame capture in progress and stop
+//         capturing without saving anything to disk.
+// 1.4.1 - Refactor: Renamed Shutdown to RemoveHooks to better clarify what is happening
+// 1.4.2 - Refactor: Renamed 'draws' to 'actions' in callstack capture option.
+// 1.5.0 - Added feature: ShowReplayUI() to request that the replay UI show itself if connected
+// 1.6.0 - Added feature: SetCaptureTitle() which can be used to set a title for a
+//         capture made with StartFrameCapture() or EndFrameCapture()
+// 1.7.0 - Added feature: SetObjectAnnotation() / SetCommandAnnotation() for adding rich
+//         annotations to objects and command streams
+
+typedef struct RENDERDOC_API_1_7_0
+{
+  pRENDERDOC_GetAPIVersion GetAPIVersion;
+
+  pRENDERDOC_SetCaptureOptionU32 SetCaptureOptionU32;
+  pRENDERDOC_SetCaptureOptionF32 SetCaptureOptionF32;
+
+  pRENDERDOC_GetCaptureOptionU32 GetCaptureOptionU32;
+  pRENDERDOC_GetCaptureOptionF32 GetCaptureOptionF32;
+
+  pRENDERDOC_SetFocusToggleKeys SetFocusToggleKeys;
+  pRENDERDOC_SetCaptureKeys SetCaptureKeys;
+
+  pRENDERDOC_GetOverlayBits GetOverlayBits;
+  pRENDERDOC_MaskOverlayBits MaskOverlayBits;
+
+  // Shutdown was renamed to RemoveHooks in 1.4.1.
+  // These unions allow old code to continue compiling without changes
+  union
+  {
+    pRENDERDOC_Shutdown Shutdown;
+    pRENDERDOC_RemoveHooks RemoveHooks;
+  };
+  pRENDERDOC_UnloadCrashHandler UnloadCrashHandler;
+
+  // Get/SetLogFilePathTemplate was renamed to Get/SetCaptureFilePathTemplate in 1.1.2.
+  // These unions allow old code to continue compiling without changes
+  union
+  {
+    // deprecated name
+    pRENDERDOC_SetLogFilePathTemplate SetLogFilePathTemplate;
+    // current name
+    pRENDERDOC_SetCaptureFilePathTemplate SetCaptureFilePathTemplate;
+  };
+  union
+  {
+    // deprecated name
+    pRENDERDOC_GetLogFilePathTemplate GetLogFilePathTemplate;
+    // current name
+    pRENDERDOC_GetCaptureFilePathTemplate GetCaptureFilePathTemplate;
+  };
+
+  pRENDERDOC_GetNumCaptures GetNumCaptures;
+  pRENDERDOC_GetCapture GetCapture;
+
+  pRENDERDOC_TriggerCapture TriggerCapture;
+
+  // IsRemoteAccessConnected was renamed to IsTargetControlConnected in 1.1.1.
+  // This union allows old code to continue compiling without changes
+  union
+  {
+    // deprecated name
+    pRENDERDOC_IsRemoteAccessConnected IsRemoteAccessConnected;
+    // current name
+    pRENDERDOC_IsTargetControlConnected IsTargetControlConnected;
+  };
+  pRENDERDOC_LaunchReplayUI LaunchReplayUI;
+
+  pRENDERDOC_SetActiveWindow SetActiveWindow;
+
+  pRENDERDOC_StartFrameCapture StartFrameCapture;
+  pRENDERDOC_IsFrameCapturing IsFrameCapturing;
+  pRENDERDOC_EndFrameCapture EndFrameCapture;
+
+  // new function in 1.1.0
+  pRENDERDOC_TriggerMultiFrameCapture TriggerMultiFrameCapture;
+
+  // new function in 1.2.0
+  pRENDERDOC_SetCaptureFileComments SetCaptureFileComments;
+
+  // new function in 1.4.0
+  pRENDERDOC_DiscardFrameCapture DiscardFrameCapture;
+
+  // new function in 1.5.0
+  pRENDERDOC_ShowReplayUI ShowReplayUI;
+
+  // new function in 1.6.0
+  pRENDERDOC_SetCaptureTitle SetCaptureTitle;
+
+  // new functions in 1.7.0
+  pRENDERDOC_SetObjectAnnotation SetObjectAnnotation;
+  pRENDERDOC_SetCommandAnnotation SetCommandAnnotation;
+} RENDERDOC_API_1_7_0;
+
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_2_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_3_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_5_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_6_0;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API entry point
+//
+// This entry point can be obtained via GetProcAddress/dlsym if RenderDoc is available.
+//
+// The name is the same as the typedef - "RENDERDOC_GetAPI"
+//
+// This function is not thread safe, and should not be called on multiple threads at once.
+// Ideally, call this once as early as possible in your application's startup, before doing
+// any API work, since some configuration functionality etc has to be done also before
+// initialising any APIs.
+//
+// Parameters:
+//   version is a single value from the RENDERDOC_Version above.
+//
+//   outAPIPointers will be filled out with a pointer to the corresponding struct of function
+//   pointers.
+//
+// Returns:
+//   1 - if the outAPIPointers has been filled with a pointer to the API struct requested
+//   0 - if the requested version is not supported or the arguments are invalid.
+//
+typedef int(RENDERDOC_CC *pRENDERDOC_GetAPI)(RENDERDOC_Version version, void **outAPIPointers);
+
+#ifdef __cplusplus
+}    // extern "C"
+#endif

--- a/src/xrEngine/renderdoc_integration.cpp
+++ b/src/xrEngine/renderdoc_integration.cpp
@@ -3,6 +3,7 @@
 
 #include "renderdoc_integration.h"
 #include "renderdoc_app.h"
+#include "IGame_Level.h"
 
 namespace
 {
@@ -10,6 +11,7 @@ namespace
 
 	RENDERDOC_API_1_7_0* s_rdc_api = nullptr;
 	RENDERDOC_Version s_rdc_version = eRENDERDOC_API_Version_1_0_0;
+	bool s_rdc_annotations = false;
 	bool s_rdc_initialized = false;
 	u32 s_rdc_seen_captures = 0;
 	string_path s_rdc_capture_template = {};
@@ -55,6 +57,7 @@ namespace
 			{
 				s_rdc_api = static_cast<RENDERDOC_API_1_7_0*>(api);
 				s_rdc_version = version;
+				s_rdc_annotations = version >= eRENDERDOC_API_Version_1_7_0;
 				return true;
 			}
 		}
@@ -137,6 +140,44 @@ namespace
 		s_rdc_api->SetCaptureFilePathTemplate(s_rdc_capture_template);
 	}
 
+	// D3D11 takes a null device here, the annotation rides the immediate command stream
+	void rdc_annotate(const char* key, RENDERDOC_AnnotationType type, u32 width,
+		const RENDERDOC_AnnotationValue* value)
+	{
+		const u32 result = s_rdc_api->SetCommandAnnotation(nullptr, nullptr, key, type, width, value);
+
+		static bool reported = false;
+		if (result && !reported)
+		{
+			reported = true;
+			Msg("! [RDC] SetCommandAnnotation failed %u on %s", result, key);
+		}
+	}
+
+	void rdc_annotate(const char* key, u32 number)
+	{
+		rdc_annotate(key, eRENDERDOC_UInt32, 0, RDAnnotationHelper(number));
+	}
+
+	void rdc_annotate(const char* key, float number)
+	{
+		rdc_annotate(key, eRENDERDOC_Float, 0, RDAnnotationHelper(number));
+	}
+
+	void rdc_annotate(const char* key, const char* text)
+	{
+		rdc_annotate(key, eRENDERDOC_String, 0, RDAnnotationHelper(text));
+	}
+
+	void rdc_annotate(const char* key, const float* floats, u32 width)
+	{
+		RENDERDOC_AnnotationValue value = {};
+		for (u32 index = 0; index < width; ++index)
+			value.vector.float32[index] = floats[index];
+
+		rdc_annotate(key, eRENDERDOC_Float, width, &value);
+	}
+
 	void rdc_log_capture(u32 index)
 	{
 		u32 length = 0;
@@ -183,8 +224,9 @@ void renderdoc_initialize()
 	int minor = 0;
 	int patch = 0;
 	s_rdc_api->GetAPIVersion(&major, &minor, &patch);
-	Msg("* [RDC] capture API %d.%d.%d ready, ui %s", major, minor, patch,
-		rdc_ui_connected() ? "connected" : "not connected");
+	Msg("* [RDC] capture API %d.%d.%d ready, ui %s, annotations %s", major, minor, patch,
+		rdc_ui_connected() ? "connected" : "not connected",
+		s_rdc_annotations ? "available" : "unavailable");
 	Msg("* [RDC] captures land in %s_frameN.rdc", s_rdc_capture_template);
 }
 
@@ -256,6 +298,33 @@ bool renderdoc_overlay_enabled()
 		return false;
 
 	return (s_rdc_api->GetOverlayBits() & eRENDERDOC_Overlay_Enabled) != 0;
+}
+
+void renderdoc_annotate_frame(const Fvector4* shader_params, u32 count)
+{
+	if (!s_rdc_annotations || s_rdc_api->IsFrameCapturing() != 1)
+		return;
+
+	rdc_annotate("xray.frame.number", Device.dwFrame);
+	rdc_annotate("xray.frame.time", Device.fTimeGlobal);
+
+	rdc_annotate("xray.camera.position", &Device.vCameraPosition.x, 3);
+	rdc_annotate("xray.camera.direction", &Device.vCameraDirection.x, 3);
+	rdc_annotate("xray.camera.fov", Device.fFOV);
+	rdc_annotate("xray.camera.aspect", Device.fASPECT);
+
+	rdc_annotate("xray.render.width", Device.dwWidth);
+	rdc_annotate("xray.render.height", Device.dwHeight);
+	rdc_annotate("xray.svp", Device.m_SecondViewport.IsSVPFrame() ? 1u : 0u);
+
+	rdc_annotate("xray.level.name", g_pGameLevel ? g_pGameLevel->name().c_str() : "");
+
+	for (u32 index = 0; index < count && shader_params; ++index)
+	{
+		string64 key = {};
+		xr_sprintf(key, "xray.shader_param.%u", index + 1);
+		rdc_annotate(key, &shader_params[index].x, 4);
+	}
 }
 
 void renderdoc_set_active_window(void* device, void* window)

--- a/src/xrEngine/renderdoc_integration.cpp
+++ b/src/xrEngine/renderdoc_integration.cpp
@@ -1,0 +1,268 @@
+#include "stdafx.h"
+#pragma hdrstop
+
+#include "renderdoc_integration.h"
+#include "renderdoc_app.h"
+
+namespace
+{
+	const char* const rdc_capture_folder = "renderdoc\\captures\\";
+
+	RENDERDOC_API_1_7_0* s_rdc_api = nullptr;
+	RENDERDOC_Version s_rdc_version = eRENDERDOC_API_Version_1_0_0;
+	bool s_rdc_initialized = false;
+	u32 s_rdc_seen_captures = 0;
+	string_path s_rdc_capture_template = {};
+	xr_string s_rdc_latest_capture;
+
+	HMODULE rdc_acquire_module()
+	{
+		HMODULE module = GetModuleHandleW(L"renderdoc.dll");
+		if (module || !Core.ParamsData.test(ECoreParams::renderdoc))
+			return module;
+
+		wchar_t path[MAX_PATH * 4] = {};
+		const DWORD length = GetModuleFileNameW(nullptr, path, DWORD(std::size(path)));
+		wchar_t* const leaf = (length && length < std::size(path)) ? wcsrchr(path, L'\\') : nullptr;
+		if (!leaf || wcscpy_s(leaf + 1, std::size(path) - size_t(leaf + 1 - path), L"renderdoc.dll"))
+		{
+			Msg("! [RDC] executable path unavailable, capture disabled");
+			return nullptr;
+		}
+
+		module = LoadLibraryExW(path, nullptr,
+			LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		if (!module)
+			Msg("~ [RDC] renderdoc.dll not loaded from the game bin folder (%lu), capture disabled",
+				GetLastError());
+		return module;
+	}
+
+	// GetAPI answers 1 only for a version it implements, so walk down until one is accepted
+	bool rdc_negotiate_api(pRENDERDOC_GetAPI get_api)
+	{
+		static const RENDERDOC_Version versions[] = {
+			eRENDERDOC_API_Version_1_7_0,
+			eRENDERDOC_API_Version_1_6_0,
+			eRENDERDOC_API_Version_1_5_0,
+			eRENDERDOC_API_Version_1_4_0,
+			eRENDERDOC_API_Version_1_1_0};
+
+		for (const RENDERDOC_Version version : versions)
+		{
+			void* api = nullptr;
+			if (get_api(version, &api) == 1 && api)
+			{
+				s_rdc_api = static_cast<RENDERDOC_API_1_7_0*>(api);
+				s_rdc_version = version;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool rdc_available()
+	{
+		if (s_rdc_api)
+			return true;
+
+		Msg("~ [RDC] renderdoc.dll is not loaded, inject with RenderDoc or launch with -renderdoc");
+		return false;
+	}
+
+	bool rdc_ui_connected()
+	{
+		return s_rdc_api && s_rdc_api->IsTargetControlConnected() == 1;
+	}
+
+	void rdc_apply_capture_options()
+	{
+		struct option_key
+		{
+			ECoreParams param;
+			RENDERDOC_CaptureOption option;
+			const char* name;
+		};
+		static const option_key keys[] = {
+			{ECoreParams::rdoc_refall, eRENDERDOC_Option_RefAllResources, "reference all resources"},
+			{ECoreParams::rdoc_cmdlists, eRENDERDOC_Option_CaptureAllCmdLists, "capture all command lists"}};
+
+		for (const option_key& key : keys)
+		{
+			if (!Core.ParamsData.test(key.param))
+				continue;
+
+			s_rdc_api->SetCaptureOptionU32(key.option, 1);
+			Msg("* [RDC] option %s now %u", key.name, s_rdc_api->GetCaptureOptionU32(key.option));
+		}
+	}
+
+	bool rdc_ensure_directory(const char* path)
+	{
+		VerifyPath(path);
+
+		const DWORD attributes = GetFileAttributesA(path);
+		return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+	}
+
+	// RenderDoc appends _frameN.rdc to the template and takes a re-apply at any time
+	void rdc_prepare_capture_path()
+	{
+		string_path executable = {};
+		if (!GetModuleFileNameA(nullptr, executable, sizeof(executable)))
+			return;
+
+		char* const leaf = strrchr(executable, '\\');
+		if (!leaf)
+			return;
+		*leaf = 0;
+
+		char* const extension = strrchr(leaf + 1, '.');
+		if (extension)
+			*extension = 0;
+
+		string_path directory = {};
+		const bool data_root = FS.path_exist("$app_data_root$");
+		if (data_root)
+			FS.update_path(directory, "$app_data_root$", rdc_capture_folder);
+
+		if (!data_root || !rdc_ensure_directory(directory))
+		{
+			xr_sprintf(directory, "%s\\%s", executable, rdc_capture_folder);
+			rdc_ensure_directory(directory);
+			Msg("~ [RDC] engine data root unusable, captures land in %s", directory);
+		}
+
+		xr_sprintf(s_rdc_capture_template, "%s%s", directory, leaf + 1);
+		s_rdc_api->SetCaptureFilePathTemplate(s_rdc_capture_template);
+	}
+
+	void rdc_log_capture(u32 index)
+	{
+		u32 length = 0;
+		u64 timestamp = 0;
+		if (!s_rdc_api->GetCapture(index, nullptr, &length, &timestamp) || !length)
+			return;
+
+		xr_vector<char> path(size_t(length) + 1, 0);
+		if (!s_rdc_api->GetCapture(index, path.data(), &length, &timestamp))
+			return;
+
+		// GetCapture hands back the absolute path already
+		s_rdc_latest_capture = path.data();
+		Msg("* [RDC] capture written %s  timestamp %llu", path.data(), timestamp);
+	}
+}
+
+void renderdoc_initialize()
+{
+	if (s_rdc_initialized)
+		return;
+	s_rdc_initialized = true;
+
+	const HMODULE module = rdc_acquire_module();
+	if (!module)
+		return;
+
+	const pRENDERDOC_GetAPI get_api =
+		reinterpret_cast<pRENDERDOC_GetAPI>(GetProcAddress(module, "RENDERDOC_GetAPI"));
+	if (!get_api || !rdc_negotiate_api(get_api))
+	{
+		Msg("! [RDC] API negotiation failed, capture disabled");
+		return;
+	}
+
+	// The engine keeps its own crash handler and minidump pipeline
+	s_rdc_api->UnloadCrashHandler();
+
+	rdc_apply_capture_options();
+	rdc_prepare_capture_path();
+	s_rdc_seen_captures = s_rdc_api->GetNumCaptures();
+
+	int major = 0;
+	int minor = 0;
+	int patch = 0;
+	s_rdc_api->GetAPIVersion(&major, &minor, &patch);
+	Msg("* [RDC] capture API %d.%d.%d ready, ui %s", major, minor, patch,
+		rdc_ui_connected() ? "connected" : "not connected");
+	Msg("* [RDC] captures land in %s_frameN.rdc", s_rdc_capture_template);
+}
+
+bool renderdoc_api_live()
+{
+	return s_rdc_api != nullptr;
+}
+
+void renderdoc_trigger_capture(u32 frames)
+{
+	if (!rdc_available())
+		return;
+
+	if (frames > 1)
+		s_rdc_api->TriggerMultiFrameCapture(frames);
+	else
+		s_rdc_api->TriggerCapture();
+
+	Msg("* [RDC] queued %u frame(s), each one writes its own rdc file, ui %s", frames,
+		rdc_ui_connected() ? "connected" : "not connected");
+}
+
+void renderdoc_poll_captures()
+{
+	if (!s_rdc_api)
+		return;
+
+	const u32 count = s_rdc_api->GetNumCaptures();
+	for (; s_rdc_seen_captures < count; ++s_rdc_seen_captures)
+		rdc_log_capture(s_rdc_seen_captures);
+}
+
+void renderdoc_open_replay_ui()
+{
+	if (!rdc_available())
+		return;
+
+	if (rdc_ui_connected() && s_rdc_version >= eRENDERDOC_API_Version_1_5_0)
+	{
+		const u32 shown = s_rdc_api->ShowReplayUI();
+		Msg("%s [RDC] connected ui raise %s", shown ? "*" : "~", shown ? "accepted" : "refused");
+		return;
+	}
+
+	// The path rides a command line so quotes keep a spaced folder in one argument
+	const xr_string quoted = s_rdc_latest_capture.empty()
+		? xr_string()
+		: xr_string("\"" + s_rdc_latest_capture + "\"");
+	const char* const capture = quoted.empty() ? nullptr : quoted.c_str();
+	const u32 pid = s_rdc_api->LaunchReplayUI(1, capture);
+	if (pid)
+		Msg("* [RDC] replay ui launched pid %u %s", pid, capture ? capture : "with no capture");
+	else
+		Msg("! [RDC] replay ui launch failed");
+}
+
+void renderdoc_set_overlay(bool visible)
+{
+	if (!rdc_available())
+		return;
+
+	s_rdc_api->MaskOverlayBits(0, visible ? (eRENDERDOC_Overlay_Default | eRENDERDOC_Overlay_Enabled) : 0);
+	Msg("* [RDC] overlay bits 0x%08x", s_rdc_api->GetOverlayBits());
+}
+
+bool renderdoc_overlay_enabled()
+{
+	if (!rdc_available())
+		return false;
+
+	return (s_rdc_api->GetOverlayBits() & eRENDERDOC_Overlay_Enabled) != 0;
+}
+
+void renderdoc_set_active_window(void* device, void* window)
+{
+	// SetActiveWindow rejects a null handle, unlike the rest of the API
+	if (!s_rdc_api || !device || !window)
+		return;
+
+	s_rdc_api->SetActiveWindow(device, window);
+}

--- a/src/xrEngine/renderdoc_integration.h
+++ b/src/xrEngine/renderdoc_integration.h
@@ -8,3 +8,5 @@ ENGINE_API void renderdoc_open_replay_ui();
 ENGINE_API void renderdoc_set_overlay(bool visible);
 ENGINE_API bool renderdoc_overlay_enabled();
 ENGINE_API void renderdoc_set_active_window(void* device, void* window);
+
+ENGINE_API void renderdoc_annotate_frame(const Fvector4* shader_params, u32 count);

--- a/src/xrEngine/renderdoc_integration.h
+++ b/src/xrEngine/renderdoc_integration.h
@@ -1,0 +1,10 @@
+#pragma once
+
+ENGINE_API void renderdoc_initialize();
+ENGINE_API bool renderdoc_api_live();
+ENGINE_API void renderdoc_poll_captures();
+ENGINE_API void renderdoc_trigger_capture(u32 frames);
+ENGINE_API void renderdoc_open_replay_ui();
+ENGINE_API void renderdoc_set_overlay(bool visible);
+ENGINE_API bool renderdoc_overlay_enabled();
+ENGINE_API void renderdoc_set_active_window(void* device, void* window);

--- a/src/xrEngine/x_ray.cpp
+++ b/src/xrEngine/x_ray.cpp
@@ -32,6 +32,7 @@
 
 #include "xrSash.h"
 #include "MonitorList.h"
+#include "renderdoc_integration.h"
 
 extern "C" void XR_EARLY_INIT();
 
@@ -1096,6 +1097,7 @@ int APIENTRY WinMain_impl(HINSTANCE hInstance,
 
 	compute_build_id();
 	Core._initialize("xray", NULL, TRUE, fsgame[0] ? fsgame : NULL);
+	renderdoc_initialize();
 
 	InitSettings();
 	Msg(XRAY_MONOLITH_VERSION);

--- a/src/xrEngine/xrEngine.vcxproj
+++ b/src/xrEngine/xrEngine.vcxproj
@@ -977,6 +977,8 @@
     <ClInclude Include="pure.h" />
     <ClInclude Include="pure_relcase.h" />
     <ClInclude Include="Rain.h" />
+    <ClInclude Include="renderdoc_app.h" />
+    <ClInclude Include="renderdoc_integration.h" />
     <ClInclude Include="Render.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="ShadersExternalData.h" />
@@ -1089,6 +1091,7 @@
     <ClCompile Include="pure.cpp" />
     <ClCompile Include="pure_relcase.cpp" />
     <ClCompile Include="Rain.cpp" />
+    <ClCompile Include="renderdoc_integration.cpp" />
     <ClCompile Include="Render.cpp" />
     <ClCompile Include="SkeletonMotions.cpp" />
     <ClCompile Include="StatGraph.cpp" />

--- a/src/xrEngine/xrEngine.vcxproj.filters
+++ b/src/xrEngine/xrEngine.vcxproj.filters
@@ -258,6 +258,12 @@
     <ClInclude Include="Rain.h">
       <Filter>Game API\Environment\Effects</Filter>
     </ClInclude>
+    <ClInclude Include="renderdoc_app.h">
+      <Filter>General</Filter>
+    </ClInclude>
+    <ClInclude Include="renderdoc_integration.h">
+      <Filter>General</Filter>
+    </ClInclude>
     <ClInclude Include="thunderbolt.h">
       <Filter>Game API\Environment\Effects</Filter>
     </ClInclude>
@@ -572,6 +578,9 @@
     </ClCompile>
     <ClCompile Include="Rain.cpp">
       <Filter>Game API\Environment\Effects</Filter>
+    </ClCompile>
+    <ClCompile Include="renderdoc_integration.cpp">
+      <Filter>General</Filter>
     </ClCompile>
     <ClCompile Include="thunderbolt.cpp">
       <Filter>Game API\Environment\Effects</Filter>

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -15,6 +15,7 @@
 
 #include "xr_object.h"
 #include "MonitorList.h"
+#include "renderdoc_integration.h"
 
 xr_token* vid_quality_token = NULL;
 
@@ -122,6 +123,61 @@ class CCC_DbgStrDump : public IConsole_Command
 public:
 	CCC_DbgStrDump(LPCSTR N) : IConsole_Command(N) { bEmptyArgsHandled = TRUE; };
 	virtual void Execute(LPCSTR args) { g_pStringContainer->dump(); }
+};
+
+class CCC_RenderDoc : public IConsole_Command
+{
+protected:
+	int Value(LPCSTR args, int fallback) { return (args && args[0]) ? atoi(args) : fallback; }
+
+public:
+	CCC_RenderDoc(LPCSTR N) : IConsole_Command(N) { bEmptyArgsHandled = TRUE; };
+};
+
+class CCC_RenderDocCapture : public CCC_RenderDoc
+{
+	enum { frames_max = 60 };
+
+public:
+	CCC_RenderDocCapture(LPCSTR N) : CCC_RenderDoc(N) {};
+
+	virtual void Execute(LPCSTR args)
+	{
+		int frames = Value(args, 1);
+		if (frames < 1 || frames > frames_max) InvalidSyntax();
+		else renderdoc_trigger_capture(u32(frames));
+	}
+
+	virtual void Info(TInfo& I) { xr_sprintf(I, sizeof(I), "frame count in range [1,%d], 1 when omitted", frames_max); }
+};
+
+class CCC_RenderDocOpen : public CCC_RenderDoc
+{
+public:
+	CCC_RenderDocOpen(LPCSTR N) : CCC_RenderDoc(N) {};
+
+	virtual void Execute(LPCSTR args) { renderdoc_open_replay_ui(); }
+};
+
+class CCC_RenderDocOverlay : public CCC_RenderDoc
+{
+public:
+	CCC_RenderDocOverlay(LPCSTR N) : CCC_RenderDoc(N) {};
+
+	virtual void Execute(LPCSTR args)
+	{
+		if (!args || !args[0])
+		{
+			Msg("* [RDC] overlay %s", renderdoc_overlay_enabled() ? "on" : "off");
+			return;
+		}
+
+		int visible = Value(args, 0);
+		if (visible < 0 || visible > 1) InvalidSyntax();
+		else renderdoc_set_overlay(visible != 0);
+	}
+
+	virtual void Info(TInfo& I) { xr_strcpy(I, "0 hides, 1 shows, empty prints the state"); }
 };
 
 //-----------------------------------------------------------------------
@@ -1041,6 +1097,9 @@ void CCC_Register()
 	CMD1(CCC_SaveCFG, "cfg_save");
 	CMD1(CCC_LoadCFG, "cfg_load");
 	CMD1(CCC_DumpCVars, "dump_cvar");
+	CMD1(CCC_RenderDocCapture, "rdoc_capture");
+	CMD1(CCC_RenderDocOpen, "rdoc_open");
+	CMD1(CCC_RenderDocOverlay, "rdoc_overlay");
 
 	CMD3(CCC_Mask, "mt_particles", &psDeviceFlags, mtParticles);
 


### PR DESCRIPTION
## **Why**
Shader and render work on this engine gets debugged by guessing until a capture exists. RenderDoc captures answer those questions directly, but taking one meant launching the game through RenderDoc's UI by first hooking it into MO2 or the global hook (which rarely works) and pressing a hotkey at the right moment (before APi initialization). This makes captures an engine tool: triggered from the console or a script, at the exact frame you want, from a normal launch with an argument (-renderdoc).

## **How**
The engine loads RenderDoc's in-application API when renderdoc.dll is already in the process, or loads it itself from the bin folder when launched with -renderdoc. It negotiates the newest API the host offers (1.7.0 down to 1.1.0) and keeps the engine's own crash handler. Three console commands drive it: 
- rdoc_capture [1..60] queues frames
- rdoc_open raises or launches the replay UI on the last capture
- rdoc_overlay 0/1 toggles the overlay (bare prints the state)
- `-rdoc_refall` and `-rdoc_cmdlists` set the matching capture options

Captures are stored in `appdata\renderdoc\captures\<exe>_frameN.rdc` and are logged when they finish. On 1.7.0 hosts each capture carries frame, time, camera, fov, render size, level, the second-viewport flag (not PiP, the default engine's) and the eight shader_param vectors as annotations. 

R4's PIX markers get colours through the d3d9 PERF entry points RenderDoc hooks, with ID3DUserDefinedAnnotation as the fallback, and render targets get debug names so they appear under their engine names.

## **Benefits over RenderDoc injection**
- Launch the game normally: the UI can attach to the running process afterwards
- Capture from a script or console at a chosen moment: including a run of frames, instead of a hotkey
- Every capture is self-describing: annotated with where and when it was taken
- Passes are coloured and named: render targets are named, so the event browser reads like the engine's own frame
- Crash handling stays the engine's own. RenderDoc's default F12 capture hotkey still overlaps the engine screenshot key here, there will be a follow-up PR later disables the host hotkeys and adds more tools

## **Overhead**
With no RenderDoc present: one flag read per frame in `FrameMove` and one in `CRender::Render`. Marker sites read a per-frame cached listener state instead of the `BeginEvent/EndEvent` pair each site issued before, so the no-debugger path is cheaper than it was. d3d9.dll is loaded only once something is already listening. Render target naming is a one-off `SetPrivateData` at creation. R1, R2 and R3 are untouched apart from two launch-flag enumerators, R3 compiles only the naming helper.