### PR TITLE
Add Lua-accessible zoom inertia factor

### DIFF
--- a/src/xrGame/EffectorZoomInertion.cpp
+++ b/src/xrGame/EffectorZoomInertion.cpp
@@ -74,13 +74,14 @@ void CEffectorZoomInertion::SetParams(float disp)
 {
 	float old_disp = m_fDispRadius;
 
-	m_fDispRadius = disp * m_fZoomAimingDispK;
-	if (m_fDispRadius < m_fDispMin)
-		m_fDispRadius = m_fDispMin;
+    // Boeker: adjust zoom inertia factor
+	m_fDispRadius = disp * m_fZoomAimingDispK * m_fUserFactor;
+	if (m_fDispRadius < m_fDispMin * m_fUserFactor)
+		m_fDispRadius = m_fDispMin * m_fUserFactor;
 
-	m_fFloatSpeed = disp * m_fZoomAimingSpeedK;
-	if (m_fFloatSpeed < m_fSpeedMin)
-		m_fFloatSpeed = m_fSpeedMin;
+	m_fFloatSpeed = disp * m_fZoomAimingSpeedK * m_fUserFactor;
+	if (m_fFloatSpeed < m_fSpeedMin * m_fUserFactor)
+		m_fFloatSpeed = m_fSpeedMin * m_fUserFactor;
 
 	//для того, чтоб сразу прошел пересчет направления
 	//движения прицела

--- a/src/xrGame/EffectorZoomInertion.h
+++ b/src/xrGame/EffectorZoomInertion.h
@@ -26,6 +26,10 @@ class CEffectorZoomInertion : public CEffectorCam
 	float m_fSpeedMin;
 	float m_fZoomAimingDispK;
 	float m_fZoomAimingSpeedK;
+
+    // Boeker: Lua-controlled zoom inertia factor
+    float m_fUserFactor = 1.0f;
+
 	//время через которое эффектор меняет направление движения
 	u32 m_dwDeltaTime;
 
@@ -39,6 +43,9 @@ public:
 
 	void Load();
 	void SetParams(float disp);
+
+    void SetUserFactor(float factor) { m_fUserFactor = factor; }
+    float GetUserFactor() const { return m_fUserFactor; }
 
 	virtual BOOL ProcessCam(SCamEffectorInfo& info);
 	virtual void SetRndSeed(s32 Seed) { m_Random.seed(Seed); };

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -1201,6 +1201,9 @@ public:
     float GetActorDamageStaggerTimeFactor() const;
     void SetActorDamageStaggerTimeFactor(float val);
 
+    // Boeker: adjust zoom inertia factor
+    void SetZoomInertionFactor(float factor);
+
 	float GetActorCrouchCoef() const;
 	void SetActorCrouchCoef(float val);
 	float GetActorClimbCoef() const;

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -60,6 +60,10 @@
 #include "ai_space.h"
 #include "ActorBackpack.h"
 
+// Boeker: zoom inertia factor support
+#include "EffectorZoomInertion.h"
+#include "ActorEffector.h"
+
 //
 //-Alundaio
 
@@ -2865,6 +2869,22 @@ void CScriptGameObject::SetActorDamageStaggerTimeFactor(float val)
         return;
     }
     pActor->DamageStaggerTimeFactor = val;
+}
+
+// Boeker: zoom inertia factor support
+void CScriptGameObject::SetZoomInertionFactor(float factor)
+{
+    CActor* pActor = smart_cast<CActor*>(&object());
+    if (!pActor)
+        return;
+
+    CEffectorZoomInertion* eff = smart_cast<CEffectorZoomInertion*>(
+        pActor->Cameras().GetCamEffector(eCEZoom)
+    );
+    if (!eff)
+        return;
+
+    eff->SetUserFactor(clampr(factor, 0.f, 2.f));
 }
 
 // demonized: Additional exports

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -675,6 +675,9 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("get_actor_lookout_coef", SAFE_WRAP(&CScriptGameObject::GetActorLookoutCoef))
 		.def("set_actor_lookout_coef", SAFE_WRAP(&CScriptGameObject::SetActorLookoutCoef))
 
+        // Boeker: adjust zoom inertia factor
+        .def("set_zoom_inertion_factor", SAFE_WRAP(&CScriptGameObject::SetZoomInertionFactor))
+
         // verdatim: Adjust damager stagger time factor
         .def("get_actor_damage_stagger_time_factor", SAFE_WRAP(&CScriptGameObject::GetActorDamageStaggerTimeFactor))
         .def("set_actor_damage_stagger_time_factor", SAFE_WRAP(&CScriptGameObject::SetActorDamageStaggerTimeFactor))


### PR DESCRIPTION
Adds a Lua-accessible method for changing the zoom inertia factor at runtime.

The new CScriptGameObject method:
SetZoomInertionFactor(float factor)

passes the value to CEffectorZoomInertion::SetUserFactor() and clamps it between 0.0 and 2.0.

This allows Lua scripts to dynamically control zoom inertia without modifying the existing zoom inertia implementation.