### PR TITLE
Fix scripted attachment UI's render phase ordering

### DIFF
--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -343,15 +343,6 @@ void CRender::Render()
 	if (Details)
 		Details->details_clear();
 
-	if (g_hud)
-	{
-        PROF_EVENT("render_hud");
-		if (g_hud->RenderActiveItemUIQuery())
-			GMBase.r_dsgraph_render_hud_ui();
-		if (g_hud->RenderCamAttachedUIQuery())
-			GMBase.r_dsgraph_render_cam_ui();
-	}
-
 }
 #include "../xrRender/CHudInitializer.h"
 
@@ -371,6 +362,17 @@ void CRender::render_forward()
 		GMBase.fade_render(); // faded-portals
 		GMBase.r_dsgraph_render_sorted(false); // strict-sorted geoms
 		g_pGamePersistent->Environment().RenderLast(); // rain/thunder-bolts
+
+		// Item and camera attachment UI draws before the sorted HUD so nearer glass and the post chain cover it
+		if (g_hud)
+		{
+			PROF_EVENT("render_hud");
+			if (g_hud->RenderActiveItemUIQuery())
+				GMBase.r_dsgraph_render_hud_ui();
+			if (g_hud->RenderCamAttachedUIQuery())
+				GMBase.r_dsgraph_render_cam_ui();
+		}
+
 		GMBase.r_dsgraph_render_sorted_hud();
 	}
 


### PR DESCRIPTION
Item and camera attachment UIs (`custom_ui_func` screens, detector screens, script attachments) were drawn after phase_combine, straight onto the back buffer, so night vision, LUT, bloom and TAA never touched them while HUD meshes and the 3D PDA screen got all of them.

Draw them in render_forward ahead of r_dsgraph_render_sorted_hud, the order the non-MT renderer uses, so the post chain covers them and a glass pane in front of a device screen blends over it the way the 3D PDA glass does.

TL;DR
Issue was exposed by Wearable Devices, this PR essentially fixes an oversight in the MT UI rendering pathway that non-MT gets right.